### PR TITLE
Fixes #133 - Silenced npm logs when builds fail

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+loglevel=silent


### PR DESCRIPTION
Fixes #133 

Added file `.npmrc` as instructed in-order to suppress npm error logs.