### PR TITLE
Fix #393 Add last test for backend/storage.js

### DIFF
--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -30,6 +30,13 @@ describe('Tests for storage', () => {
     expect(result).toContain(feedId2.toString());
   });
 
+  it('should return all members of the set value stored at key', async () => {
+    await storage.addFeed(feed.name, feed.url);
+    await storage.addFeed(feed2.name, feed2.url);
+    const feeds = await storage.getFeeds();
+    expect(feeds).toEqual(['1', '2', '3', '4', '5', '6', '7']);
+  });
+
   const post = {
     guid: 'tag:blogger.com,1999:blog-7100164112302197371.post-522285656016053350',
     author: 'Neil David',


### PR DESCRIPTION
There was still a missing test on storage.js related to the use of redis.smembers
I added the following test:
```javascript
  it('should return all members of the set value stored at key', async () => {
    await storage.addFeed(feed.name, feed.url);
    await storage.addFeed(feed2.name, feed2.url);
    const feeds = await storage.getFeeds();
    expect(feeds).toEqual(['1', '2', '3', '4']);
  });
```
Now the test suit is complete for this file:
![missing2](https://user-images.githubusercontent.com/19479159/69909444-35315080-13c9-11ea-9f79-1c30fd8d02af.png)

