### PR TITLE
Fix #226: Remove Explicit Parameter Bug Fix

### DIFF
--- a/src/email-sender.js
+++ b/src/email-sender.js
@@ -14,7 +14,7 @@ const nodemailer = require('nodemailer');
 
 exports.sendMessage = async function (receipiants, subjectMessage, message) {
   return new Promise((resolve, reject) => {
-    const transporter = nodemailer.createTransport('SMTP', {
+    const transporter = nodemailer.createTransport({
       // Email Server (.env variable must be used refer to the Contribution.md)
       host: process.env.NODEMAILER_SERVER,
       port: 25,


### PR DESCRIPTION
Nodemailer no longer has explicit variables in their transport. 
Remove the Explicit Parameter in Nodemailer transport function. Bug Fix for PR #93 #226 