### PR TITLE
Fixes #206 - Refactor code to use node-fetch instead of Bent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,16 +1135,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/bent/-/bent-7.0.2.tgz",
-      "integrity": "sha512-vjI+A83Tvg3gdIlYHIP4YrlANtS/LCpQP1mHq+nig1+7jJKNAzVYPAw9rp5IevVoeoM6y64jX1PqaSjmUZqQLg==",
-      "requires": {
-        "bytesish": "^0.4.1",
-        "caseless": "~0.12.0",
-        "is-stream": "^2.0.0"
-      }
-    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -1382,11 +1372,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "bytesish": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/bytesish/-/bytesish-0.4.1.tgz",
-      "integrity": "sha512-j3l5QmnAbpOfcN/Z2Jcv4poQYfefs8rDdcbc6iEKm+OolvUXAE2APodpWj+DOzqX6Bl5Ys1cQkcIV2/doGvQxg=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -4505,11 +4490,6 @@
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
-    },
-    "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-symbol": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "bent": "^7.0.2",
     "bull": "^3.11.0",
     "bull-board": "^0.5.0",
     "dotenv": "^8.2.0",

--- a/src/wiki-feed-parser.js
+++ b/src/wiki-feed-parser.js
@@ -12,7 +12,7 @@ const { JSDOM } = jsdom;
 */
 module.exports.getData = function () {
   return fetch(process.env.FEED_URL)
-    .then((res) => res.text() )
+    .then((res) => res.text())
     .then((data) => {
       const dom = new JSDOM(data);
       return dom.window.document.querySelector('pre').textContent.split(/\r\n|\r|\n/);

--- a/src/wiki-feed-parser.js
+++ b/src/wiki-feed-parser.js
@@ -1,8 +1,7 @@
-const bent = require('bent');
+const fetch = require('node-fetch');
 const jsdom = require('jsdom');
 require('./config.js');
 
-const request = bent('string');
 const { JSDOM } = jsdom;
 
 /*
@@ -12,7 +11,8 @@ const { JSDOM } = jsdom;
 * That data is then returned as a Promise
 */
 module.exports.getData = function () {
-  return request(process.env.FEED_URL)
+  return fetch(process.env.FEED_URL)
+    .then((res) => res.text() )
     .then((data) => {
       const dom = new JSDOM(data);
       return dom.window.document.querySelector('pre').textContent.split(/\r\n|\r|\n/);


### PR DESCRIPTION
### What changes are being made? (feature)
This pull request refactors the code in the repository to use node-fetch instead of Bent for requests.

### Why are these changes necessary? Link any related issues
To avoid having multiple dependencies for doing the same thing, it would be a good idea to replace Bent with node-fetch wherever it is used. Closes #206