### PR TITLE
Fixes #197, fixes #199: revamp inactive-blog-filter and tests

### DIFF
--- a/src/backend/utils/inactive-blog-filter.js
+++ b/src/backend/utils/inactive-blog-filter.js
@@ -98,6 +98,8 @@ async function update(
         // We convert the dateDiff(result) from ms in days
         const timeDiff = Math.ceil(dateDiff(recentPostDate) / (1000 * 3600 * 24));
 
+        // BLOG_INACTIVE_TIME is supplied with a necessary default value, e.g. of 365 days
+        // See: https://github.com/Seneca-CDOT/telescope/issues/396
         if (timeDiff > (process.env.BLOG_INACTIVE_TIME || 365)) {
           log.info(`Blog at: ${feedUrl} is INACTIVE!`);
 

--- a/src/backend/utils/inactive-blog-filter.js
+++ b/src/backend/utils/inactive-blog-filter.js
@@ -34,7 +34,7 @@ function dateDiff(postDate) {
 /**
  * Checks if feed url is redlisted
  * @param {string} feedUrl - url of the feed to check against redlist
- * @param {string} [redlistPath=feeds-redlist.json] - relative path to JSON file storing non-active feeds
+ * @param {string} [redlistPath=feeds-redlist.json] - path to JSON file storing non-active feeds
  */
 async function check(feedUrl, redlistPath = 'feeds-redlist.json') {
   // Read redlist file
@@ -46,7 +46,7 @@ async function check(feedUrl, redlistPath = 'feeds-redlist.json') {
       return Promise.resolve(redList.some(isRedlisted.bind(null, feedUrl)));
     })
     .catch(err => {
-      log.error(`failed to read ${redlistPath}: no feeds`);
+      log.error(`failed to read ${redlistPath}`, err.message);
       return Promise.reject(err);
     });
 }
@@ -59,9 +59,9 @@ async function check(feedUrl, redlistPath = 'feeds-redlist.json') {
  * pass feed data more intuitively
  *
  * Due to amount of operations, this can be run periodically instead of with every feed update
- * @param {string} [feedsPath=feeds.txt] - relative path to .txt file storing active feeds
- * @param {string} [redlistPath=feeds-redlist.json] - relative path to JSON file storing non-active feeds
- * @param {feed} [parser=feedParser] - reference to the function used to parse feeds
+ * @param {string} [feedsPath=feeds.txt] - path to .txt file storing active feeds
+ * @param {string} [redlistPath=feeds-redlist.json] - path to JSON file storing non-active feeds
+ * @param {function} [parser=feedParser] - reference to the function used to parse feeds
  */
 async function update(
   feedsPath = 'feeds.txt',
@@ -69,7 +69,7 @@ async function update(
   parser = feedParser
 ) {
   if (!feedsPath || !redlistPath) {
-    return Promise.reject(new Error('failed to update: bad arguments'));
+    return Promise.reject(new Error('failed to update: bad filepath'));
   }
 
   // Read the feeds list file
@@ -91,7 +91,7 @@ async function update(
 
       let recentPostDate = new Date();
 
-      if (feed) {
+      if (feed && typeof feed[0] !== 'undefined') {
         recentPostDate = new Date(feed[0].date);
 
         // Check if the blog is inactive
@@ -129,7 +129,7 @@ async function update(
             log.info(`wrote to ${redlistPath}: ${rlData}`);
           })
           .catch(err => {
-            log.error(`failed to update feeds`, err);
+            log.error(err.message);
             throw err;
           });
       }

--- a/src/backend/utils/inactive-blog-filter.js
+++ b/src/backend/utils/inactive-blog-filter.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const feedParser = require('../feed/parser');
 const { logger } = require('./logger');
 
+const fsPromises = fs.promises;
 const log = logger.child({ module: 'inactive-blog-filter' });
 
 /**
@@ -31,39 +32,26 @@ function dateDiff(postDate) {
 }
 
 /**
- * Callback for redlist check
- * @callback checkCallback
- * @param {boolean} result - true/false whether or not a feed url is redlisted
- */
-
-/**
  * Checks if feed url is redlisted
  * @param {string} feedUrl - url of the feed to check against redlist
- * @param {checkCallback} callback - a callback that runs after the check
+ * @param {string} [redlistPath=feeds-redlist.json] - relative path to JSON file storing non-active feeds
  */
-function check(feedUrl, callback) {
+async function check(feedUrl, redlistPath = 'feeds-redlist.json') {
   // Read redlist file
-  fs.readFile('feeds-redlist.json', 'utf-8', (err, redListRaw) => {
-    if (err) {
-      // Error reading file
-      callback(err, false);
-      return;
-    }
-
-    if (redListRaw.length === 0) {
-      // File is empty
-      callback(undefined, false);
-      return;
-    }
-
-    // Concat to array no matter what
-    const redList = [].concat(JSON.parse(redListRaw));
-
-    callback(null, redList.some(isRedlisted.bind(null, feedUrl)));
-  });
+  return fsPromises
+    .readFile(redlistPath, 'utf-8')
+    .then(redListRaw => {
+      // Concat to array no matter what
+      const redList = [].concat(JSON.parse(redListRaw));
+      return Promise.resolve(redList.some(isRedlisted.bind(null, feedUrl)));
+    })
+    .catch(err => {
+      log.error(`failed to read ${redlistPath}: no feeds`);
+      return Promise.reject(err);
+    });
 }
 
-/*
+/**
  * Performs a separate sweep of all feeds to see which ones are inactive,
  * then updates last post date in feeds-redlist.json
  *
@@ -71,15 +59,21 @@ function check(feedUrl, callback) {
  * pass feed data more intuitively
  *
  * Due to amount of operations, this can be run periodically instead of with every feed update
+ * @param {string} [feedsPath=feeds.txt] - relative path to .txt file storing active feeds
+ * @param {string} [redlistPath=feeds-redlist.json] - relative path to JSON file storing non-active feeds
+ * @param {feed} [parser=feedParser] - reference to the function used to parse feeds
  */
-function update() {
-  // Read the feeds list file
-  fs.readFile('feeds.txt', 'utf8', (err, lines) => {
-    if (err) {
-      log.error('unable to read initial list of feeds, cannot update', err.message);
-      return;
-    }
+async function update(
+  feedsPath = 'feeds.txt',
+  redlistPath = 'feeds-redlist.json',
+  parser = feedParser
+) {
+  if (!feedsPath || !redlistPath) {
+    return Promise.reject(new Error('failed to update: bad arguments'));
+  }
 
+  // Read the feeds list file
+  return fsPromises.readFile(feedsPath, 'utf-8').then(async lines => {
     // Divide the file into separate lines
     const feedUrlList = lines
       .split(/\r?\n/)
@@ -92,18 +86,21 @@ function update() {
     let linesRead = 0;
 
     feedUrlList.forEach(async feedItem => {
-      const feed = await feedParser(feedItem);
+      const feed = await parser(feedItem);
       const feedUrl = feedItem.url;
 
       let recentPostDate = new Date();
 
-      // In case of invalid/ dead feeds
-      if (typeof feed[0] !== 'undefined') {
+      if (feed) {
         recentPostDate = new Date(feed[0].date);
+
+        log.info(`feed[0].date: ${feed[0].date}`);
 
         // Check if the blog is inactive
         // We convert the dateDiff(result) from ms in days
         const timeDiff = Math.ceil(dateDiff(recentPostDate) / (1000 * 3600 * 24));
+        log.info(`timeDiff: ${timeDiff}`);
+        log.info(`process.env.BLOG_INACTIVE_TIME: ${process.env.BLOG_INACTIVE_TIME}`);
 
         if (timeDiff > process.env.BLOG_INACTIVE_TIME) {
           log.info(`Blog at: ${feedUrl} is INACTIVE!`);
@@ -114,6 +111,7 @@ function update() {
           });
         }
       } else {
+        // In case of invalid/ dead feeds
         log.info(`Blog at: ${feedUrl} HAS NOTHING TO SHARE!`);
 
         redlistUpdate.push({
@@ -129,16 +127,19 @@ function update() {
         // Write the new feeds-redlist.json
         const rlData = JSON.stringify(redlistUpdate, null, 2);
 
-        fs.writeFile('feeds-redlist.json', rlData, werr => {
-          if (werr) {
-            log.error('unable to write to feeds-redlist.json, cannot update', err.message);
-            return;
-          }
-
-          log.info('wrote to feeds-redlist.json');
-        });
+        await fsPromises
+          .writeFile(redlistPath, rlData)
+          .then(() => {
+            log.info(`wrote to ${redlistPath}: ${rlData}`);
+          })
+          .catch(err => {
+            log.error(`failed to update feeds`, err);
+            throw err;
+          });
       }
     });
+
+    return Promise.resolve(redlistUpdate);
   });
 }
 

--- a/src/backend/utils/inactive-blog-filter.js
+++ b/src/backend/utils/inactive-blog-filter.js
@@ -94,15 +94,11 @@ async function update(
       if (feed) {
         recentPostDate = new Date(feed[0].date);
 
-        log.info(`feed[0].date: ${feed[0].date}`);
-
         // Check if the blog is inactive
         // We convert the dateDiff(result) from ms in days
         const timeDiff = Math.ceil(dateDiff(recentPostDate) / (1000 * 3600 * 24));
-        log.info(`timeDiff: ${timeDiff}`);
-        log.info(`process.env.BLOG_INACTIVE_TIME: ${process.env.BLOG_INACTIVE_TIME}`);
 
-        if (timeDiff > process.env.BLOG_INACTIVE_TIME) {
+        if (timeDiff > (process.env.BLOG_INACTIVE_TIME || 365)) {
           log.info(`Blog at: ${feedUrl} is INACTIVE!`);
 
           redlistUpdate.push({

--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -109,7 +109,7 @@ describe('Testing of update()', () => {
     },
     {
       url: 'http://ajhooper.blogspot.com/feeds/posts/default',
-      date: new Date('2008-10-18T17:22:32.366Z').getTime(),
+      date: '2008-10-18T17:22:32.366Z',
       status: 'inactive',
     },
     {
@@ -145,8 +145,6 @@ describe('Testing of update()', () => {
     return inactiveFilter
       .update(pathToInactiveFeeds, pathToMockRedList, mockFeedParser)
       .then(data => {
-        log.info(`data.url: ${data.url}`);
-        log.info(`data.length: ${data.length}`);
         expect(data.length).toEqual(inactiveRedlist.length);
         for (let i = 0; i < inactiveRedlist.length; i += 1) {
           expect(data[i].url).toBe(inactiveRedlist[i].url);
@@ -154,7 +152,6 @@ describe('Testing of update()', () => {
       })
       .catch(err => {
         deleteMockRedlist();
-        log.error(err.message);
         throw new Error(err.message);
       });
   });

--- a/test/inactive-blog-filter.test.js
+++ b/test/inactive-blog-filter.test.js
@@ -10,7 +10,7 @@ const deleteMockRedlist = () => {
   try {
     fs.unlinkSync(pathToMockRedList);
   } catch (err) {
-    log.error(`failed to delete ${pathToMockRedList}`, err);
+    log.error(`failed to delete ${pathToMockRedList}`, err.message);
     throw err;
   }
 };
@@ -19,7 +19,7 @@ const initializeMockRedlist = () => {
     fs.writeFileSync(pathToMockRedList, '[]', { flag: 'w' });
   } catch (err) {
     deleteMockRedlist();
-    log.error(`failed to write to ${pathToMockRedList}`, err);
+    log.error(`failed to write to ${pathToMockRedList}`, err.message);
     throw err;
   }
 };
@@ -43,7 +43,8 @@ describe('Redlisted feed checking', () => {
           expect(isRedlisted).toBe(false);
         })
         .catch(err => {
-          throw new Error(err.message);
+          log.error(err.message);
+          throw err;
         });
     });
   });
@@ -56,7 +57,8 @@ describe('Redlisted feed checking', () => {
           expect(isRedlisted).toBe(true);
         })
         .catch(err => {
-          throw new Error(err.message);
+          log.error(err.message);
+          throw err;
         });
     });
   });
@@ -134,7 +136,8 @@ describe('Testing of update()', () => {
       })
       .catch(err => {
         deleteMockRedlist();
-        throw new Error(err.message);
+        log.error(err.message);
+        throw err;
       });
   });
 
@@ -152,7 +155,8 @@ describe('Testing of update()', () => {
       })
       .catch(err => {
         deleteMockRedlist();
-        throw new Error(err.message);
+        log.error(err.message);
+        throw err;
       });
   });
 
@@ -170,7 +174,8 @@ describe('Testing of update()', () => {
       })
       .catch(err => {
         deleteMockRedlist();
-        throw new Error(err.message);
+        log.error(err.message);
+        throw err;
       });
   });
 

--- a/test/test_files/inactive-blog-filter.test-active-feeds.txt
+++ b/test/test_files/inactive-blog-filter.test-active-feeds.txt
@@ -1,0 +1,1 @@
+https://blog.humphd.org/

--- a/test/test_files/inactive-blog-filter.test-dead-feeds.txt
+++ b/test/test_files/inactive-blog-filter.test-dead-feeds.txt
@@ -1,0 +1,1 @@
+http://KrazyDre.blogspot.com/feeds/posts/default?alt=rss

--- a/test/test_files/inactive-blog-filter.test-inactive-feeds.txt
+++ b/test/test_files/inactive-blog-filter.test-inactive-feeds.txt
@@ -1,0 +1,1 @@
+http://ajhooper.blogspot.com/feeds/posts/default


### PR DESCRIPTION
Fixes #197: builds upon #211 and #380 to boost testing coverage for `inactive-blog-filter.js` into the green (representing a significant step towards the resolution of #268).

Fixes #199: both the `check()` and `update()` functions of `inactive-blog-filter.js` now use [fs.promises](https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_promises_api). Thank you, @MeisterRed, for agreeing to collaborate!