### PR TITLE
fixes #247: added danger.js to check for changes to files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,5 @@ before_install:
       redis-server --service-start
       redis-cli info
     fi
+before_script:
+  - npm run danger

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "bull": "3.11.0",
     "bull-board": "0.5.0",
+    "danger": "9.2.8",
     "dompurify": "2.0.7",
     "dotenv": "8.2.0",
     "express": "4.17.1",
@@ -50,6 +51,7 @@
     "ioredis": "4.14.1",
     "ioredis-mock": "4.18.2",
     "jsdom": "15.2.1",
+    "lodash": "4.17.15",
     "node-fetch": "2.6.0",
     "node-summarizer": "1.0.7",
     "nodemailer": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
     "start": "node src",
-    "debug-server": "nodemon server.js"
+    "debug-server": "nodemon server.js",
+    "danger": "danger ci"
   },
   "husky": {
     "hooks": {

--- a/src/utils/dangerfile.js
+++ b/src/utils/dangerfile.js
@@ -7,5 +7,5 @@ const tests = includes(danger.git.fileMatch, '../../test/*.test.js');
 if (apps.modified && !tests.modified) {
   const message = `Changes were made to file in src, but not to the test file folder`;
   const idea = `Perhaps check if tests for the src file needs to be changed?`;
-  warn(`${message} - <i>${idea}</i>`);
+  warn(`${message} - <i>${idea}</i> `);
 }

--- a/src/utils/dangerfile.js
+++ b/src/utils/dangerfile.js
@@ -7,5 +7,5 @@ const tests = includes(danger.git.fileMatch, '../../test/*.test.js');
 if (apps.modified && !tests.modified) {
   const message = `Changes were made to file in src, but not to the test file folder`;
   const idea = `Perhaps check if tests for the src file needs to be changed?`;
-  warn(`${message} - <i>${idea}</i> `);
+  warn(`${message} - <i>${idea}</i>`);
 }

--- a/src/utils/dangerfile.js
+++ b/src/utils/dangerfile.js
@@ -1,0 +1,11 @@
+const { danger, warn } = require('danger');
+const { includes } = require('lodash');
+
+const apps = includes(danger.git.fileMatch, '../*.js');
+const tests = includes(danger.git.fileMatch, '../../test/*.test.js');
+
+if (apps.modified && !tests.modified) {
+  const message = `Changes were made to file in src, but not to the test file folder`;
+  const idea = `Perhaps check if tests for the src file needs to be changed?`;
+  warn(`${message} - <i>${idea}</i>`);
+}


### PR DESCRIPTION
Still a WIP, I'll ask probably whoever worked on Travis CI to take a look at this, specifically the `Token Setup` part:

![image](https://user-images.githubusercontent.com/18711727/69025961-03ff5c00-0997-11ea-9692-99f26dea986f.png)

At the moment it "should" check for two situations, the first one as written by @humphd to check
- package.json has been changed
if it has, it will then check if package-lock.json has been changed. If package-lock.json has not been changed a message to terminal should be printed to warn the user.

It will also:
- check if any of the source files has been changed
if it has, will check to see if any of the tests has been changed. If none of them has been changed, a message to terminal should be printed to warn the user.

Lastly, I think we'll need to make exceptions to the Linter as it is giving me errors for the console messages.