### PR TITLE
Fix #305: Fix test failure with logger.debug()

### DIFF
--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -1,6 +1,6 @@
 const Bull = require('bull');
 const { Redis, redisUrl } = require('./redis');
-const parentLogger = require('./logger');
+const { logger } = require('./logger');
 
 /**
  * Shared redis connections for pub/sub, see:
@@ -16,7 +16,7 @@ const subscriber = new Redis(redisUrl);
  * We also setup logging for this queue name.
  */
 function createQueue(name) {
-  const log = parentLogger.child({ module: `queue:${name}` });
+  const log = logger.child({ module: `queue:${name}` });
   const queue = new Bull(name, {
     createClient: type => {
       switch (type) {

--- a/src/lib/redis.js
+++ b/src/lib/redis.js
@@ -2,7 +2,7 @@ require('../config');
 const Redis = require('ioredis');
 const MockRedis = require('ioredis-mock');
 
-const logger = require('./logger');
+const { logger } = require('./logger');
 
 // If you need to set the Redis URL, do it in REDIS_URL
 const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379';


### PR DESCRIPTION
The problem was the way `src/lib/queue.js` and `src/lib/redis.js` were importing `logger`.
Adding destructuring fixed it. 

Please test it before approving.