### PR TITLE
Allow Windows builds to fail without failing Travis overall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,8 @@ before_install:
       redis-server --service-start
       redis-cli info
     fi
+matrix:
+  allow_failures:
+    # Windows can fail if choco can't download redis
+    # https://github.com/Seneca-CDOT/telescope/issues/387
+    - os: windows


### PR DESCRIPTION
Fixes #387 partially, by allowing Windows builds to fail, but not failing Travis overall.  This is a bandaid, meant to get our builds to pass while we sort out how to deal with Redis in CI.