### PR TITLE
Fix #44: Added Github Actions CI for redis run, npm install and test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,30 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: zhulik/redis-action@v1.0.0
+      with:
+          redis version: '5'
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        
+        npm ci
+        npm run build --if-present
+        npm test
+      env:
+        CI: true


### PR DESCRIPTION
This PR adds a basic Github Action to do the following

1. Checkout the code from git
2. Run docker image of redis
3. Run basic npm commands: `npm ci`, `npm run eslint` and `npm run jest`

This is triggered every time someone makes a push to the master branch. I think that should be enough for now. We can probably add checks on each pull request made to the master, I am not sure if that'd be too much. Thoughts?

I tested on my repo. The telescope repo doesn't show an Actions tab. It is be free for all public repositories. Maybe when the code is pushed the button appears?

