### PR TITLE
Fix #260 implement addPost and getPost method

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -1,4 +1,4 @@
-const { redis } = require('../lib/redis');
+const { redis } = require('./backend/lib/redis');
 
 // Redis Keys
 const FEED_ID = 'feed_id';

--- a/src/storage.js
+++ b/src/storage.js
@@ -51,13 +51,13 @@ module.exports = {
         'site',
         post.site
       )
-      .zadd(POSTS, new Date(post.published).getTime(), post.guid) // sort set by published date as scores
+      .zadd(POSTS, post.published.getTime(), post.guid) // sort set by published date as scores
       .exec();
   },
 
   getPosts: (startDate, endDate) =>
     // Get all posts between start and end dates in the sorted set
-    redis.zrangebyscore(POSTS, new Date(startDate).getTime(), new Date(endDate).getTime()),
+    redis.zrangebyscore(POSTS, startDate.getTime(), endDate.getTime()),
 
   getPost: guid => redis.hgetall(guid),
 };

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -14,4 +14,50 @@ describe('Tests for storage', () => {
     const result = await storage.getFeed(feedId);
     expect(result).toEqual(feed2);
   });
+
+  const post = {
+    guid: 'tag:blogger.com,1999:blog-7100164112302197371.post-522285656016053350',
+    author: 'Neil David',
+    title: 'My First Blog',
+    link: 'http://nadavid.blogspot.com/2008/09/my-first-blog.html',
+    content:
+      "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
+    text: 'post one text',
+    updated: '2009-09-07T22:23:00.544Z',
+    published: '2009-09-07T22:20:00.000Z',
+    url: 'http://seneca.co/jsmith',
+    site: 'wordpress.com',
+  };
+
+  const post2 = {
+    guid: '2tag:blogger.com,1999:blog-7100164112302197371.post-522285656016053350',
+    author: 'Neil David2',
+    title: 'My First Blog2',
+    link: 'http://nadavid2.blogspot.com/2008/09/my-first-blog.html',
+    content:
+      "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
+    text: 'post one text2',
+    updated: '2008-09-07T22:12:00.544Z',
+    published: '2008-09-07T22:09:00.000Z',
+    url: 'http://seneca.co/jsmith',
+    site: 'wordpress.com',
+  };
+
+  it('should allow retrieving a post by guid after inserting', async () => {
+    await storage.addPost(post);
+    const result = await storage.getPost(post.guid);
+    expect(result.link).toEqual(post.link);
+  });
+
+  it('get all posts returns corrent number of posts', async () => {
+    await storage.addPost(post2);
+    const result = await storage.getPosts(post2.published, post.published);
+    expect(result.length).toEqual(2);
+  });
+
+  it('get all posts returns sorted posts by date', async () => {
+    const result = await storage.getPosts(post2.published, post.published);
+    expect(result[0]).toEqual(post2.guid);
+    expect(result[1]).toEqual(post.guid);
+  });
 });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -23,8 +23,8 @@ describe('Tests for storage', () => {
     content:
       "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
     text: 'post one text',
-    updated: '2009-09-07T22:23:00.544Z',
-    published: '2009-09-07T22:20:00.000Z',
+    updated: Date('2009-09-07T22:23:00.544Z'),
+    published: Date('2009-09-07T22:20:00.000Z'),
     url: 'http://seneca.co/jsmith',
     site: 'wordpress.com',
   };
@@ -37,8 +37,8 @@ describe('Tests for storage', () => {
     content:
       "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
     text: 'post one text2',
-    updated: '2008-09-07T22:12:00.544Z',
-    published: '2008-09-07T22:09:00.000Z',
+    updated: Date('2008-09-07T22:12:00.544Z'),
+    published: Date('2008-09-07T22:09:00.000Z'),
     url: 'http://seneca.co/jsmith',
     site: 'wordpress.com',
   };


### PR DESCRIPTION
Added addPost() function using guid as unique key for each post and store posts as sorted set by published date.
Added getPost() by guid and getPosts() by range of dates.
Added test for testing above mentioned functions.