### PR TITLE
Fix #172: implement queue failed feeds behaviour

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,15 @@ function processFeedUrls(lines) {
 async function enqueueFeedJobs(feedJobs) {
   feedJobs.forEach(async feedJob => {
     console.log(`Enqueuing Job - ${feedJob.url}`);
-    await feedQueue.add(feedJob);
+    await feedQueue.add(feedJob, {
+      attempts: 8,
+      backoff: {
+        type: 'exponential',
+        delay: 60 * 1000,
+      },
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
   });
 }
 

--- a/test/feed-worker.test.js
+++ b/test/feed-worker.test.js
@@ -1,0 +1,41 @@
+const feedWorker = require('../src/feed-worker');
+
+describe('testing the worker callback function', () => {
+  const job1 = {
+    data: { url: 'https://c3ho.blogspot.com/feeds/posts/default/-/open-source?alt=rss' },
+  };
+  const job2 = { data: { url: 'c3ho.blogspot.com/feeds/posts/default/-/open-source?alt=rss' } };
+  const job3 = { data: { url: 'https://c3ho.blogspot.com/feeds/posts/default/-/open-source' } };
+  const job4 = { data: { url: 'c3ho.blogspot.com/feeds/posts/default/-/open-source' } };
+  const job5 = { data: { url: 'https://google.ca' } };
+  const job6 = { data: { url: '128.190.222.135' } };
+  const job7 = { data: { url: 'http://en.blog.wordpress.com/category/INVALID_CATEGORY/feed/' } };
+
+  it('should pass with a valid ATOM feed URI', async () => {
+    await expect(feedWorker.workerCallback(job1)).resolves.toBeTruthy();
+  });
+
+  it('should fail with an invalid ATOM feed URI should error', async () => {
+    await expect(feedWorker.workerCallback(job2)).rejects.toThrow();
+  });
+
+  it('should pass with a valid RSS feed URI', async () => {
+    await expect(feedWorker.workerCallback(job3)).resolves.toBeTruthy();
+  });
+
+  it('should fail with an invalid RSS feed URI', async () => {
+    await expect(feedWorker.workerCallback(job4)).rejects.toThrow();
+  });
+
+  it('should fail with a valid URI, but not a feed URI', async () => {
+    await expect(feedWorker.workerCallback(job5)).rejects.toThrow();
+  });
+
+  it('should fail by passing an IP address instead of a URI', async () => {
+    await expect(feedWorker.workerCallback(job6)).rejects.toThrow();
+  });
+
+  it('should fail by passing an invalid RSS category feed due to empty array', async () => {
+    await expect(feedWorker.workerCallback(job7)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Reference issue #172.

**Status update:**
Ready for review.

Solution: extracted worker callback function out, changed it to using promises instead of done, made it much easier to cope with unit testing.


**Historical conversations:** (outdated, still good for reference)

WIP Update:
I need help with writing the test cases to validate the `feed-worker.js` module. Currently it is not working.

Contrary to its name, the function `queue.process` does not process anything immediately upon its call, **it's actually registering a callback function for the queue that is only called everytime a job is placed in the queue**. See bull's official documentation here: https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queueprocess.

Since code inside the callback function gets called at a later time, I need to have a different way of testing their functionalities rather than just having a straight up function call. I've consulted bull library's own set of test cases, namely this one: https://github.com/OptimalBits/bull/blob/develop/test/test_sandboxed_process.js to help with setting up my own.

Basically the current format is roughly this:
```
feedWorker.start(); // calls feedQueue.process() and hook up callback function

feedQueue.on('completed', (job, value) => { // hook up callback to test the success branch of the callback function
  expect(job.data).toEqual(job1.data);
  expect(value[0].title).toEqual('First Post!');
  done();
});

feedQueue.on('error', error => { // hook up callback to test the failure branch of the callback function
  expect(error.message.startsWith('Failed to parse url: '));
  done();
});

feedQueue.add(job1); // adds a job into the queue, triggering the callback
```

However, the tests seem to unable to reach `done()` inside the callback handlers, and it seems that `feedQueue.on('completed')` and `feedQueue.on('error')` never get called. As a result, the tests just hang and jest doesn't exit cleanly.