### PR TITLE
Fixes #144 - Added the Redis URL to env.example and pass it when making Bull queue

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,3 +3,6 @@ NODE_ENV=development
 
 # PORT is the port used by the web server
 PORT=8080
+
+# REDIS_URL specifies Redis server info
+REDIS_URL='redis://127.0.0.1:6379'

--- a/env.example
+++ b/env.example
@@ -5,4 +5,4 @@ NODE_ENV=development
 PORT=8080
 
 # REDIS_URL specifies Redis server info
-REDIS_URL='redis://127.0.0.1:6379'
+REDIS_URL=redis://127.0.0.1:6379

--- a/src/feed-queue.js
+++ b/src/feed-queue.js
@@ -1,7 +1,6 @@
-const config = require('./config');
 const Bull = require('bull');
+require('./config');
 
-const redisUrl = process.env.REDIS_URL;
-const queue = new Bull('feed-queue', redisUrl);
+const queue = new Bull('feed-queue', process.env.REDIS_URL);
 
 module.exports = queue;

--- a/src/feed-queue.js
+++ b/src/feed-queue.js
@@ -1,5 +1,7 @@
+const config = require('./config');
 const Bull = require('bull');
 
-const queue = new Bull('feed-queue');
+const redisUrl = process.env.REDIS_URL;
+const queue = new Bull('feed-queue', redisUrl);
 
 module.exports = queue;


### PR DESCRIPTION
Fixes #144 

Changes made:
- Added the Redis URL to `env.example` 
- Pass the URL when making Bull queue via the constructor in `src/feed-queue.js`