### PR TITLE
Fix #252, #258, #299: add logging to feed queue, refactor lib/redis, lib/queue

### DIFF
--- a/src/feed-queue.js
+++ b/src/feed-queue.js
@@ -1,9 +1,8 @@
-const Bull = require('bull');
 const { setQueues } = require('bull-board');
+const { createQueue } = require('./lib/queue');
 
-require('./config');
-
-const queue = new Bull('feed-queue', process.env.REDIS_URL || 'redis://127.0.0.1:6379');
+// Create a Bull Redis Queue
+const queue = createQueue('feed-queue');
 
 // For visualizing queues using bull board
 setQueues(queue);

--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -1,0 +1,31 @@
+const Bull = require('bull');
+const { Redis, redisUrl } = require('./redis');
+
+require('../config');
+
+// https://github.com/OptimalBits/bull/blob/28a2b9aa444d028fc5192c9bbdc9bb5811e77b08/PATTERNS.md#reusing-redis-connections
+const client = new Redis(redisUrl);
+const subscriber = new Redis(redisUrl);
+
+/**
+ * Pass a name and get back a Bull Queue using that name.
+ * We manage the creation of the redis connections.
+ */
+function createQueue(name) {
+  return new Bull(name, {
+    createClient: type => {
+      switch (type) {
+        case 'client':
+          return client;
+        case 'subscriber':
+          return subscriber;
+        default:
+          return new Redis(redisUrl);
+      }
+    },
+  });
+}
+
+module.exports = {
+  createQueue,
+};

--- a/src/lib/redis.js
+++ b/src/lib/redis.js
@@ -2,10 +2,31 @@ require('../config');
 const Redis = require('ioredis');
 const MockRedis = require('ioredis-mock');
 
+const logger = require('./logger');
+
 // If you need to set the Redis URL, do it in REDIS_URL
-const redisUrl = process.env.REDIS_URL;
+const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+
 // Set MOCK_REDIS=1 to mock, MOCK_REDIS= to use real redis
 const useMockRedis = process.env.MOCK_REDIS;
 
+// RedisConstructor is one of Redis or MockRedis
+const RedisConstructor = useMockRedis ? MockRedis : Redis;
+
 // Export either a real Redis instance, or Mocked.
-module.exports = useMockRedis ? new MockRedis(redisUrl) : new Redis(redisUrl);
+const redisInstance = new RedisConstructor(redisUrl);
+
+// If using MockRedis, shim info() until https://github.com/stipsan/ioredis-mock/issues/841 ships
+if (useMockRedis && typeof MockRedis.prototype.info !== 'function') {
+  logger.debug('Shimming MockRedis info() method');
+  MockRedis.prototype.info = () => Promise.resolve('redis_version:999.999.999');
+}
+
+module.exports = {
+  // Redis URL to use if using the constructor
+  redisUrl,
+  // If callers need to create a new redis instance, they'll use the ctor
+  Redis: RedisConstructor,
+  // Otherwise they can use this shared instance (most should use this)
+  redis: redisInstance,
+};

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,4 +1,4 @@
-const redis = require('./lib/redis');
+const { redis } = require('./lib/redis');
 
 // Redis Keys
 const FEED_ID = 'feed_id';


### PR DESCRIPTION
I'm testing a theory on the test failures in #252.  To do it, I made a fix for #258, and merged/updated the work in #252.  I want to see what this does on Travis.