### PR TITLE
Fixes 148: Added a Page Hit Counter Function

### DIFF
--- a/counter.js
+++ b/counter.js
@@ -1,0 +1,8 @@
+var db = require("redis-client").createClient();
+require("http").createServer(function(request, response) {
+    db.incr("count",function(err, reply) {
+        response.writeHead(200, { "Content-Type": "text/plain" });
+        response.write(reply.toString());
+        response.end();
+    });
+}).listen(8181);


### PR DESCRIPTION
In this pull request, I implemented a simple Hit Counter that can store the number of visitors to main CDOT page to a Redis Database. The port number can be changed to the one selected by those making the database.
Aside from tracking visitors to the main page, I thought it could also be great to track the number of visitors to individual blogs. Perhaps this function can be updated to address that feature as well. 
