### PR TITLE
Issue #348: Update logo link to Seneca-CDOT's GitHub Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Telescope <img align="left" width="100" height="100" src=https://github.com/brucremo/telescope/blob/master/images/telescope-logo.png>
+# Telescope <img align="left" width="100" height="100" src=https://github.com/Seneca-CDOT/telescope/blob/master/images/telescope-logo.png>
 
 [![Build Status](https://travis-ci.org/Seneca-CDOT/telescope.svg?branch=master)](https://travis-ci.org/Seneca-CDOT/telescope)
 [![CircleCI](https://circleci.com/gh/Seneca-CDOT/telescope.svg?style=svg)](https://circleci.com/gh/Seneca-CDOT/telescope)


### PR DESCRIPTION
The link has been updated and now the logo link in our Readme.md points to CDOT's GitHub repo