### PR TITLE
Added reading-level module with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pretest": "npm run lint",
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
-    "jest-watch":"cross-env MOCK_REDIS=1 jest --watch",
+    "jest-watch": "cross-env MOCK_REDIS=1 jest --watch",
     "start": "node src",
     "debug-server": "nodemon server.js"
   },

--- a/package.json
+++ b/package.json
@@ -24,14 +24,10 @@
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
     "jest-watch": "cross-env MOCK_REDIS=1 jest --watch",
-<<<<<<< HEAD
-    "start": "node src",
-=======
     "start": "node src/backend",
     "server": "node src/backend/web/server",
     "hint": "hint http://localhost:3000",
     "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint",
->>>>>>> 7c934cdf0918232bdf1a6b1aefdf455d7e8e1485
     "debug-server": "nodemon server.js"
   },
   "husky": {

--- a/src/backend/utils/reading-level.js
+++ b/src/backend/utils/reading-level.js
@@ -1,0 +1,33 @@
+/*
+  Function takes a string and returns an object with the following properties:
+  sentences, words, syllables, unrounded, rounded
+  Also includes an error property if an error is encountered while analyzing the string
+
+  unrounded is a measure of the string's complexity using the Flesch-Kincaid Grade Level Readability Formula.
+  rounded is the same measure rounded to the nearest 1
+
+  example without errors:
+  input: 'this is a simple sentence'
+  return:
+  { sentences: 1,
+  words: 5,
+  syllables: 7,
+  unrounded: 2.879999999999999,
+  rounded: 3 }
+
+  example with error:
+  input: '0120131908 74123987419823'
+  return:
+  { sentences: 1,
+  words: 0,
+  syllables: 0,
+  unrounded: NaN,
+  rounded: NaN,
+  error: 'Either no sentences or words, please enter valid text' }
+*/
+
+const readingLevel = require('reading-level');
+
+module.exports = async function(content) {
+  return readingLevel(content, 'full');
+};

--- a/test/reading-level.test.js
+++ b/test/reading-level.test.js
@@ -1,0 +1,27 @@
+const readingLevel = require('../src/backend/utils/reading-level');
+
+describe('Reading level checks', () => {
+  test('Analysis of text should return unrounded complexity of 2.879999999999999', async () => {
+    readingLevel('this is a simple sentence').then(result => {
+      expect(result.unrounded).toBe(2.879999999999999);
+    });
+  });
+
+  test('Analysis of text should return unrounded complexity of 20.854285714285712', async () => {
+    readingLevel('the perpendicular platypus perused the panoramic pyramid').then(result => {
+      expect(result.unrounded).toBe(20.854285714285712);
+    });
+  });
+
+  test('Analysis of text should return error', async () => {
+    readingLevel('0120131908 74123987419823').then(result => {
+      expect(result.error).toBe(!null);
+    });
+  });
+
+  test('Analysis of text should return error', async () => {
+    readingLevel('').then(result => {
+      expect(result.error).toBe(!null);
+    });
+  });
+});


### PR DESCRIPTION
Issue #84 

Implemented the [reading-level](https://www.npmjs.com/package/reading-level) node and created tests for the function.
Tests only check if the unrounded reading level matches the expected result and if errors occur, as I figured those would be the most important values. I can modify the tests to check if all the returned values match the expected result, but it requires another function to be run for each test.
Also left documentation for using reading-level in the reading level-module. 