### PR TITLE
Refactor shutdown logic into separate file

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,78 +1,20 @@
 require('./lib/config.js');
 const feedQueue = require('./feed/queue');
 const feedWorker = require('./feed/worker');
-const { logger } = require('./utils/logger');
+const { logger: log } = require('./utils/logger');
 const wikiFeed = require('./utils/wiki-feed-parser');
-
-const log = logger.child({ module: 'main' });
+const shutdown = require('./lib/shutdown');
 
 // Start the web server
-const server = require('./web/server');
-
-/**
- * Stops the Redis Queue, web server, etc. closing all connections gracefully
- */
-let isShuttingDown = false;
-
-function shutDown() {
-  if (isShuttingDown) {
-    return;
-  }
-
-  isShuttingDown = true;
-  log.info('Received kill signal, shutting down gracefully');
-
-  // Force shutting down
-  setTimeout(() => {
-    log.error('Could not close connections in time, forcefully shutting down');
-    process.exit(1);
-  }, 10000);
-
-  // Try to shut down
-  Promise.all([
-    // 1. Shutdown the queue
-    feedQueue
-      .close()
-      .then(() => log.info('Feed queue shut down.'))
-      .catch(err => log.error('Unable to close feed queue gracefully', err)),
-    // 2. Shutdown the web server, if necessary
-    new Promise((resolve, reject) => {
-      if (!(server && server.listening)) {
-        log.info('Web server already shut down.');
-        resolve();
-        return;
-      }
-      server.close(err => {
-        if (err) {
-          log.error('Unable to close web server gracefully', { err });
-          reject(err);
-        } else {
-          log.info('Web server shut down.');
-          resolve();
-        }
-      });
-    }),
-  ])
-    .then(() => {
-      log.info('Shutting down.');
-      process.exit(0);
-    })
-    .catch(err => log.error(err));
-}
+require('./web/server');
 
 /**
  * Shutting Down Logic for most Server Shutdown Cases
  */
-process.on('SIGTERM', shutDown);
-process.on('SIGINT', shutDown);
-process.on('unhandledRejection', err => {
-  log.error({ err }, 'UNHANDLED REJECTION: Shutting down...');
-  shutDown();
-});
-process.on('uncaughtException', err => {
-  log.error({ err }, 'UNCAUGHT EXCEPTION: Shutting down...');
-  shutDown();
-});
+process.on('SIGTERM', shutdown('SIGTERM'));
+process.on('SIGINT', shutdown('SIGINT'));
+process.on('unhandledRejection', shutdown('UNHANDLED REJECTION'));
+process.on('uncaughtException', shutdown('UNCAUGHT EXCEPTION'));
 
 /**
  * Adds feed URL jobs to the feed queue for processing
@@ -81,9 +23,8 @@ process.on('uncaughtException', err => {
 async function enqueueWikiFeed() {
   const data = await wikiFeed.parseData();
   await Promise.all(
-    data.map(async feedJob => {
-      log.info(`Enqueuing feed job for ${feedJob.url}`);
-      await feedQueue.add(feedJob, {
+    data.map(feedJob =>
+      feedQueue.add(feedJob, {
         attempts: process.env.FEED_QUEUE_ATTEMPTS || 8,
         backoff: {
           type: 'exponential',
@@ -91,8 +32,8 @@ async function enqueueWikiFeed() {
         },
         removeOnComplete: true,
         removeOnFail: true,
-      });
-    })
+      })
+    )
   ).catch(err => log.error({ err }, 'Error queuing wiki feeds'));
 }
 

--- a/src/backend/lib/shutdown.js
+++ b/src/backend/lib/shutdown.js
@@ -1,0 +1,55 @@
+const { promisify } = require('util');
+
+const feedQueue = require('../feed/queue');
+const { logger: log } = require('../utils/logger');
+const server = require('../web/server');
+
+let isShuttingDown = false;
+
+function stopQueue() {
+  return feedQueue
+    .close()
+    .then(() => log.info('Feed queue shut down.'))
+    .catch(err => log.error('Unable to close feed queue gracefully', { err }));
+}
+
+function stopWebServer() {
+  const serverClose = promisify(server.close.bind(server));
+  return serverClose()
+    .then(() => log.info('Web server shut down.'))
+    .catch(err => log.error('Unable to close web server gracefully', { err }));
+}
+
+function shutdown(signal) {
+  return cause => {
+    if (isShuttingDown) {
+      return;
+    }
+
+    log.info(`Received ${signal}, starting shut down`);
+    isShuttingDown = true;
+
+    if (cause) {
+      log.error({ cause });
+    }
+
+    // If our attempts to shut down cleanly don't work, force it
+    setTimeout(() => {
+      log.error('Could not close connections in time, forcefully shutting down');
+      process.exit(1);
+    }, 5000).unref();
+
+    // Try to shut down cleanly
+    Promise.all([stopQueue(), stopWebServer()])
+      .then(() => {
+        log.info('Completing shut down.');
+        process.exit(0);
+      })
+      .catch(err => {
+        log.error('Failed to perform clean shutdown', { err });
+        process.exit(1);
+      });
+  };
+}
+
+module.exports = shutdown;


### PR DESCRIPTION
I refactored the shutdown logic into its own file in `lib/shutdown.js` to simplify our main entry point.  I also removed a stray `async` call and unnecessary `log()` while I was testing.