### PR TITLE
Adds Docker files as a milestone for issue-4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/node_modules/
+**/node_modules_linux/
+**/docs/
+**/Dockerfile
+**/.dockerignore
+**/.editorconfig
+**/.eslintrc.js
+**/.gitignore
+**/.git
+**/README.md
+**/LICENSE
+**/.vscode
+**/.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:10
+
+# Change working directory
+WORKDIR "/telescope"
+
+# Update packages and install dependency packages for services
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get clean \
+ && echo 'Finished installing dependencies'
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install npm production packages 
+RUN npm install --production
+
+COPY . .
+
+ENV NODE_ENV production
+ENV PORT 3000
+
+EXPOSE 3000
+
+USER node
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  telescope:
+    build: .
+    depends_on:
+      - redis
+    ports:
+      - "3000:3000"
+    network_mode: host
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"


### PR DESCRIPTION

**_What is this pull request:_**
This will add Dockerfile and .dockerignore to the project. So that we can run the project without installing node packages like so:

```bash
$ docker-compose up --build
```

and more importantly, we can ship the Docker image to Kubernetes later on.

