### PR TITLE
Added tests for inactive blog checking (#197)

### DIFF
--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const inactiveFilter = require('../src/inactive-blog-filter');
+
+const redlist = JSON.parse(fs.readFileSync('../feeds-redlist.json'));
+
+describe('Redlisted feed checking', () => {
+  it('should return false for bad feed URLs', async () => {
+    const badURLs = [redlist[0].slice(0, -1), '', undefined];
+    badURLs.forEach((url) => {
+      inactiveFilter.check(url, (callback, result) => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  it('should return true for all feed URLs in feeds-redlist.json', async () => {
+    redlist.forEach((feed) => {
+      inactiveFilter.check(feed.url, (callback, result) => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -1,11 +1,11 @@
 const fs = require('fs');
 const inactiveFilter = require('../src/inactive-blog-filter');
 
-const redlist = JSON.parse(fs.readFileSync('../feeds-redlist.json'));
+const redlist = JSON.parse(fs.readFileSync('feeds-redlist.json'));
 
 describe('Redlisted feed checking', () => {
   it('should return false for bad feed URLs', async () => {
-    const badURLs = [redlist[0].slice(0, -1), '', undefined];
+    const badURLs = [redlist[0].url.slice(0, -1), '', undefined];
     badURLs.forEach((url) => {
       inactiveFilter.check(url, (callback, result) => {
         expect(result).toBe(false);

--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const inactiveFilter = require('../src/inactive-blog-filter');
 
-const redlist = JSON.parse(fs.readFileSync('feeds-redlist.json'));
+const redlist = JSON.parse(fs.readFileSync('feeds-redlist.json', 'utf8'));
 
 describe('Redlisted feed checking', () => {
   it('should return false for bad feed URLs', async () => {

--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -1,10 +1,8 @@
-const fs = require('fs');
 const inactiveFilter = require('../src/inactive-blog-filter');
-
-const redlist = JSON.parse(fs.readFileSync('feeds-redlist.json', 'utf8'));
+const redlist = require('../feeds-redlist.json');
 
 describe('Redlisted feed checking', () => {
-  it('should return false for bad feed URLs', async () => {
+  it('should return false for bad feed URLs', () => {
     const badURLs = [redlist[0].url.slice(0, -1), '', undefined];
     badURLs.forEach((url) => {
       inactiveFilter.check(url, (callback, result) => {
@@ -13,7 +11,7 @@ describe('Redlisted feed checking', () => {
     });
   });
 
-  it('should return true for all feed URLs in feeds-redlist.json', async () => {
+  it('should return true for all feed URLs in feeds-redlist.json', () => {
     redlist.forEach((feed) => {
       inactiveFilter.check(feed.url, (callback, result) => {
         expect(result).toBe(true);


### PR DESCRIPTION
This pull request adds testing for the `check()` function defined in [inactive-blog-filter.js](https://github.com/Seneca-CDOT/telescope/blob/master/src/inactive-blog-filter.js#L41).

This pull request does *not*, however, cover testing for the `update()` function. As noted in https://github.com/Seneca-CDOT/telescope/issues/197#issuecomment-554145637, the creation of some testing environment, or some alteration of the `update()` function needs to be done to facilitate proper testing. I plan to continue looking into this, and plan to make a separate pull request when I come up with a solution.