### PR TITLE
Fix #205: Add jest -watch option

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Some helpful guides:
 1. Run `npm install`.
 1. Run `npm test`
 1. IF eslint detect some issues run `npm run eslint-fix` before manually fixing the issue (Will save you time :smile:) and then run `npm test` again.
+1. Run `npm run watch` to watch files for any changes and rerun tests related to changed files.
 1. Run `npm start` to start telescope.
    _If you get a series of errors, you may have to start redis-server depending on your installation configuration, do this by running the command `redis-server` in a seperate command window)._
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Some helpful guides:
 1. Run `npm install`.
 1. Run `npm test`
 1. IF eslint detect some issues run `npm run eslint-fix` before manually fixing the issue (Will save you time :smile:) and then run `npm test` again.
-1. Run `npm run watch` to watch files for any changes and rerun tests related to changed files.
+1. Run `npm run jest-watch` to watch files for any changes and rerun tests related to changed files.
 1. Run `npm start` to start telescope.
    _If you get a series of errors, you may have to start redis-server depending on your installation configuration, do this by running the command `redis-server` in a seperate command window)._
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "postlint": "npm run stylelint",
     "prettier": "prettier --write \"./**/*.{md,json,html,css,js,yml}\"",
     "pretest": "npm run lint",
+    "watch": "jest --watch",
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
     "start": "node src/backend",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "postlint": "npm run stylelint",
     "prettier": "prettier --write \"./**/*.{md,json,html,css,js,yml}\"",
     "pretest": "npm run lint",
-    "watch": "jest --watch",
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
     "jest-watch":"cross-env MOCK_REDIS=1 jest --watch",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "watch": "jest --watch",
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
-    "start": "node src/backend",
-    "server": "node src/backend/web/server",
-    "hint": "hint http://localhost:3000",
-    "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint"
+    "jest-watch":"cross-env MOCK_REDIS=1 jest --watch",
+    "start": "node src",
+    "debug-server": "nodemon server.js"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Adding jest --watch option to the code will allowed user to do detailed test on the files.
After using command `npm run watch` user will see pop up menu that will give options  what commands can be run in order to perform analysis on the files:
<img width="445" alt="r04" src="https://user-images.githubusercontent.com/49209351/69761432-61cd3a00-1135-11ea-8c7e-b5d3f53d7ad5.PNG">

