### PR TITLE
Adding ESLint to pretest, and moving Jest to test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "eslint": "eslint --ignore-path .gitignore .",
     "eslint-fix": "eslint --fix --ignore-path .gitignore .",
-    "test": "npm run eslint",
+    "pretest": "npm run eslint",
+    "test": "npm run jest",
     "jest": "jest",
     "start": "node src"
   },


### PR DESCRIPTION
As referenced in #67, this will allow both ESLint and Jest to run when the `npm test` command is run. Right now ESLint will run first and give feed back on errors, before running Jest. This order could be changed later but also is most likely for the best right now considering Jest currently needs to be exited with CTRL+C.