### PR TITLE
Fixes #315: Added password to the Bull queue constructor

### DIFF
--- a/env.example
+++ b/env.example
@@ -15,9 +15,10 @@ LOG_FILE=
 # FEED_URL url used to access feed list
 FEED_URL=https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
 
-# REDIS_URL specifies Redis server info
+# Redis Server info, password may be optional (e.g., leave empty if you don't set one)
 REDIS_URL=redis://127.0.0.1:6379
-REDIS_PORT=6379
+REDIS_PORT=6739
+REDIS_PASSWORD=
 
 # MOCK_REDIS=1 will use an in-memory, mock Redis instance. Useful for testing.
 MOCK_REDIS=

--- a/src/backend/lib/queue.js
+++ b/src/backend/lib/queue.js
@@ -1,13 +1,14 @@
 const Bull = require('bull');
-const { Redis, redisUrl } = require('./redis');
+const { createRedisClient } = require('./redis');
 const { logger } = require('../utils/logger');
 
 /**
  * Shared redis connections for pub/sub, see:
  * https://github.com/OptimalBits/bull/blob/28a2b9aa444d028fc5192c9bbdc9bb5811e77b08/PATTERNS.md#reusing-redis-connections
  */
-const client = new Redis(redisUrl);
-const subscriber = new Redis(redisUrl);
+
+const client = createRedisClient();
+const subscriber = createRedisClient();
 
 /**
  * Create a Queue with the given `name` (String).
@@ -25,7 +26,7 @@ function createQueue(name) {
         case 'subscriber':
           return subscriber;
         default:
-          return new Redis(redisUrl);
+          return createRedisClient();
       }
     },
   })


### PR DESCRIPTION
Fixes #315 
- Added REDIS_PASSWORD to the env.example
- Added password to the Bull queue constructor

In order to pass password to the Redis constructor, I had to change the parameter list to the following, according to the [documentation](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options):
```js
new Redis(port, host, redisPassword);
```