### PR TITLE
Added add-feed script to manually add a feed to the queue

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -200,6 +200,16 @@ When working on fixing bugs, please use the following workflow:
    ...manually fix any errors yourself, rerunning npm test each time to confirm
    ```
 
+You can add feeds to the queue manually using `add-feed` followed by the name of the blogger and url of the feed. This can be useful for testing purposes.
+
+First, add a link to the binary:
+
+`npm link`
+
+Then use `add-feed`
+
+`add-feed --name "Bender Bending Rodriguez" --url futurama.wordpress.com/feed`
+
 ### Squashing Commits
 
 Before creating your pull request you may want to squash all your commits down to one. Ideally this should be done before you rebase on the upstream master.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "dependencies": {
     "bull": "3.12.1",
     "bull-board": "0.5.0",
+    "commander": "4.0.1",
+    "dompurify": "2.0.7",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-healthcheck": "0.1.0",
@@ -56,6 +58,7 @@
     "ioredis": "4.14.1",
     "ioredis-mock": "4.18.4",
     "jsdom": "15.2.1",
+    "minimist": "1.2.0",
     "node-fetch": "2.6.0",
     "node-summarizer": "1.0.7",
     "nodemailer": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
       "./test/lib/setupJest.js"
     ]
   },
+  "bin": {
+    "add-feed": "./src/backend/utils/add-feed.js"
+  },
   "scripts": {
     "eslint": "eslint --ignore-path .gitignore .",
     "eslint-fix": "eslint --fix --ignore-path .gitignore .",
@@ -31,8 +34,7 @@
     "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint",
     "lighthouse-index": "lighthouse http://localhost:3000 --output-path=./lighthouse-report.html --view",
     "lighthouse": "cross-env PORT=3000 npm-run-all -r -p server lighthouse-index",
-    "debug-server": "nodemon server.js",
-    "add-feed": "node src/backend/utils/add-feed.js"
+    "debug-server": "nodemon server.js"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint",
     "lighthouse-index": "lighthouse http://localhost:3000 --output-path=./lighthouse-report.html --view",
     "lighthouse": "cross-env PORT=3000 npm-run-all -r -p server lighthouse-index",
-    "test-ci": "run-s prettier-check test"
+    "debug-server": "nodemon server.js",
+    "add-feed": "node src/backend/utils/add-feed.js"
   },
   "husky": {
     "hooks": {
@@ -47,7 +48,6 @@
   "dependencies": {
     "bull": "3.12.1",
     "bull-board": "0.5.0",
-    "commander": "4.0.1",
     "dompurify": "2.0.7",
     "dotenv": "8.2.0",
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "bin": {
-    "add-feed": "./src/backend/utils/add-feed.js"
+    "add-feed": "./tools/add-feed.js"
   },
   "scripts": {
     "eslint": "eslint --ignore-path .gitignore .",
@@ -34,7 +34,7 @@
     "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint",
     "lighthouse-index": "lighthouse http://localhost:3000 --output-path=./lighthouse-report.html --view",
     "lighthouse": "cross-env PORT=3000 npm-run-all -r -p server lighthouse-index",
-    "debug-server": "nodemon server.js"
+    "test-ci": "run-s prettier-check test"
   },
   "husky": {
     "hooks": {
@@ -50,7 +50,6 @@
   "dependencies": {
     "bull": "3.12.1",
     "bull-board": "0.5.0",
-    "dompurify": "2.0.7",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-healthcheck": "0.1.0",

--- a/src/backend/utils/add-feed.js
+++ b/src/backend/utils/add-feed.js
@@ -1,0 +1,5 @@
+require('../../config');
+
+const program = require('commander');
+
+const version = '0.0.1';

--- a/src/backend/utils/add-feed.js
+++ b/src/backend/utils/add-feed.js
@@ -1,5 +1,34 @@
-require('../../config');
+require('../lib/config');
 
-const program = require('commander');
+const args = require('minimist')(process.argv.slice(2));
+const { logger } = require('./logger');
+const { isValidUrl } = require('./utils');
+const { addFeed } = require('../utils/storage');
+// const validator = require('validator');
 
-const version = '0.0.1';
+const log = logger.child({ module: 'add-feed' });
+
+async function add() {
+  console.log('ARGS', args);
+  if (
+    !Object.prototype.hasOwnProperty.call(args, 'name') ||
+    !Object.prototype.hasOwnProperty.call(args, 'url')
+  ) {
+    log.error('INVALID NUMBER OF ARGUMENTS');
+    process.exit(1);
+  }
+  const { name, url } = args;
+  if (!isValidUrl(url)) {
+    log.error('INVALID URL');
+    process.exit(1);
+  }
+  const cleanName = String(name);
+  if (cleanName.match(/[.*+?^${}()|[\]\\`]/)) {
+    log.error('ONLY ALPHANUMERICAL CHARACTERS ALLOWED');
+    process.exit(1);
+  }
+
+  addFeed(cleanName, url).catch(e => log.error(e));
+  log.info('feed added');
+}
+add();

--- a/src/backend/utils/add-feed.js
+++ b/src/backend/utils/add-feed.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 require('../lib/config');
 
 const args = require('minimist')(process.argv.slice(2));
@@ -12,7 +14,7 @@ async function add() {
     !Object.prototype.hasOwnProperty.call(args, 'name') ||
     !Object.prototype.hasOwnProperty.call(args, 'url')
   ) {
-    log.error('INVALID NUMBER OF ARGUMENTS');
+    log.error('Usage: add-feed --name <name of the blog author> --url <the feed of the url>');
     process.exit(1);
   }
   const { name, url } = args;
@@ -20,15 +22,9 @@ async function add() {
     log.error('INVALID URL');
     process.exit(1);
   }
-  const cleanName = String(name);
-  if (cleanName.match(/[.*+?^${}()|[\]\\`]/)) {
-    log.error('ONLY ALPHANUMERICAL CHARACTERS ALLOWED');
-    process.exit(1);
-  }
 
   const feed = { name, url };
 
-  log.info(`Enqueuing feed job for ${url}`);
   await feedQueue
     .add(feed, {
       attempts: process.env.FEED_QUEUE_ATTEMPTS || 8,
@@ -43,7 +39,6 @@ async function add() {
       log.error({ err }, 'Error enqueuing feed');
       process.exit(1);
     });
-  log.info('feed added');
   process.exit(0);
 }
 add();

--- a/tools/add-feed.js
+++ b/tools/add-feed.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-require('../lib/config');
+require('../src/backend/lib/config');
 
 const args = require('minimist')(process.argv.slice(2));
-const { logger } = require('./logger');
-const { isValidUrl } = require('./utils');
-const feedQueue = require('../feed/queue');
+const { logger } = require('../src/backend/utils/logger');
+const { isValidUrl } = require('../src/backend/utils/utils');
+const feedQueue = require('../src/backend/feed/queue');
 
 const log = logger.child({ module: 'add-feed' });
 


### PR DESCRIPTION
fix #273. This PR is unfinished but I wanted to create one for feedback before I commit more work into this. I have a working script with some bugs. I've manually tested the script by checking the bull board and confirming the feed job was queued.

To run the script, use ``` npm run add-feed -- --name "bloggers name" --url <feed url> ```. This will make use of the feedQueue.add under ``` src/backend/feed/queue ``` to add a feed to the queue for processing. 

I wanted to make this as an npm script so I changed package.json but if the script is executed using npm, the appropriate error messages seem to be suppressed and it gives a vague npm error message instead. When run as ``` node add-feed.js ..etc ``` the proper error and info messages are displayed. 