### PR TITLE
Closes #72: Adds more test cases to feedParser.test.js

### DIFF
--- a/test/feed-parser.test.js
+++ b/test/feed-parser.test.js
@@ -71,7 +71,7 @@ test('Non existant feed failure case.', async () => {
   try {
     await feedParser('http://doesnotexists___.com');
   } catch (err) {
-    expect(err.message).toBe('getaddrinfo ENOTFOUND doesnotexists___.com');
+    expect(err.code).toBe('getaddrinfo ENOTFOUND doesnotexists___.com');
   }
 });
 
@@ -80,7 +80,7 @@ test('Not a feed failure case', async () => {
     const nonFeedURL = 'https://kerleysblog.blogspot.com';
     await feedParser(nonFeedURL);
   } catch (err) {
-    expect(err.message).toBe('Not a feed');
+    expect(err.code).toBe('Not a feed');
   }
 });
 

--- a/test/feed-parser.test.js
+++ b/test/feed-parser.test.js
@@ -71,10 +71,9 @@ test('Non existant feed failure case.', async () => {
   try {
     await feedParser('http://doesnotexists___.com');
   } catch (err) {
-    expect(err.code).toBe('getaddrinfo ENOTFOUND doesnotexists___.com');
+    expect(err.code).toBe('ENOTFOUND');
   }
 });
-
 test('Not a feed failure case', async () => {
   try {
     const nonFeedURL = 'https://kerleysblog.blogspot.com';

--- a/test/feed-parser.test.js
+++ b/test/feed-parser.test.js
@@ -71,7 +71,7 @@ test('Non existant feed failure case.', async () => {
   try {
     await feedParser('http://doesnotexists___.com');
   } catch (err) {
-    expect(err.message).toBe('getaddrinfo ENOTFOUND doesnotexists___.com doesnotexists___.com:80');
+    expect(err.message).toBe('getaddrinfo ENOTFOUND doesnotexists___.com');
   }
 });
 

--- a/test/feed-parser.test.js
+++ b/test/feed-parser.test.js
@@ -37,6 +37,7 @@ test('Passing a valid URI, but not a feed URI should error', async () => {
   await expect(feedParser('https://google.ca')).rejects.toThrow('Not a feed');
 });
 
+
 test('Passing an IP address instead of a URI should throw an error', async () => {
   await expect(feedParser('128.190.222.135')).rejects.toThrow('error');
 });
@@ -58,4 +59,39 @@ test('Passing a valid RSS category feed should return an array that is not empty
   fixtures.nockValidRssRes();
   const data = await feedParser(feedURL);
   expect(data.length > 0).toBe(true);
+});
+
+const assertValidFeed = (feed) => {
+  expect(Array.isArray(feed)).toBeTruthy();
+  expect(feed.length > 0).toBeTruthy();
+};
+
+
+test('Non existant feed failure case.', async () => {
+  try {
+    await feedParser('http://doesnotexists___.com');
+  } catch (err) {
+    expect(err.message).toBe('getaddrinfo ENOTFOUND doesnotexists___.com doesnotexists___.com:80');
+  }
+});
+
+test('Not a feed failure case', async () => {
+  try {
+    const nonFeedURL = 'https://kerleysblog.blogspot.com';
+    await feedParser(nonFeedURL);
+  } catch (err) {
+    expect(err.message).toBe('Not a feed');
+  }
+});
+
+test('Blogger feed success case', async () => {
+  const validFeed = 'https://kerleysblog.blogspot.com/feeds/posts/default?alt=rss';
+  const feed = await feedParser(validFeed);
+  assertValidFeed(feed);
+});
+
+test('Wordpress site feed success case', async () => {
+  const validFeed = 'https://medium.com/feed/@Medium';
+  const feed = await feedParser(validFeed);
+  assertValidFeed(feed);
 });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -12,12 +12,49 @@ const getHtmlUri = () => 'https://test321.blogspot.com/blog';
 // Remove leading protocol from a URI
 const stripProtocol = uri => uri.replace(/^https?:\/\//, '');
 
-const getFeedBody = () =>
-  '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel><title>W3Schools Home Page</title><link>https://www.w3schools.com</link><description>Free web building tutorials</description><item><title>RSS Tutorial</title><link>https://www.w3schools.com/xml/xml_rss.asp</link><description>New RSS tutorial on W3Schools</description></item><item><title>XML Tutorial</title><link>https://www.w3schools.com/xml</link><description>New XML tutorial on W3Schools</description></item></channel></rss>';
-const getInvalidFeedBody = () =>
-  '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel></channel></rss>';
-const getHtmlBody = () =>
-  '<!DOCTYPE html><html><head><title>HTML Page</title></head><body>HTML, NOT XML</body></html>';
+const getValidFeedBody = () =>
+  `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0">
+    <channel>
+      <title>W3Schools Home Page</title>
+      <link>https://www.w3schools.com</link>
+      <description>Free web building tutorials</description>
+      <item>
+        <title>RSS Tutorial</title>
+        <link>https://www.w3schools.com/xml/xml_rss.asp</link>
+        <description>New RSS tutorial on W3Schools</description>
+      </item>
+      <item>
+        <title>XML Tutorial</title>
+        <link>https://www.w3schools.com/xml</link>
+        <description>New XML tutorial on W3Schools</description>
+      </item>
+    </channel>
+  </rss>
+  `;
+
+const getEmptyFeedBody = () =>
+  `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0">
+    <channel/>
+  </rss>
+  `;
+
+const getValidHtmlBody = () =>
+  `
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset="utf8" />
+      <title>HTML Page</title>
+    </head>
+    <body>
+      <p>HTML, NOT XML</p>
+    </body>
+  </html>
+  `;
 
 /**
  * Generic network nock request, used below to define all our mock requests.
@@ -41,24 +78,24 @@ exports.getRssUri = getRssUri;
 exports.getHtmlUri = getHtmlUri;
 exports.stripProtocol = stripProtocol;
 
-exports.getFeedBody = getFeedBody;
-exports.getInvalidFeedBody = getInvalidFeedBody;
-exports.getHtmlBody = getHtmlBody;
+exports.getValidFeedBody = getValidFeedBody;
+exports.getEmptyFeedBody = getEmptyFeedBody;
+exports.getValidHtmlBody = getValidHtmlBody;
 
 exports.nockValidAtomResponse = function() {
-  nockResponse(getAtomUri(), getFeedBody(), 200, 'application/rss+xml');
+  nockResponse(getAtomUri(), getValidFeedBody(), 200, 'application/rss+xml');
 };
 
 exports.nockValidRssResponse = function() {
-  nockResponse(getRssUri(), getFeedBody(), 200, 'application/rss+xml');
+  nockResponse(getRssUri(), getValidFeedBody(), 200, 'application/rss+xml');
 };
 
 exports.nockInvalidRssResponse = function() {
-  nockResponse(getRssUri(), getInvalidFeedBody(), 200, 'application/rss+xml');
+  nockResponse(getRssUri(), getEmptyFeedBody(), 200, 'application/rss+xml');
 };
 
 exports.nockValidHtmlResponse = function() {
-  nockResponse(getHtmlUri(), getHtmlBody(), 200, 'text/html');
+  nockResponse(getHtmlUri(), getValidHtmlBody(), 200, 'text/html');
 };
 
 exports.nock404Response = function() {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,33 +1,66 @@
 const nock = require('nock');
+const url = require('url');
 
 /**
  * This is a fixture module for telescope tests which contains measures to
  * maintain a reproducible environment for system testing
  */
 
-const validBody =
+const getAtomUri = () => 'https://test321.blogspot.com/feeds/posts/default/-/open-source';
+const getRssUri = () => 'https://test321.blogspot.com/feeds/posts/default/-/open-source?alt=rss';
+const getHtmlUri = () => 'https://test321.blogspot.com/blog';
+// Remove leading protocol from a URI
+const stripProtocol = uri => uri.replace(/^https?:\/\//, '');
+
+const getFeedBody = () =>
   '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel><title>W3Schools Home Page</title><link>https://www.w3schools.com</link><description>Free web building tutorials</description><item><title>RSS Tutorial</title><link>https://www.w3schools.com/xml/xml_rss.asp</link><description>New RSS tutorial on W3Schools</description></item><item><title>XML Tutorial</title><link>https://www.w3schools.com/xml</link><description>New XML tutorial on W3Schools</description></item></channel></rss>';
+const getInvalidFeedBody = () =>
+  '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel></channel></rss>';
+const getHtmlBody = () =>
+  '<!DOCTYPE html><html><head><title>HTML Page</title></head><body>HTML, NOT XML</body></html>';
 
-const atomUri = 'https://test321.blogspot.com/feeds/posts/default/-/open-source';
+/**
+ * Generic network nock request, used below to define all our mock requests.
+ *
+ * @param {String} uri - the full, absolute URL to use for this mock network request
+ * @param {String} body  - the body to return
+ * @param {Number} httpResponseCode - the HTTP result code
+ * @param {String} mimeType  - the mime type to use for the response
+ */
+function nockResponse(uri, body, httpResponseCode, mimeType) {
+  const { protocol, host, pathname, search } = url.parse(uri);
+  nock(`${protocol}//${host}`)
+    .get(`${pathname}${search || ''}`)
+    .reply(httpResponseCode, body, {
+      'Content-Type': mimeType,
+    });
+}
 
-const rssUri = 'https://test321.blogspot.com/feeds/posts/default/-/open-source?alt=rss';
+exports.getAtomUri = getAtomUri;
+exports.getRssUri = getRssUri;
+exports.getHtmlUri = getHtmlUri;
+exports.stripProtocol = stripProtocol;
 
-exports.testAtomUri = function() {
-  return atomUri;
+exports.getFeedBody = getFeedBody;
+exports.getInvalidFeedBody = getInvalidFeedBody;
+exports.getHtmlBody = getHtmlBody;
+
+exports.nockValidAtomResponse = function() {
+  nockResponse(getAtomUri(), getFeedBody(), 200, 'application/rss+xml');
 };
 
-exports.testRssUri = function() {
-  return rssUri;
+exports.nockValidRssResponse = function() {
+  nockResponse(getRssUri(), getFeedBody(), 200, 'application/rss+xml');
 };
 
-exports.nockValidAtomRes = function() {
-  nock('https://test321.blogspot.com')
-    .get('/feeds/posts/default/-/open-source')
-    .reply(200, validBody);
+exports.nockInvalidRssResponse = function() {
+  nockResponse(getRssUri(), getInvalidFeedBody(), 200, 'application/rss+xml');
 };
 
-exports.nockValidRssRes = function() {
-  nock('https://test321.blogspot.com')
-    .get('/feeds/posts/default/-/open-source?alt=rss')
-    .reply(200, validBody);
+exports.nockValidHtmlResponse = function() {
+  nockResponse(getHtmlUri(), getHtmlBody(), 200, 'text/html');
+};
+
+exports.nock404Response = function() {
+  nockResponse(getHtmlUri(), 'Not Found', 404, 'text/html');
 };


### PR DESCRIPTION
Finishing work begun by @nazneennahar in https://github.com/Seneca-CDOT/telescope/pull/219.  This adds more tests for the feed parser, and closes #72.  I've switched to using `nock` for the network requests vs. live URLs.