### PR TITLE
Add test for dateDiff function. Improving coverage for inactive-blog-filter.

### DIFF
--- a/src/backend/utils/inactive-blog-filter.js
+++ b/src/backend/utils/inactive-blog-filter.js
@@ -144,3 +144,4 @@ function update() {
 
 exports.check = check;
 exports.update = update;
+exports.dateDiff = dateDiff;

--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -19,3 +19,17 @@ describe('Redlisted feed checking', () => {
     });
   });
 });
+
+describe('Testing dateDiff function', () => {
+  it('dateDiff should return a positive value if postDate(parameter) is before currentDate', () => {
+    expect(inactiveFilter.dateDiff(Date.now() - 1)).toBeGreaterThan(0);
+  });
+
+  it('dateDiff should return a negative value if postDate(parameter) is after currentDate', () => {
+    expect(inactiveFilter.dateDiff(Date.now() + 1)).toBeLessThan(0);
+  });
+
+  it('dateDiff should return a zero value if postDate(parameter) is the same as currentDate', () => {
+    expect(inactiveFilter.dateDiff(Date.now())).toEqual(0);
+  });
+});


### PR DESCRIPTION
Improving the coverage for the `inactive-blog-filter` file by adding tests for the `dateDiff` function. I also had to export the `dateDiff` function in order to test it. See #197, doesn't close it but helps move it forward.
- - -
Before:
![image](https://user-images.githubusercontent.com/30512065/69837380-77695f00-121c-11ea-9db3-05dc85e32d27.png)
![image](https://user-images.githubusercontent.com/30512065/69837964-59512e00-121f-11ea-970d-507b855c0072.png)

- - -
After:
![image](https://user-images.githubusercontent.com/30512065/69837937-3161ca80-121f-11ea-9450-6770b3895956.png)
![image](https://user-images.githubusercontent.com/30512065/69837976-6706b380-121f-11ea-95d7-a87addfaacf8.png)


