### PR TITLE
Closes #54: Fetch data from GitHub API

### DIFF
--- a/env.example
+++ b/env.example
@@ -29,3 +29,6 @@ NODEMAILER_SERVER=
 # BLOG_INACTIVE_TIME is the period (days) of inactivity
 # before a blog will be considered redlisted
 BLOG_INACTIVE_TIME=360
+
+# GITHUB_TOKEN is used when fetching data from the GitHub API
+GITHUB_TOKEN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -5718,6 +5718,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6151,6 +6156,11 @@
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
       }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
     },
     "parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
     "feedparser-promised": "^2.0.1",
     "pino": "^5.13.6",
     "pino-pretty": "^3.3.0",
-    "node-summarizer": "^1.0.7",
     "valid-url": "^1.0.9",
-    "jsdom": "^15.2.1",
     "nodemailer": "^6.3.1",
+    "jsdom": "^15.2.1",
+    "node-fetch": "^2.6.0",
+    "node-summarizer": "^1.0.7",
+    "parse-github-url": "^1.0.2",
     "sentiment": "^5.0.2"
   },
   "devDependencies": {

--- a/src/github-url.js
+++ b/src/github-url.js
@@ -1,0 +1,134 @@
+require('./config');
+const parseGithubUrl = require('parse-github-url');
+const fetch = require('node-fetch');
+
+const githubAPI = 'http://api.github.com';
+
+
+const isValidGithubUrl = (ghUrl) => ghUrl.protocol === 'https:'
+                                  && ghUrl.host === 'github.com'
+                                  && (ghUrl.branch !== 'issues'
+                                    || ghUrl.branch !== 'pull'
+                                    || ghUrl.branch !== 'master');
+
+/**
+ * @description Takes a url, checks if it's a valid github url
+ * and returns JSON with fetched data related to the url from Github's V3 API.
+ * At the moment, it accepts URLs of repositories, issues and pull requests.
+ * @link https://developer.github.com/v3/
+ * @param {string} url Url that will be processed.
+ * @return An object with all the fetched data.
+ */
+exports.getGithubUrlData = async (incomingUrl) => {
+  const ghUrl = parseGithubUrl(incomingUrl);
+
+  if (!isValidGithubUrl(ghUrl)) {
+    throw new Error('Invalid GitHub url');
+  }
+
+  let subUrl = '';
+
+  /**
+   * If repo is null, it's a user URL.
+   * The request needs to be format this way:
+   * GET /users/:user
+   */
+  if (ghUrl.repo === null) subUrl = `/users/${ghUrl.path}`;
+
+  /**
+   * If branch is master and there's a repo,
+   * it's repo URL:
+   * GET /repos/:user/:repo
+   */
+  else if (ghUrl.branch === 'master') subUrl = `/repos/${ghUrl.repo}`;
+
+  /**
+   * Otherwise it's a {pull request, issue} URL:
+   * GET /repos/:user/:repo/{issues, pulls}
+   */
+  else subUrl = ghUrl.branch === 'pull' ? `/repos/${ghUrl.repo}/pulls` : `/repos/${ghUrl.repo}/issues`;
+
+  /**
+   * Add the {issue,pull request} number at the end of the request:
+   * GET /repos/:owner/:repo/{issues, pulls}/:{issue, pull_number}
+   */
+  subUrl += (ghUrl.filepath !== null ? `/${ghUrl.filepath}` : '');
+
+  /**
+   * Add GITHUB_TOKEN if in process.env
+   */
+  subUrl += typeof process.env.GITHUB_TOKEN !== 'undefined' ? `?access_token=${process.env.GITHUB_TOKEN}` : '';
+
+  return fetch(`${githubAPI}${subUrl}`)
+    .then((res) => res.json())
+    .then((data) => {
+      let fetchedData;
+
+      /**
+       * Format the fetched data in a specifi way depending if the url
+       * is for a repo, user or for a {pull request, issue}
+       */
+      // User
+      if (ghUrl.repo === null) {
+        const {
+          login: user,
+          avatar_url: avatarURL,
+          name,
+          company,
+          blog,
+          email,
+          bio,
+        } = data;
+
+        fetchedData = {
+          user,
+          avatarURL,
+          name,
+          company,
+          blog,
+          email,
+          bio,
+        };
+
+      // Repo
+      } else if (ghUrl.branch === 'master') {
+        const {
+          owner: { avatar_url: avatarURL },
+          description,
+          license,
+          open_issues: openIssues,
+          forks,
+          created_at: createdAt,
+          language,
+        } = data;
+
+        fetchedData = {
+          avatarURL,
+          description,
+          license,
+          openIssues,
+          forks,
+          createdAt,
+          language,
+        };
+
+      // Issue or Pull Request
+      } else {
+        const {
+          user: { login, avatar_url: avatarURL },
+          body,
+          created_at: createdAt,
+        } = data;
+
+        fetchedData = {
+          login,
+          avatarURL,
+          body,
+          createdAt,
+          branch: ghUrl.branch,
+          repo: ghUrl.name,
+        };
+      }
+      return fetchedData;
+    });
+};

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -1,0 +1,86 @@
+const gh = require('../src/github-url');
+
+/**
+ * Test to validate fetching data when passing a user URL.
+ * It uses the Seneca-CDOT URL
+ */
+test('test fetching data for a valid user URL', async () => {
+  const validUserUrl = 'https://github.com/Seneca-CDOT';
+  const validUserData = {
+    user: expect.any(String),
+    avatarURL: expect.any(String),
+    name: expect.any(String),
+    company: expect.any(String),
+    blog: expect.any(String),
+    email: expect.any(String),
+    bio: expect.any(String),
+  };
+
+  const user = await gh.getGithubUrlData(validUserUrl);
+  Object.keys(validUserData).map((property) => expect(user).toHaveProperty(property));
+});
+
+/**
+ * Test to validate fetching data when passing a repo URL.
+ * It uses the telescope URL
+ */
+test('test fetching data for a valid repository URL', async () => {
+  const validRepoUrl = 'https://github.com/Seneca-CDOT/telescope';
+  const validRepoData = {
+    avatarURL: expect.any(String),
+    description: expect.any(String),
+    license: {
+      key: expect.any(String),
+      name: expect.any(String),
+      spdx_id: expect.any(String),
+      url: expect.any(String),
+      node_id: expect.any(String),
+    },
+    openIssues: expect.any(Number),
+    forks: expect.any(Number),
+    createdAt: expect.any(String),
+    language: expect.any(String),
+  };
+
+  const repo = await gh.getGithubUrlData(validRepoUrl);
+  Object.keys(validRepoData).map((property) => expect(repo).toHaveProperty(property));
+});
+
+/**
+ * Test to validate fetching data when passing a repo URL.
+ * It uses telescope's issue 2
+ */
+test('test fetching data for a valid issue URL', async () => {
+  const validIssueUrl = 'https://github.com/Seneca-CDOT/telescope/issues/2';
+  const validIssueData = {
+    login: expect.any(String),
+    avatarURL: expect.any(String),
+    body: expect.any(String),
+    createdAt: expect.any(String),
+    branch: expect.any(String),
+    repo: expect.any(String),
+  };
+
+  const issue = await gh.getGithubUrlData(validIssueUrl);
+  Object.keys(validIssueData).map((property) => expect(issue).toHaveProperty(property));
+});
+
+
+/**
+ * Test to validate fetching data when passing a pull request URL.
+ * It uses telescope's pull request 1
+ */
+test('test fetching data for a valid pull request URL', async () => {
+  const validPullRequestUrl = 'https://github.com/Seneca-CDOT/telescope/pull/1';
+  const validPullRequestData = {
+    login: expect.any(String),
+    avatarURL: expect.any(String),
+    body: expect.any(String),
+    createdAt: expect.any(String),
+    branch: expect.any(String),
+    repo: expect.any(String),
+  };
+
+  const pr = await gh.getGithubUrlData(validPullRequestUrl);
+  Object.keys(validPullRequestData).map((property) => expect(pr).toHaveProperty(property));
+});


### PR DESCRIPTION
Closes #54 
This takes a valid Github URL and returns fetched data related to it from the [GitHub API](https://developer.github.com/v3/).
At the moment, it supports URLs for:
- Users: https://github.com/{myUser}
- Repositories: https://github.com/{myUser}/{repository}
- Issues https://github.com/{myUser}/{repository}/issues/{issue#}
- Pull Requests https://github.com/{myUser}/{repository}/pull/{pullRequest#}

Every request to the GitHub API returns a big chunk of data, and I chose the properties that I thought could be interesting for Telescope. This can be changed, please feel free to suggest other properties.
To see full chucks of data fetched from the GitHub API:
- User [Seneca-CDOT](https://api.github.com/users/Seneca-CDOT)
- Repository [Telescope](https://api.github.com/repos/Seneca-CDOT/telescope)
- Issue [Telescope's issue #1](https://api.github.com/repos/Seneca-CDOT/telescope/issues/1)
- Pull Request [Telescope's PR #1](https://api.github.com/repos/Seneca-CDOT/telescope/pulls/1)

What returns:
- User:
```js
{
  user: String,
  avatarURL: String,
  name: String,
  company: String,
  blog: String,
  email: String,
  bio: String,
};
```

- Repository:
```js
{
 avatarURL: String,
 description: String,
  license: {
    key: String,
    name: String,
    spdx_id: String,
    url: String,
    node_id: String,
  },
  openIssues: Number,
  forks: Number,
  createdAt: String,
  language: String,
};
```

- Issue and Pull Request:
```js
{
  login: String,
  avatarURL: String,
  body: String,
  createdAt: String,
  branch: String,
  repo: String,
  };
```

I wanted to use [bent](https://www.npmjs.com/package/bent), but unfortunately it only likes `200` status codes, and the GitHub API does a lot redirections (status code `301`), so I couldn't get it to work

I also included tests for the 4 valid types of URLs.