### PR TITLE
Fix #323: Disable linebreak style and add gitattributes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,11 @@ module.exports = {
      * https://eslint.org/docs/rules/func-names
      */
     'func-names': 'off',
+
+    /**
+     * Disallow enforcement of consistent linebreak style
+     * https://eslint.org/docs/rules/func-names
+     */
+    'linebreak-style': 'off',
   },
 };

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'node'
+  - lts/*
 services:
   - redis-server
 os:


### PR DESCRIPTION
This PR disallows eslint to enforce consistent line endings. This is being done to support our windows users, who are currently not able to pass linting tests. To make sure any code that is added now has consistent line endings, 'lf' in our case, I have also added a `.gitattributes` file. You can read more about it [here](https://git-scm.com/docs/gitattributes). 
Specifically about [text](https://git-scm.com/docs/gitattributes#_code_text_code) and [eol](https://git-scm.com/docs/gitattributes#_code_eol_code). 