### PR TITLE
Fix #145 Adding logging to events in the feed queue

### DIFF
--- a/src/feed-queue.js
+++ b/src/feed-queue.js
@@ -1,11 +1,72 @@
 const Bull = require('bull');
 const { setQueues } = require('bull-board');
+const parentLogger = require('../utils/logger');
+
+const log = parentLogger.child({ module: 'feed-queue' });
 
 require('./config');
 
-const queue = new Bull('feed-queue', process.env.REDIS_URL || 'redis://127.0.0.1:6379');
+/**
+ * Function to log all events in the feed queue
+ */
+function watch(feedQueue) {
+  feedQueue
+    .on('error', (error) => {
+      // An error occured
+      log.error(`Queue ${feedQueue.name} error:`, error, ' Stack: ', error.stack);
+    })
+    .on('waiting', (jobID) => {
+      // A job is waiting for the next idling worker
+      log.info(`Job ${jobID} is waiting.`);
+    })
+    .on('active', (job) => {
+      // A job has started (use jobPromise.cancel() to abort it)
+      log.info(`Job ${job.id} is active`);
+    })
+    .on('stalled', (job) => {
+      // A job was marked as stalled. This is useful for debugging
+      // which workers are crashing or pausing the event loop
+      log.info(`Job ${job.id} has stalled.`);
+    })
+    .on('progress', (job, progress) => {
+      // A job's progress was updated
+      log.info(`Job ${job.id} progress:`, progress);
+    })
+    .on('completed', (job) => {
+      // A job has been completed
+      log.info(`Job ${job.id} completed.`);
+    })
+    .on('failed', (job, err) => {
+      // A job failed with an error
+      log.error(`Job ${job.id} failed:`, err);
+    })
+    .on('paused', (job) => {
+      // The queue was paused
+      log.info(`Queue ${feedQueue.name} resumed. ID:`, job.id);
+    })
+    .on('resumed', (job) => {
+      // The queue resumed
+      log.info(`Queue ${feedQueue.name} resumed. ID: `, job.id);
+    })
+    .on('cleaned', (jobs, types) => {
+      // Old jobs were cleaned from the queue
+      // 'Jobs' is an array of cleaned jobs
+      // 'Types' is an array of their types
+      log.info(`Queue ${feedQueue.name} was cleaned. Jobs: `, jobs, ' Types: ', types);
+    })
+    .on('drained', () => {
+      // The queue was drained
+      // (the last item in the queue was returned by a worker)
+      log.info(`Queue ${feedQueue.name} was drained.`);
+    })
+    .on('removed', (job) => {
+      log.info(`Job ${job.id} was removed.`);
+    });
+}
 
 // For visualizing queues using bull board
+const queue = new Bull('feed-queue', process.env.REDIS_URL);
+watch(queue);
 setQueues(queue);
 
 module.exports = queue;

--- a/src/feed-queue.js
+++ b/src/feed-queue.js
@@ -65,7 +65,7 @@ function watch(feedQueue) {
 }
 
 // For visualizing queues using bull board
-const queue = new Bull('feed-queue', process.env.REDIS_URL);
+const queue = new Bull('feed-queue', process.env.REDIS_URL || 'redis://127.0.0.1:6379');
 watch(queue);
 setQueues(queue);
 


### PR DESCRIPTION
Fixes issue #145, using our new logger to log events that are emitted from our feed queue. 

This is pretty much just the code found [here](https://github.com/OriginProtocol/origin/blob/e9881d687241fdbf557239a90eeac12d96792d62/infra/cron/src/scheduler.js#L22-L73), which is under the MIT license. 

One thing I am concerned about is that it posts to the console during the tests (see below). I am looking into this, but if anyone has any advice or knows how to fix this, I'd love your help! 

<img width="750" alt="Screen Shot 2019-11-16 at 4 51 21 PM" src="https://user-images.githubusercontent.com/34118418/68999817-1e044600-0894-11ea-9afa-ed4b78d42fc5.png">

Additionally, there are some events (`cleaned` and `stalled`, for example) that aren't emitted when running `npm start` at the moment. I am researching on how to write tests for them.