### PR TITLE
Fixes #187: switch from jsdom to puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "passport-openid": "0.4.0",
     "pino": "5.13.6",
     "pino-pretty": "3.4.0",
+    "puppeteer": "2.0.0",
     "reading-level": "0.0.7",
     "sentiment": "5.0.2",
     "spam-filter": "1.1.1",

--- a/src/backend/utils/text-parser.js
+++ b/src/backend/utils/text-parser.js
@@ -1,11 +1,20 @@
-const jsdom = require('jsdom');
+const puppeteer = require('puppeteer');
 
-const { JSDOM } = jsdom;
+module.exports = async function(htmlFragment) {
+  let browser;
+  try {
+    browser = await puppeteer.launch();
+    const page = await browser.newPage();
 
-// Simple function to convert html to text
-// Issue #75: https://github.com/Seneca-CDOT/telescope/issues/75
-exports.run = async function(html) {
-  const frag = JSDOM.fragment(html);
-  const result = await frag.textContent;
-  return result;
+    await page.setContent(htmlFragment, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const result = await page.evaluate('document.body.innerText');
+    return result;
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
 };

--- a/test/text-parser.test.js
+++ b/test/text-parser.test.js
@@ -5,13 +5,18 @@ const textParser = require('../src/backend/utils/text-parser');
  * Function should only extract what in the body
  */
 test('Testing text-parser', async () => {
-  const result = await textParser.run('<!DOCTYPE html><p>Hello World</p>');
+  const result = await textParser('<!DOCTYPE html><p>Hello World</p>');
   expect(result).toBe('Hello World');
 });
 
-test.skip('Testing text-parser with new line', async () => {
-  const result = await textParser.run(
+test('Testing text-parser with new line', async () => {
+  const result = await textParser(
     '<!DOCTYPE html><html><head><title>OSD600</title></head><body style = "text-align:center;"><h1>Seneca</h1><div>OpenSource Telescope</div></body></html>'
   );
   expect(result).toBe('Seneca\nOpenSource Telescope');
+});
+
+test('Testing text-parser with Document Fragment', async () => {
+  const result = await textParser('<p>OSD600</p>');
+  expect(result).toBe('OSD600');
 });


### PR DESCRIPTION
Switch from JSDOM to Puppeteer for parsing HTML to Text