### PR TITLE
Fix #289: deal with log levels that crash the server

### DIFF
--- a/src/backend/utils/logger.js
+++ b/src/backend/utils/logger.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-lonely-if */
 const pino = require('pino');
 const expressPino = require('express-pino-logger');
 const os = require('os');
@@ -5,13 +6,28 @@ const os = require('os');
 require('../lib/config');
 
 let logger;
+let logLevel;
 
 /* If in Development mode:
  * Output logs to console (which is by default)
  * Enable prettyPrint option and translate time from epoch time to local time.
  * Set log level to LOG_LEVEL environment variable with 'debug' as default level.
  */
-if (process.env.NODE_ENV === 'development') {
+
+/* Created a local variable to to hold the value form process.env.LOG_LEVEL.toLowerCase()
+ * The if statement will check the variable if the variable is anything other than levels
+ * stated within file it will automatically set to info.
+ * https://getpino.io/#/docs/api?id=level-string Look for the title ``` level (String) ```
+ */
+
+logLevel = (process.env.LOG_LEVEL || 'info').toLowerCase();
+if (!pino.levels.values[logLevel]) {
+  logLevel = 'info';
+}
+
+if (logLevel !== 'info') {
+  logLevel = 'info';
+} else if (process.env.NODE_ENV === 'development') {
   logger = pino({
     prettyPrint: {
       translateTime: 'SYS: yyyy-mm-dd HH:MM:ss.l ',
@@ -19,29 +35,31 @@ if (process.env.NODE_ENV === 'development') {
     },
     level: process.env.LOG_LEVEL || 'debug',
   });
-} else if (process.env.LOG_FILE) {
-  /* If in Production mode:
-   * Write logs to a specified path.
-   * Set log level to LOG_LEVEL environment variable with 'info' as default level.
-   */
-  logger = pino(
-    {
-      level: process.env.LOG_LEVEL || 'info',
+} else {
+  if (process.env.LOG_FILE) {
+    /* If in Production mode:
+     * Write logs to a specified path.
+     * Set log level to LOG_LEVEL environment variable with 'info' as default level.
+     */
+    logger = pino(
+      {
+        level: logLevel || 'info',
+        prettyPrint: {
+          translateTime: 'SYS: yyyy-mm-dd HH:MM:ss.l ',
+          colorize: false,
+        },
+      },
+      pino.destination(process.env.LOG_FILE)
+    );
+  } else {
+    logger = pino({
+      level: logLevel || 'info',
       prettyPrint: {
         translateTime: 'SYS: yyyy-mm-dd HH:MM:ss.l ',
         colorize: false,
       },
-    },
-    pino.destination(process.env.LOG_FILE)
-  );
-} else {
-  logger = pino({
-    level: process.env.LOG_LEVEL || 'info',
-    prettyPrint: {
-      translateTime: 'SYS: yyyy-mm-dd HH:MM:ss.l ',
-      colorize: false,
-    },
-  });
+    });
+  }
 }
 
 const expressLogger = expressPino({ logger });


### PR DESCRIPTION
Fixes #231  Server crashes if LOG_LEVEL is upper case (FIXED)

- Created a new local variable to to hold the value form ```process.env.LOG_LEVEL.toLowerCase()``` . <br>

- Have an statement to check if the variable coming in is either in lowercase or one of the documented levels on  ``` https://getpino.io/#/docs/api?id=level-string``` .

- If it's not then the new local variable will be set to  level parameter ``` info ```.
