### PR TITLE
deleted console logs from spamming tests

### DIFF
--- a/src/extract-urls.js
+++ b/src/extract-urls.js
@@ -6,7 +6,5 @@ const getUrls = require('get-urls');
 exports.extract = function(htmlData) {
   const urls = getUrls(htmlData);
   const arrayOfUrls = Array.from(urls);
-  console.log('Printing URLs from blog feed data');
-  console.log(arrayOfUrls);
   return arrayOfUrls;
 };

--- a/src/feed-worker.js
+++ b/src/feed-worker.js
@@ -20,8 +20,6 @@ exports.workerCallback = async function(job) {
         processedPosts.push(processedPost);
         extractUrls.extract(post.description);
       });
-      // We can pass these objects into another queue, For now just printing to the console.
-      console.log(processedPosts);
       return Promise.resolve(processedPosts);
     }
     return Promise.reject(new Error(`Failed to extract posts from url: ${url}`));


### PR DESCRIPTION
Got rid of the annoying console.log spams when running ```npm test```

fixes https://github.com/Seneca-CDOT/telescope/issues/333