### PR TITLE
Fix issue #256: Add .vsccode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build
 .env.development.local
 .env.test.local
 .env.production.local
-.vscode/
 
 npm-debug.log*
 yarn-debug.log*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/src/index.js",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true
+}


### PR DESCRIPTION
This PR addresses issue #256 

I added a basic `.vscode` folder with some code formatting config, extension recommendation (eslint, prettier and editorconfig) and a script to run debugging in VSCode.

I am open to more idea on what to add.