### PR TITLE
Updated readme to include how to grab existing planet project 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 A tool for tracking blogs in orbit around Seneca's open source involvement
 
 An initial discussion of the project is available in the [Overview](docs/overview.md) document.
+
+# Getting the project legacy code
+
+You may want a copy of the legacy project for later reading.
+
+To grab a local copy of the legacy project.. you can run [wget](https://www.gnu.org/software/wget/).
+
+To build the project for yourself you can follow the instructions in the [INSTALL](https://people.gnome.org/~jdub/bzr/planet/devel/trunk/INSTALL) file.
+
+__Linux/Mac__
+```
+wget -r --no-parent https://people.gnome.org/~jdub/bzr/planet/devel/trunk/
+```
+
+__Windows__
+1. Download wget binary [here](http://wget.addictivecode.org/FrequentlyAskedQuestions.html#download)
+2. ```cd path/to/downloaded/wget```
+3. ```wget -r --no-parent https://people.gnome.org/~jdub/bzr/planet/devel/trunk/```


### PR DESCRIPTION
I was able to download the planet cdot code from the overview using wget
```
wget -r --no-parent https://people.gnome.org/~jdub/bzr/planet/devel/trunk/
```
Fixes: #29 