### PR TITLE
Fix #243: Skipping failing tests in feed-parser.test.js

### DIFF
--- a/test/feed-parser.test.js
+++ b/test/feed-parser.test.js
@@ -30,12 +30,12 @@ test('Passing an IP address instead of a URI should throw an error', 
   await expect(feedParser('128.190.222.135')).rejects.toThrow('error');
 });
 
-test('Passing an invalid RSS category feed should return an empty array', async () => {
+test.skip('Passing an invalid RSS category feed should return an empty array', async () => {
   const data = await feedParser('http://en.blog.wordpress.com/category/INVALID_CATEGORY/feed/');
   expect(data.length).toBe(0);
 });
 
-test('Passing a avalid RSS category feed should return an array that is not empty', async () => {
+test.skip('Passing a valid RSS category feed should return an array that is not empty', async () => {
   const data = await feedParser('http://en.blog.wordpress.com/category/features/feed');
   expect(data.length > 0).toBe(true);
 });


### PR DESCRIPTION
As suggested in #243, I am adding `.skip()` to the failing tests while it is being fixed. I am looking into using mock responses instead (see #245). 