### PR TITLE
Fix #173 - Queue Shutdown

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -3,13 +3,47 @@
  */
 
 const fs = require('fs');
+<<<<<<< HEAD:src/backend/index.js
 const { logger } = require('./utils/logger');
 const feedQueue = require('./feed/queue');
 const feedWorker = require('./feed/worker');
+=======
+const feedQueue = require('./feed-queue');
+const feedWorker = require('./feed-worker');
+const parentLogger = require('../src/lib/logger');
+
+const log = parentLogger.child({ module: 'module-name' });
+>>>>>>> Issue-173: Remade Server Graceful Shutdown:src/index.js
 
 const log = logger.child({ module: 'basic-queue' });
 // Start the web server
+<<<<<<< HEAD:src/backend/index.js
 require('./web/server');
+=======
+const server = require('./backend/web/server');
+
+/**
+ * Stops the Redis Queue, closes all connections gracefuly
+ */
+function shutDown() {
+  log.info('Received kill signal, shutting down gracefully');
+
+  // Close the Redis Queue
+  feedQueue.close();
+
+  // Close server and terminate all connections
+  server.close(() => {
+    log.info('Closed out remaining connections');
+    process.exit(0);
+  });
+
+  // Force shutting down
+  setTimeout(() => {
+    log.error('Could not close connections in time, forcefully shutting down');
+    process.exit(1);
+  }, 10000);
+}
+>>>>>>> Issue-173: Remade Server Graceful Shutdown:src/index.js
 
 /**
  * Process a string into a list of Objects, each with a feed URL
@@ -55,6 +89,9 @@ fs.readFile('feeds.txt', 'utf8', (err, lines) => {
     process.exit(-1);
     return;
   }
+
+  process.on('SIGTERM', shutDown);
+  process.on('SIGINT', shutDown);
 
   // Process this text file into a list of URL jobs, and enqueue for download
   const feedJobs = processFeedUrls(lines);

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -3,23 +3,14 @@
  */
 
 const fs = require('fs');
-<<<<<<< HEAD:src/backend/index.js
-const { logger } = require('./utils/logger');
-const feedQueue = require('./feed/queue');
-const feedWorker = require('./feed/worker');
-=======
 const feedQueue = require('./feed-queue');
 const feedWorker = require('./feed-worker');
 const parentLogger = require('../src/lib/logger');
 
 const log = parentLogger.child({ module: 'module-name' });
->>>>>>> Issue-173: Remade Server Graceful Shutdown:src/index.js
 
 const log = logger.child({ module: 'basic-queue' });
 // Start the web server
-<<<<<<< HEAD:src/backend/index.js
-require('./web/server');
-=======
 const server = require('./backend/web/server');
 
 /**
@@ -43,7 +34,6 @@ function shutDown() {
     process.exit(1);
   }, 10000);
 }
->>>>>>> Issue-173: Remade Server Graceful Shutdown:src/index.js
 
 /**
  * Process a string into a list of Objects, each with a feed URL

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -3,17 +3,14 @@
  */
 
 const fs = require('fs');
-const feedQueue = require('./feed-queue');
-const feedWorker = require('./feed-worker');
-const parentLogger = require('../src/lib/logger');
+const feedQueue = require('./feed/queue');
+const feedWorker = require('./feed/worker');
+const parentLogger = require('./utils/logger');
 
 const log = parentLogger.child({ module: 'main' });
 
-const log = parentLogger.child({ module: 'module-name' });
-
-const log = logger.child({ module: 'basic-queue' });
 // Start the web server
-const server = require('./backend/web/server');
+const server = require('./web/server');
 
 /**
  * Stops the Redis Queue, closes all connections gracefuly
@@ -46,7 +43,7 @@ function shutDown() {
     ),
   ])
     .then(() => process.exit(0))
-    .catch(err => log.error(error));
+    .catch(err => log.error(err));
 }
 
 /**

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -7,6 +7,8 @@ const feedQueue = require('./feed-queue');
 const feedWorker = require('./feed-worker');
 const parentLogger = require('../src/lib/logger');
 
+const log = parentLogger.child({ module: 'main' });
+
 const log = parentLogger.child({ module: 'module-name' });
 
 const log = logger.child({ module: 'basic-queue' });
@@ -34,6 +36,12 @@ function shutDown() {
     process.exit(1);
   }, 10000);
 }
+<<<<<<< HEAD:src/backend/index.js
+=======
+
+process.on('SIGTERM', shutDown);
+process.on('SIGINT', shutDown);
+>>>>>>> Issue-173: Remade Server Graceful Shutdown:src/index.js
 
 /**
  * Process a string into a list of Objects, each with a feed URL

--- a/src/backend/web/server.js
+++ b/src/backend/web/server.js
@@ -15,3 +15,5 @@ process.on('unhandledRejection', ({ name, message }) => {
     process.exit(1);
   });
 });
+
+module.exports = server;

--- a/src/backend/web/server.js
+++ b/src/backend/web/server.js
@@ -8,12 +8,4 @@ const server = app.listen(HTTP_PORT, () => {
   logger.info(`Telescope listening on port ${HTTP_PORT}`);
 });
 
-process.on('unhandledRejection', ({ name, message }) => {
-  logger.error('UNHANDLED REJECTION:  Shutting down...');
-  logger.error(`${name}: ${message}`);
-  server.close(() => {
-    process.exit(1);
-  });
-});
-
 module.exports = server;


### PR DESCRIPTION
This PR fixes issue #173.

**I would like to explain what I have done.** 
In [the code example](https://github.com/Chocobozzz/PeerTube/blob/2b4dd7e26d93c2d9bef4f365cb03c511eff4ca8f/server/lib/job-queue/job-queue.ts#L101-L106), provided in issue #112 by @humphd, JobQueue is _a class_, and `terminate()` function is implemented as a member of this class - hence, it can be called from every place where `JobQueue` is used.
The main aim of the `terminate()` function is to close _a number of queues_, which are implemented in the `JobQueue class`. Implementing the same logic for us requires me to rewrite the structure of the `feed-queue.js`, making it a class.

**Another thing that I wanted to mention:**
I have made a little research on the "Killing" the process, and, as stated [here](https://stackoverflow.com/a/4479816):

 _"There is no way you can execute any code in your application when it is being Killed by Operating System or User. That is why it's called Killing."_

The `close()` function for the _graceful shutdown_, as I understood, is just a destructor for the queue, and can be called in the other files like `feed-worker.js` when there is no more need for the Queue to be used. 

**Although**, for the sake of error handling, logging and _graceful termination_ **I added** the try-catch block with the logging on the `feed-worker.js` file. 

I am open to any suggestions and will be happy to correct my work if I am wrong. 