### PR TITLE
Fix #238: include a default redis URL for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,27 @@ os:
   - "linux"
   - "osx"
   - "windows"
-addons:
-  homebrew:
-    packages: 
-      - redis
-    update: true
-install:
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install redis-64; fi
-  - npm install eslint --save-dev
 before_install:
+  # When we switch to Prettier, this CRLF fixup should go away
   - cd ../..
   - mv $TRAVIS_REPO_SLUG _old
   - git config --global core.autocrlf false
   - git clone --depth=50 _old $TRAVIS_REPO_SLUG
   - cd $TRAVIS_REPO_SLUG
-  
+  # Deal with Redis install per-platform
+  - echo $TRAVIS_OS_NAME
+  - echo $PATH
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update && brew install redis && brew services start redis
+    fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
+      redis-server --daemonize yes
+      redis-cli info
+    else
+      choco install redis-64
+      redis-server --service-install
+      redis-server --service-start
+      redis-cli info
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ os:
   - "linux"
   - "osx"
   - "windows"
+cache:
+  directories:
+    # On OSX, cache homebrew - https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci?answertab=active#tab-top
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
+before_cache:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cleanup; fi
+  # Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
 before_install:
   # When we switch to Prettier, this CRLF fixup should go away
   - cd ../..

--- a/src/feed-queue.js
+++ b/src/feed-queue.js
@@ -3,7 +3,7 @@ const { setQueues } = require('bull-board');
 
 require('./config');
 
-const queue = new Bull('feed-queue', process.env.REDIS_URL);
+const queue = new Bull('feed-queue', process.env.REDIS_URL || 'redis://127.0.0.1:6379');
 
 // For visualizing queues using bull board
 setQueues(queue);


### PR DESCRIPTION
We don't have an `.env` provided, and our queue depends on a Redis URL.  Let's provide a fallback.