### PR TITLE
Fix #208 Use mock responses when testing the GitHub data fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1898,6 +1898,22 @@
         "moment-timezone": "^0.5.25"
       }
     },
+    "cross-fetch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -4832,6 +4848,15 @@
         "jest-util": "^24.9.0"
       }
     },
+    "jest-fetch-mock": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
+      "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
+      "requires": {
+        "cross-fetch": "^2.2.2",
+        "promise-polyfill": "^7.1.1"
+      }
+    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
@@ -6698,6 +6723,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-polyfill": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ=="
     },
     "promise.prototype.finally": {
       "version": "3.1.1",
@@ -8983,6 +9013,11 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "testEnvironment": "node",
     "coveragePathIgnorePatterns": [
       "/node_modules/"
-    ]
+    ],
+    "automock": false,
+    "setupFiles": [
+    "./test/setupJest.js"
+  ]
   },
   "scripts": {
     "eslint": "eslint --ignore-path .gitignore .",
@@ -36,6 +40,7 @@
     "express-healthcheck": "^0.1.0",
     "feedparser-promised": "^2.0.1",
     "get-urls": "^9.2.0",
+    "jest-fetch-mock": "^2.1.2",
     "jsdom": "^15.2.1",
     "node-fetch": "^2.6.0",
     "node-summarizer": "^1.0.7",

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -1,10 +1,15 @@
 const gh = require('../src/github-url');
+global.fetch = require('node-fetch');
+
+beforeEach(() => {
+  fetch.resetMocks();
+});
 
 /**
  * Test to validate fetching data when passing a user URL.
  * It uses the Seneca-CDOT URL
  */
-test.skip('test fetching data for a valid user URL', async () => {
+test('test fetching data for a valid user URL', async () => {
   const validUserUrl = 'https://github.com/Seneca-CDOT';
   const validUserData = {
     user: expect.any(String),
@@ -16,6 +21,16 @@ test.skip('test fetching data for a valid user URL', async () => {
     bio: expect.any(String),
   };
 
+  fetch.mockResponseOnce(JSON.stringify({
+    login: 'foo',
+    avatar_url: 'foo',
+    name: 'foo',
+    company: 'foo',
+    blog: 'foo',
+    email: 'foo',
+    bio: 'foo',
+  }, { status: 200 }));
+
   const user = await gh.getGithubUrlData(validUserUrl);
   Object.keys(validUserData).map((property) => expect(user).toHaveProperty(property));
 });
@@ -24,7 +39,7 @@ test.skip('test fetching data for a valid user URL', async () => {
  * Test to validate fetching data when passing a repo URL.
  * It uses the telescope URL
  */
-test.skip('test fetching data for a valid repository URL', async () => {
+test('test fetching data for a valid repository URL', async () => {
   const validRepoUrl = 'https://github.com/Seneca-CDOT/telescope';
   const validRepoData = {
     avatarURL: expect.any(String),
@@ -41,6 +56,21 @@ test.skip('test fetching data for a valid repository URL', async () => {
     createdAt: expect.any(String),
     language: expect.any(String),
   };
+  fetch.mockResponseOnce(JSON.stringify({
+    owner: { avatar_url: 'foo' },
+    description: 'foo',
+    license: {
+      key: 'foo',
+      name: 'foo',
+      spdx_id: 'foo',
+      url: 'foo',
+      node_id: 'foo',
+    },
+    open_issues: 0,
+    forks: 0,
+    created_at: 'foo',
+    language: 'foo',
+  }, { status: 200 }));
 
   const repo = await gh.getGithubUrlData(validRepoUrl);
   Object.keys(validRepoData).map((property) => expect(repo).toHaveProperty(property));
@@ -50,7 +80,7 @@ test.skip('test fetching data for a valid repository URL', async () => {
  * Test to validate fetching data when passing a repo URL.
  * It uses telescope's issue 2
  */
-test.skip('test fetching data for a valid issue URL', async () => {
+test('test fetching data for a valid issue URL', async () => {
   const validIssueUrl = 'https://github.com/Seneca-CDOT/telescope/issues/2';
   const validIssueData = {
     login: expect.any(String),
@@ -61,6 +91,16 @@ test.skip('test fetching data for a valid issue URL', async () => {
     repo: expect.any(String),
   };
 
+  fetch.mockResponseOnce(JSON.stringify({
+    user:
+    {
+      login: 'foo',
+      avatar_url: 'foo',
+    },
+    body: 'foo',
+    created_at: 'foo',
+  }, { status: 200 }));
+
   const issue = await gh.getGithubUrlData(validIssueUrl);
   Object.keys(validIssueData).map((property) => expect(issue).toHaveProperty(property));
 });
@@ -70,7 +110,7 @@ test.skip('test fetching data for a valid issue URL', async () => {
  * Test to validate fetching data when passing a pull request URL.
  * It uses telescope's pull request 1
  */
-test.skip('test fetching data for a valid pull request URL', async () => {
+test('test fetching data for a valid pull request URL', async () => {
   const validPullRequestUrl = 'https://github.com/Seneca-CDOT/telescope/pull/1';
   const validPullRequestData = {
     login: expect.any(String),
@@ -80,6 +120,16 @@ test.skip('test fetching data for a valid pull request URL', async () => {
     branch: expect.any(String),
     repo: expect.any(String),
   };
+
+  fetch.mockResponseOnce(JSON.stringify({
+    user:
+    {
+      login: 'foo',
+      avatar_url: 'foo',
+    },
+    body: 'foo',
+    created_at: 'foo',
+  }, { status: 200 }));
 
   const pr = await gh.getGithubUrlData(validPullRequestUrl);
   Object.keys(validPullRequestData).map((property) => expect(pr).toHaveProperty(property));

--- a/test/setupJest.js
+++ b/test/setupJest.js
@@ -1,0 +1,3 @@
+const fetch = require('jest-fetch-mock');
+
+jest.setMock('node-fetch', fetch);


### PR DESCRIPTION
Fixes #208 and fixes #225.

The GitHub tests now use [`jest-fetch-mock`](https://www.npmjs.com/package/jest-fetch-mock)  for mock responses. I tested if offline and the tests passed.
Examples for `jest-fetch-mock` [here](https://www.npmjs.com/package/jest-fetch-mock#simple-mock-and-assert) and [here](https://github.com/mattiaerre/jest-do-it/blob/master/008-jest-fetch-mock/current-weather.test.js).


