### PR TITLE
Fix 148 added page view counter for the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
 <body>
     <h1>Planet CDOT</h1>
+    <div id="CounterVisitor">
+    </div>
 
     <div class="daygroup">
         <h2>October 30, 2019</h2>
@@ -304,5 +306,22 @@ Powered by:<br>
         </p>
     </div>
 </body>
+<script>
+    var n = localStorage.getItem('on_load_counter');
+    
+    if (n === null) {
+      n = 0;
+    }
+    n++;
+    
+    localStorage.setItem("on_load_counter", n);
+    
+    nums = n.toString().split('').map(Number);
+    document.getElementById('CounterVisitor').innerHTML = '';
+    for (var i of nums) {
+      document.getElementById('CounterVisitor').innerHTML += '<span class="counter-item">' + i + '</span>';
+    }
+    
+    </script>
 
 </html>


### PR DESCRIPTION
Hello all,
So this pull request serves as possible solution to implementing a feature that tracks the number of visitors to the CDOT Planet.
I added a simple function that tracks visit to the home page based on the localStorage in the browser for now, 
I also thought it could be a good idea to track visits to individual blog, that way a blog's popularity could be determined from the list. However, doing this requires storing view counts to a database, and that hasn't been uploaded to master as far as I can tell, so I guess it's a feature that can be impelmented down the line. 