### PR TITLE
Fix #181: Adding Windows and MacOS support to CircleCI config.yml file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Execute tests
           command: npm test
 
-  build-Macos:
+  build-macos:
     macos:
       xcode: "9.0"
     working_directory: ~/telescope
@@ -33,7 +33,7 @@ jobs:
           name: Execute tests
           command: npm test
   
-  build-Windows:
+  build-windows:
     working_directory: ~/telescope
     executor:
       name: win/vs2019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
   buildwindows:
     executor: win/vs2019
     working_directory: ~/telescope
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
     steps:
       - checkout
       - run: Write-Host 'Hello, Windows'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2 # use version 2.0 of CircleCI
+orbs:
+  win: circleci/windows@1.0.0
 jobs: # a basic unit of work in a run
   build:
     working_directory: ~/telescope

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,18 @@
 version: 2.1
 orbs:
-     win: circleci/windows@1.0.0 
-  jobs:
-    build:
-      docker: 
-        - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
-      steps:
-        - checkout # check out the code in the project directory
-        - run: echo "hello world" # run the `echo` command
-    buildWindows:
-    executor: win/vs2019
+  win: circleci/windows@1.0.0
+
+jobs:
+  build:
+    working_directory: ~/telescope
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
     steps:
       - checkout
-      - run: Write-Host 'Hello, Windows
-
-
-workflows:
-  my_workflow:
-    jobs:
-      -build
-      -buildWindows
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs: # a basic unit of work in a run
 
   buildmacos:
     working_directory: ~/telescope
+    macos:
+      xcode: "10.0"
     docker:
       - image: circleci/node:lts
       - image: circleci/redis:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,9 @@ jobs:
     working_directory: ~/telescope
     steps: 
       - checkout
-       - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+       - run: npm ci
+       - run: npm test
+         
          
       
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
     working_directory: ~/telescope
     steps: 
       - checkout
-       - run: npm ci
-       - run: npm test
+      - run: npm ci
+      - run: npm test
          
          
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  win: circleci/windows@1.0.0
+
 jobs:
   build:
     working_directory: ~/telescope
@@ -14,10 +17,46 @@ jobs:
           name: Execute tests
           command: npm test
 
+  build-Macos:
+    macos:
+      xcode: "9.0"
+    working_directory: ~/telescope
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
+  
+  build-Windows:
+    working_directory: ~/telescope
+    executor:
+      name: win/vs2019
+      shell: bash.exe
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
 
 
-  workflows:
-    version: 2.1
-    build:
-      jobs:
-        - build
+
+
+workflows:
+  version: 2.1
+  build:
+    jobs:
+      - build
+      - build-Macos
+      - build-Windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  win: circleci/windows@1.0.0
 jobs:
   build:
     working_directory: ~/telescope
@@ -19,6 +21,17 @@ jobs:
     working_directory: ~/telescope
     resource_class: large
     steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
+  buildwindows:
+    executor:
+      name: win/vs2019
+     steps:
       - checkout
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,32 @@ jobs:
           name: Execute tests
           command: npm test
   buildwindows:
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
+    #docker:
+    #  - image: circleci/node:lts
+     # - image: circleci/redis:latest
     executor: win/vs2019
     working_directory: ~/telescope
     steps:
-      - checkout
-      - run: Write-Host 'Hello, Windows'
+       - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
+  buildmacos:
+    macos:
+      xcode:
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/node:latest
+    working_directory: ~/telescope
+    steps:
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
    
 
 workflows:
@@ -32,4 +50,5 @@ workflows:
     jobs:
       - build
       - buildwindows
+      - buildmacos
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
- version: 2.1
- orbs:
+version: 2.1
+orbs:
      win: circleci/windows@1.0.0 
   jobs:
     build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,39 @@
 version: 2.1
+
 jobs:
-    build:
-      docker: 
-        - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
-      steps:
-        - checkout # check out the code in the project directory
-        - run: echo "hello world" # run the `echo` command
-    buildmacos:
-      macos:
-        xcode: "10.0.0"
-      docker: 
-        - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
-      steps:
-        - checkout # check out the code in the project directory
-        - run: echo "hello world" # run the `echo` command
+  "build-linux":
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+    working_directory: ~/telescope
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm ci 
+
+  "build-macos":
+    macos:
+      xcode: "10.0"
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+    working_directory: ~/telescope
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm ci 
 
 workflows:
-  myworkflow:
+  build:
     jobs:
-      - build
-      - buildmacos
+      - "build-linux"
+      - "build-macos"
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 version: 2.1
-  jobs:
+jobs:
     build:
       docker: 
         - image: circleci/node:4.8.2 # the primary container, where your job's commands are run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,10 @@
-version: 2 # use version 2.0 of CircleCI
+version: 2.1 # use version 2.0 of CircleCI
 orbs:
   win: circleci/windows@1.0.0
 jobs: # a basic unit of work in a run
   build:
+    machine: true
+    resource_class: large
     working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
@@ -17,7 +19,6 @@ jobs: # a basic unit of work in a run
           command: npm test
 
   buildmacos:
-    working_directory: ~/telescope
     macos:
       xcode: "10.0"
     docker:
@@ -32,25 +33,24 @@ jobs: # a basic unit of work in a run
           name: Execute tests
           command: npm test
   
-  #buildwindows:
-    #working_directory: ~/telescope
-    #executor: win/vs2019
-    #docker:
-    #  - image: circleci/node:lts
-    #  - image: circleci/redis:latest
-    #steps:
-   #   - checkout
-     # - run:
-    #      name: Install dependencies
-    #      command: npm ci
-    #  - run:
-     #     name: Execute tests
-     #     command: npm test
-     
+  buildwindows:
+    executor: win/vs2019
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
+
 workflows:
-  version: 2
+  #version: 2
   build_and_test:
     jobs:
       - build
       - buildmacos
-    #  - buildwindows
+      - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,21 @@ jobs:
           name: Execute tests
           command: npm test
   buildwindows:
-      executor:
-        name: win/vs2019
-        #shell: powershell.exe
-      working_directory: ~/telescope
-      docker:
-        - image: circleci/node:lts
-        - image: circleci/node:lts
-      steps:
-        - checkout
-        - run:
-            name: Install dependencies
-            command: npm ci
-        - run:
-            name: Execute tests
-            command: npm test
+    working_directory: ~/telescope
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+    executor:
+      name: win/vs2019
+      #shell: powershell.exe
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
 
 workflows:
   mybuild:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ jobs: # a basic unit of work in a run
           command: npm test
 
   buildmacos:
-  working_directory: ~/telescope
+    working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
-      - image: circleci/redis:latest 
+      - image: circleci/redis:latest
     steps:
       - checkout
       - run:
@@ -27,6 +27,7 @@ jobs: # a basic unit of work in a run
       - run:
           name: Execute tests
           command: npm test
+ 
     
   
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2 # use version 2.0 of CircleCI
+version: 2.1 # use version 2.0 of CircleCI
 orbs:
   win: circleci/windows@1.0.0
 jobs: # a basic unit of work in a run
@@ -52,7 +52,7 @@ jobs: # a basic unit of work in a run
   
 
 workflows:
-  version: 2
+  #version: 2
   build_and_test:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,9 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
-  buildmacos:
+  buildmacos: 
     macos:
-      xcode: "11.0.0"
-      docker:
-        - image: circleci/node:lts
-        - image: circleci/redis:latest 
+      xcode: "10.0.0"
     working_directory: ~/telescope
     resource_class: large
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
-orbs:
-  win: circleci/windows@1.0.0
-
 jobs:
   build:
     working_directory: ~/telescope
@@ -16,36 +13,22 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
-  buildwindows:
-    executor: win/vs2019
-    working_directory: ~/telescope
-    steps:
-       - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
   buildmacos:
-    macos:
-      xcode:
+    working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
-      - image: circleci/node:latest
-    working_directory: ~/telescope
+      - image: circleci/redis:latest 
     steps:
+      - checkout
       - run:
           name: Install dependencies
           command: npm ci
       - run:
           name: Execute tests
           command: npm test
-   
 
 workflows:
-  mybuild:
+  myworkflows:
     jobs:
       - build
-      - buildwindows
       - buildmacos
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,5 +55,5 @@ workflows:
   build:
     jobs:
       - "build"
-      - "build-Macos"
-      - "build-Windows"
+      - "build-macos"
+      - "build-windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
   buildwindows:
       executor:
         name: win/vs2019
-        shell: powershell.exe
+        #shell: powershell.exe
       working_directory: ~/telescope
       steps:
         - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,9 @@ jobs:
 
   buildmacos:
     working_directory: ~/telescope
-    macos:
-     xcode: "9.0"
+    executor:
+      macos:
+        xcode: "9.0"
     
     docker:
       - image: circleci/node:lts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,10 @@ jobs:
   buildwindows:
     executor:
       name: win/vs2019
-    docker:
-      - image: "circleci/node:lts"
-      - image: "circleci/reids:latest"
+    working_directory: ~/telescope
+    #docker:
+     # - image: "circleci/node:lts"
+     # - image: "circleci/reids:latest"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,22 @@
-version: 2.1 # use version 2.0 of CircleCI
-orbs:
-  win: circleci/windows@1.0.0
-jobs: # a basic unit of work in a run
-  build:
-    machine: true
-    resource_class: large
-    working_directory: ~/telescope
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
-
-  buildmacos:
-    macos:
-      xcode: "10.0"
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
-  
-  buildwindows:
+ version: 2.1
+ orbs:
+     win: circleci/windows@1.0.0 
+  jobs:
+    build:
+      docker: 
+        - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
+      steps:
+        - checkout # check out the code in the project directory
+        - run: echo "hello world" # run the `echo` command
+    buildWindows:
     executor: win/vs2019
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+      - run: Write-Host 'Hello, Windows
+
 
 workflows:
-  #version: 2
-  build_and_test:
+  my_workflow:
     jobs:
-      - build
-      - buildmacos
-      - buildwindows
+      -build
+      -buildWindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0 # use version 2.0 of CircleCI
+version: 2.1 # use version 2.0 of CircleCI
 orbs:
   win: circleci/windows@1.0.0
 jobs: # a basic unit of work in a run
@@ -52,7 +52,7 @@ jobs: # a basic unit of work in a run
   
 
 workflows:
-  version: 2
+  #version: 2
   build_and_test:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,10 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
+  buildwindows:
+      executor:
+        name: win/vs2019
+        shell: powershell.exe
+      working_directory: ~/telescope
+      steps:
+        - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,26 +14,21 @@ jobs: # a basic unit of work in a run
           name: Execute tests
           command: npm test
 
-  buildmacos: # runs not using `Workflows` must have a `build` job as entry point
-    macos:  # indicate that we are using the macOS executor
-      xcode: "10.0.0" # indicate our selected version of Xcode
-    steps: # a series of commands to run
+  buildmacos: 
+    macos:  
+      xcode: "10.0.0" 
+    working_directory: ~/telescope
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
+    steps: 
       - checkout  # pull down code from your version control system.
+     - run:
+          name: Install dependencies
+          command: npm ci
       - run:
-          # run our tests using xcode's cli tool `xcodebuild`
-          name: Run Unit Tests
-          command: xcodebuild test -scheme circleci-demo-macos
-      - run:
-          # build our application
-          name: Build Application
-          command: xcodebuild
-      - run:
-          # compress Xcode's build output so that it can be stored as an artifact
-          name: Compress app for storage
-          command: zip -r app.zip build/Release/circleci-demo-macos.app
-      - store_artifacts: # store this build output. Read more: https://circleci.com/docs/2.0/artifacts/
-          path: app.zip
-          destination: app
+          name: Execute tests
+          command: npm test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,9 @@ jobs:
           command: npm test
   buildmacos:
     macos:
-      xcode: "10.0.0"
+      xcode: "11.0.0"
     working_directory: ~/telescope
+    resource_class: large
     docker:
       - image: circleci/node:lts
       - image: circleci/redis:latest 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,21 +17,11 @@ jobs:
           name: Execute tests
           command: npm test
   buildwindows:
-    working_directory: ~/telescope
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
-    executor:
-      name: win/vs2019
-      #shell: powershell.exe
+    executor: win/vs2019
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+      - run: Write-Host 'Hello, Windows'
+   
 
 workflows:
   mybuild:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
   buildwindows:
     executor:
       name: win/vs2019
-     steps:
+    steps:
       - checkout
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
    #       command: npm test
           
 workflows:
-  version: 2.1
   build:
     jobs:
       - "build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,22 @@ jobs: # a basic unit of work in a run
       - run:
           name: Execute tests
           command: npm test
+  
+  buildwindows:
+    working_directory: ~/telescope
+    executor: win/vs2019
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
+    
  
     
   
@@ -41,3 +57,4 @@ workflows:
     jobs:
       - build
       - buildmacos
+      - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
-orbs:
-  win: circleci/windows@1.0.0
-
+ build-macos:
+    macos:
+      xcode: "9.0"
 jobs:
   build:
     working_directory: ~/telescope
@@ -17,43 +17,43 @@ jobs:
           name: Execute tests
           command: npm test
 
-  build-macos:
-    macos:
-      xcode: "9.0"
-    working_directory: ~/telescope
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+  #build-macos:
+   # macos:
+     # xcode: "9.0"
+  #  working_directory: ~/telescope
+   # docker:
+    #  - image: circleci/node:lts
+    #  - image: circleci/redis:latest 
+   # steps:
+    #  - checkout
+    #  - run:
+     #     name: Install dependencies
+     #     command: npm ci
+    #  - run:
+     #     name: Execute tests
+     #     command: npm test
   
-  build-windows:
-    working_directory: ~/telescope
-    executor:
-      name: win/vs2019
-      shell: bash.exe
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+ # build-windows:
+  #  working_directory: ~/telescope
+  #  executor:
+   #   name: win/vs2019
+   #   shell: bash.exe
+   # docker:
+   #   - image: circleci/node:lts
+    #  - image: circleci/redis:latest 
+  #  steps:
+  #    - checkout
+  #    - run:
+  #        name: Install dependencies
+  #        command: npm ci
+   #   - run:
+   #       name: Execute tests
+   #       command: npm test
           
-workflows:
-  version: 2.1
-  build:
-    jobs:
-      - "build"
-      - "build-macos"
-      - "build-windows"
+#workflows:
+ # version: 2.1
+  #build:
+  #  jobs:
+   #   - "build"
+    #  - "build-macos"
+    #  - "build-windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,38 @@
 version: 2.1
-
-orbs:
-
-commands:
-  install-dependencies:
+jobs:
+  build:
+    working_directory: ~/telescope
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
     steps:
       - checkout
-      - run: npm ci
-  execute-tests:
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
+  buildmacos:
+    macos:
+      xcode:
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
     steps:
-      - run: npm test
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
 
-executors:
-  docker:
-    - image: circleci/node:lts
-    - image: circleci/redis:latest
+workflows:
+  my_workflow:
+    jobs:
+      - build
+      - buildmacos
 
-jobs:
-  build-linux:
-    executor: docker
-    steps:
-      - install-dependencies
-      - execute-tests
 
-#workflows:
+    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
           name: Execute tests
           command: npm test
   buildmacos:
+    macos:
+      xcode: "10.0.0"
     working_directory: ~/telescope
     docker:
       - image: circleci/node:lts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,9 @@ jobs:
   buildwindows:
     executor:
       name: win/vs2019
-    - image: circleci/node:lts
-    - image: circleci/redis:latest
-
+      shell: bash.exe
     working_directory: ~/telescope
-    steps:
+    steps: 
       - checkout
        - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
   buildwindows:
     executor:
       name: win/vs2019
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
+    - image: circleci/node:lts
+    - image: circleci/redis:latest
 
     working_directory: ~/telescope
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ jobs:
           name: Execute tests
           command: npm test
   buildwindows:
-    executor: win/vs2019
-    working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
       - image: circleci/redis:latest
+    executor: win/vs2019
+    working_directory: ~/telescope
     steps:
       - checkout
       - run: Write-Host 'Hello, Windows'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,14 +49,11 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
-
-
-
-
+          
 workflows:
   version: 2.1
   build:
     jobs:
-      - build
-      - build-Macos
-      - build-Windows
+      - "build"
+      - "build-Macos"
+      - "build-Windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
- build-macos:
-    macos:
-      xcode: "9.0"
+ #build-macos:
+  #  macos:
+   #   xcode: "9.0"
 jobs:
   build:
     working_directory: ~/telescope

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,3 +6,17 @@ version: 2.1
       steps:
         - checkout # check out the code in the project directory
         - run: echo "hello world" # run the `echo` command
+    buildmacos:
+      macos:
+        xcode: "10.0.0"
+       docker: 
+        - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
+      steps:
+        - checkout # check out the code in the project directory
+        - run: echo "hello world" # run the `echo` command
+
+workflows:
+  myworkflow:
+    jobs:
+      - build
+      - buildmacos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,4 @@ workflows:
     jobs:
       - build
       - buildmacos
-      - buildwindows
+     # - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,4 @@ workflows:
     jobs:
       - build
       - buildmacos
-     # - buildwindows
+      - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
           name: Execute tests
           command: npm test
   buildwindows:
-    #docker:
-    #  - image: circleci/node:lts
-     # - image: circleci/redis:latest
     executor: win/vs2019
     working_directory: ~/telescope
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1 # use version 2.0 of CircleCI
+version: 2 # use version 2.0 of CircleCI
 orbs:
   win: circleci/windows@1.0.0
 jobs: # a basic unit of work in a run
@@ -32,29 +32,25 @@ jobs: # a basic unit of work in a run
           name: Execute tests
           command: npm test
   
-  buildwindows:
-    working_directory: ~/telescope
-    executor: win/vs2019
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
-    
- 
-    
-  
-
+  #buildwindows:
+    #working_directory: ~/telescope
+    #executor: win/vs2019
+    #docker:
+    #  - image: circleci/node:lts
+    #  - image: circleci/redis:latest
+    #steps:
+   #   - checkout
+     # - run:
+    #      name: Install dependencies
+    #      command: npm ci
+    #  - run:
+     #     name: Execute tests
+     #     command: npm test
+     
 workflows:
-  #version: 2
+  version: 2
   build_and_test:
     jobs:
       - build
       - buildmacos
-      - buildwindows
+    #  - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           command: npm test
   buildwindows:
     executor: win/vs2019
+    working_directory: ~/telescope
     steps:
       - checkout
       - run: Write-Host 'Hello, Windows'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,34 +15,25 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
-  buildmacos: 
-    macos:
-      xcode: "10.0.0"
+  buildwindows:
+    executor:
+      name: win/vs2019
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+
     working_directory: ~/telescope
-    resource_class: large
     steps:
       - checkout
-      - run:
+       - run:
           name: Install dependencies
           command: npm ci
       - run:
           name: Execute tests
           command: npm test
-  buildwindows:
-    executor:
-      name: win/vs2019
-    working_directory: ~/telescope
-    #docker:
-     # - image: "circleci/node:lts"
-     # - image: "circleci/reids:latest"
-    steps:
-      - checkout
-      - run: Write-Host 'Hello, Windows'
          
       
 workflows:
   myworkflows:
     jobs:
       - buildlinux
-      - buildmacos
       - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1 # use version 2.0 of CircleCI
+version: 2.0 # use version 2.0 of CircleCI
 orbs:
   win: circleci/windows@1.0.0
 jobs: # a basic unit of work in a run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
- #build-macos:
-  #  macos:
-   #   xcode: "9.0"
 jobs:
   build:
     working_directory: ~/telescope
@@ -17,21 +14,22 @@ jobs:
           name: Execute tests
           command: npm test
 
-  #build-macos:
-   # macos:
-     # xcode: "9.0"
-  #  working_directory: ~/telescope
-   # docker:
-    #  - image: circleci/node:lts
-    #  - image: circleci/redis:latest 
-   # steps:
-    #  - checkout
-    #  - run:
-     #     name: Install dependencies
-     #     command: npm ci
-    #  - run:
-     #     name: Execute tests
-     #     command: npm test
+  buildmacos:
+    working_directory: ~/telescope
+    macos:
+     xcode: "9.0"
+    
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest 
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
   
  # build-windows:
   #  working_directory: ~/telescope
@@ -50,10 +48,10 @@ jobs:
    #       name: Execute tests
    #       command: npm test
           
-#workflows:
- # version: 2.1
-  #build:
-  #  jobs:
-   #   - "build"
-    #  - "build-macos"
+workflows:
+  version: 2.1
+  build:
+    jobs:
+      - "build"
+      - "buildmacos"
     #  - "build-windows"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     buildmacos:
       macos:
         xcode: "10.0.0"
-       docker: 
+      docker: 
         - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
       steps:
         - checkout # check out the code in the project directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,11 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
-        
-   build-Macos:
-    working_directory: ~/telescope
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
 
-workflows:
-  version: 2.1
-  build:
-    jobs:
-      - "build"
-      - "build-Macos"
+
+
+  workflows:
+    version: 2.1
+    build:
+      jobs:
+        - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,10 @@
-version: 2.1
-
-jobs:
-  "build-linux":
+version: 2 # use version 2.0 of CircleCI
+jobs: # a basic unit of work in a run
+  build:
+    working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
-      - image: circleci/redis:latest
-    working_directory: ~/telescope
+      - image: circleci/redis:latest 
     steps:
       - checkout
       - run:
@@ -13,27 +12,32 @@ jobs:
           command: npm ci
       - run:
           name: Execute tests
-          command: npm ci 
+          command: npm test
 
-  "build-macos":
-    macos:
-      xcode: "10.0"
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
-    working_directory: ~/telescope
-    steps:
-      - checkout
+  buildmacos: # runs not using `Workflows` must have a `build` job as entry point
+    macos:  # indicate that we are using the macOS executor
+      xcode: "10.0.0" # indicate our selected version of Xcode
+    steps: # a series of commands to run
+      - checkout  # pull down code from your version control system.
       - run:
-          name: Install dependencies
-          command: npm ci
+          # run our tests using xcode's cli tool `xcodebuild`
+          name: Run Unit Tests
+          command: xcodebuild test -scheme circleci-demo-macos
       - run:
-          name: Execute tests
-          command: npm ci 
+          # build our application
+          name: Build Application
+          command: xcodebuild
+      - run:
+          # compress Xcode's build output so that it can be stored as an artifact
+          name: Compress app for storage
+          command: zip -r app.zip build/Release/circleci-demo-macos.app
+      - store_artifacts: # store this build output. Read more: https://circleci.com/docs/2.0/artifacts/
+          path: app.zip
+          destination: app
 
 workflows:
-  build:
+  version: 2
+  build_and_test:
     jobs:
-      - "build-linux"
-      - "build-macos"
-      
+      - build
+      - buildmacos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   win: circleci/windows@1.0.0
 jobs:
-  build:
+  buildlinux:
     working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
@@ -37,16 +37,12 @@ jobs:
      # - image: "circleci/reids:latest"
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
-
+      - run: Write-Host 'Hello, Windows'
+         
+      
 workflows:
   myworkflows:
     jobs:
-      - build
+      - buildlinux
       - buildmacos
       - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
   buildmacos:
     macos:
       xcode: "11.0.0"
+      docker:
+        - image: circleci/node:lts
+        - image: circleci/redis:latest 
     working_directory: ~/telescope
     resource_class: large
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,27 +32,27 @@ jobs: # a basic unit of work in a run
           name: Execute tests
           command: npm test
   
-  buildwindows:
-    working_directory: ~/telescope
-    executor: win/vs2019
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+  #buildwindows:
+    #working_directory: ~/telescope
+    #executor: win/vs2019
+    #docker:
+     # - image: circleci/node:lts
+     # - image: circleci/redis:latest
+    #steps:
+      #- checkout
+     # - run:
+     #     name: Install dependencies
+     #     command: npm ci
+     # - run:
+     #     name: Execute tests
+      #    command: npm test
     
  
     
   
 
 workflows:
-  #version: 2
+  version: 2
   build_and_test:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,21 +14,21 @@ jobs: # a basic unit of work in a run
           name: Execute tests
           command: npm test
 
-  buildmacos: 
-    macos:  
-      xcode: "10.0.0" 
-    working_directory: ~/telescope
+  buildmacos:
+  working_directory: ~/telescope
     docker:
       - image: circleci/node:lts
       - image: circleci/redis:latest 
-    steps: 
-      - checkout  # pull down code from your version control system.
-     - run:
+    steps:
+      - checkout
+      - run:
           name: Install dependencies
           command: npm ci
       - run:
           name: Execute tests
           command: npm test
+    
+  
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,20 +32,20 @@ jobs: # a basic unit of work in a run
           name: Execute tests
           command: npm test
   
-  #buildwindows:
-    #working_directory: ~/telescope
-    #executor: win/vs2019
-    #docker:
-     # - image: circleci/node:lts
-     # - image: circleci/redis:latest
-    #steps:
-      #- checkout
-     # - run:
-     #     name: Install dependencies
-     #     command: npm ci
-     # - run:
-     #     name: Execute tests
-      #    command: npm test
+  buildwindows:
+    working_directory: ~/telescope
+    executor: win/vs2019
+    docker:
+      - image: circleci/node:lts
+      - image: circleci/redis:latest
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Execute tests
+          command: npm test
     
  
     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,16 @@ jobs:
       working_directory: ~/telescope
       steps:
         - checkout
+        - run:
+            name: Install dependencies
+            command: npm ci
+        - run:
+            name: Execute tests
+            command: npm test
+
+workflows:
+  mybuild:
+    jobs:
+      - build
+      - buildwindows
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,20 +13,15 @@ jobs:
       - run:
           name: Execute tests
           command: npm test
-  buildmacos:
-    macos:
-      xcode:
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
+    build-macos: 
+      working_directory: ~/telescope
+      macos:  
+        xcode: "10.0.0"
+      steps:
+        - checkout
+        - run: echo "hello World"
+
+  
 
 workflows:
   my_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
   buildwindows:
     executor:
       name: win/vs2019
+    docker:
+      - image: "circleci/node:lts"
+      - image: "circleci/reids:latest"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,8 @@
 version: 2.1
-jobs:
-  build:
-    working_directory: ~/telescope
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
-    build-macos: 
-      working_directory: ~/telescope
-      macos:  
-        xcode: "10.0.0"
+  jobs:
+    build:
+      docker: 
+        - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
       steps:
-        - checkout
-        - run: echo "hello World"
-
-  
-
-workflows:
-  my_workflow:
-    jobs:
-      - build
-      - buildmacos
-
-
-    
+        - checkout # check out the code in the project directory
+        - run: echo "hello world" # run the `echo` command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,3 +45,4 @@ workflows:
     jobs:
       - build
       - buildmacos
+      - buildwindows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
         name: win/vs2019
         #shell: powershell.exe
       working_directory: ~/telescope
+      docker:
+        - image: circleci/node:lts
+        - image: circleci/node:lts
       steps:
         - checkout
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,57 +1,26 @@
 version: 2.1
-jobs:
-  build:
-    working_directory: ~/telescope
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
 
-  buildmacos:
-    working_directory: ~/telescope
-    executor:
-      macos:
-        xcode: "9.0"
-    
-    docker:
-      - image: circleci/node:lts
-      - image: circleci/redis:latest 
+orbs:
+
+commands:
+  install-dependencies:
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Execute tests
-          command: npm test
-  
- # build-windows:
-  #  working_directory: ~/telescope
-  #  executor:
-   #   name: win/vs2019
-   #   shell: bash.exe
-   # docker:
-   #   - image: circleci/node:lts
-    #  - image: circleci/redis:latest 
-  #  steps:
-  #    - checkout
-  #    - run:
-  #        name: Install dependencies
-  #        command: npm ci
-   #   - run:
-   #       name: Execute tests
-   #       command: npm test
-          
-workflows:
-  build:
-    jobs:
-      - "build"
-      - "buildmacos"
-    #  - "build-windows"
+      - run: npm ci
+  execute-tests:
+    steps:
+      - run: npm test
+
+executors:
+  docker:
+    - image: circleci/node:lts
+    - image: circleci/redis:latest
+
+jobs:
+  build-linux:
+    executor: docker
+    steps:
+      - install-dependencies
+      - execute-tests
+
+#workflows:

--- a/package.json
+++ b/package.json
@@ -47,5 +47,10 @@
     "stylelint": "^11.1.1",
     "stylelint-config-recommended": "^3.0.0",
     "supertest": "^4.0.2"
+  },
+  "rules": {
+    "linebreak-style": 0
+
   }
+
 }


### PR DESCRIPTION
After reading the documentation, and also using this video as a guide
https://www.youtube.com/watch?v=3V84yEz6HwA&t=185s, I added three separate jobs build on one type of environment (MacOS, Linux, Windows). These jobs can run in parallel if we use workflows and then list each job under the workflow