### PR TITLE
Fix #81: Translate page to any language

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,6 +448,7 @@
             crossorigin="anonymous"></script>
         <!-- MDB core JavaScript -->
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/js/mdb.min.js"></script>
+<<<<<<< Updated upstream:index.html
         <!-- Google translate Javascript -->
         <script type="text/javascript">
 =======

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
                             <a href="https://twitter.com/seneca_cdot?lang=en" id="icon" target="_blank">
                                 <i class="fab fa-twitter fa-2x"></i>
                             </a>
+                            <a>  <div id="google_translate_element2"></div> </a>
                         </li>
                     </ul>
                 </div>
@@ -447,6 +448,12 @@
             crossorigin="anonymous"></script>
         <!-- MDB core JavaScript -->
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/js/mdb.min.js"></script>
+        <!-- Google translate Javascript -->
+        <script type="text/javascript">
+            function googleTranslateElementInit2() {new google.translate.TranslateElement({pageLanguage: 'en',autoDisplay: false}, 'google_translate_element2');}
+            </script>
+            <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit2"></script>
+    
     </body>
     
     

--- a/index.html
+++ b/index.html
@@ -450,6 +450,10 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/js/mdb.min.js"></script>
         <!-- Google translate Javascript -->
         <script type="text/javascript">
+=======
+          <!-- Google translate Javascript -->
+          <script type="text/javascript">
+>>>>>>> Stashed changes:src/frontend/index.html
             function googleTranslateElementInit2() {new google.translate.TranslateElement({pageLanguage: 'en',autoDisplay: false}, 'google_translate_element2');}
             </script>
             <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit2"></script>


### PR DESCRIPTION
###  Fix issue #81
*  Using google translate I was able to add a script that allowed the text on the page to translated to any language.
* code could be found on https://gtranslate.io/
* Scroll down on the page and you will find prices
* click download on the one that is free

![68519388-b0866300-025e-11ea-86fd-634dec886246](https://user-images.githubusercontent.com/19510118/68731380-daf95880-059d-11ea-920d-2600bb236902.png)

*  A popup box will appear, click on the tab Html and it will display the sample code.
![68519458-2c80ab00-025f-11ea-903d-7243984b9631](https://user-images.githubusercontent.com/19510118/68731436-14ca5f00-059e-11ea-9503-b0dce0bc3d2b.png)


