### PR TITLE
Fixes #386 - Added specific environment instructions in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -87,11 +87,13 @@ This guide is sourced from the official [Docker-CE](https://docs.docker.com/inst
 
 **Install Docker Engine - Community Edition**
 
-1. Update the apt package index: `sudo apt-get update`
+_IMPORTANT: If you are not a superuser, then type `sudo` before each of the following commands_
+
+1. Update the apt package index: `apt-get update`
 2. Install packages to allow apt to use a repository over HTTPS:
 
 ```
-sudo apt-get install \
+apt-get install \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -100,30 +102,30 @@ sudo apt-get install \
 ```
 
 3. Add Docker’s official GPG key: `curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -`
-4. Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint: `sudo apt-key fingerprint 0EBFCD88`
+4. Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint: `apt-key fingerprint 0EBFCD88`
 5. Use the following command to set up the stable repository:
 
 ```
-sudo add-apt-repository \
+add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
 ```
 
-6. Update the apt package index again: `sudo apt-get update`
-7. Install the latest version of Docker Engine community: `sudo apt-get install docker-ce docker-ce-cli containerd.io`
-8. Verify your installation by running `sudo docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
-9. If you want to add yourself to the Docker group (and not be required to enter `sudo` before every docker command), then follow these steps ([source](https://docs.docker.com/install/linux/linux-postinstall/)):
-    1. Create the Docker group: `sudo groupadd docker`
-    1. Add your user to the group: `sudo usermod -aG docker $USER`
+6. Update the apt package index again: `apt-get update`
+7. Install the latest version of Docker Engine community: `apt-get install docker-ce docker-ce-cli containerd.io`
+8. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
+9. If you want to add yourself to the Docker group then follow these steps ([source](https://docs.docker.com/install/linux/linux-postinstall/)):
+    1. Create the Docker group: `groupadd docker`
+    1. Add your user to the group: `usermod -aG docker $USER`
     1. Log out and log back in (you may have to restart if you are running through a virtual machine)
-    1. Verify if you can run docker without `sudo`: `docker run hello-world`
+    1. Verify if you can still run docker: `docker run hello-world`
 _NOTE: This may cause errors if you have already run docker before, if so then run the following commands to reset it:_
 ```
 sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
 sudo chmod g+rwx "$HOME/.docker" -R
 ```
-10. If you would like to run docker as a service on your machine:
+10. Now run docker as a service on your machine, on startup:
     1. Enable docker on startup: `sudo systemctl enable docker`
     1. Disable docker on startup: `sudo systemctl disable docker`
 **Install Docker-Compose**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,10 +51,12 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 #### Linux (Ubuntu)
 
-**This guide is sourced from the official [Docker Community Edition](https://docs.docker.com/install/linux/docker-ce/ubuntu/) Installation Documentation.**
+**This guide is sourced from the official [Docker-CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [docker-compose](https://docs.docker.com/compose/install/) Installation Documentation.**
+
+**Install Docker Engine - Community Edition**
 
 1. Update the apt package index: `sudo apt-get update`
-1. Install packages to allow apt to use a repository over HTTPS:
+2. Install packages to allow apt to use a repository over HTTPS:
 
 ```
 sudo apt-get install \
@@ -79,11 +81,24 @@ sudo add-apt-repository \
 6. Update the apt package index again: `sudo apt-get update`
 7. Install the latest version of Docker Engine community: `sudo apt-get install docker-ce docker-ce-cli containerd.io`
 8. Verify your installation by running `sudo docker run hello-world`. This should print a hello world paragraph that includes a confirmation that docker is working on your system.
-   _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach listed above under WSL._
+
+**Install docker-compose**
+
+9. Run to download the current stable version of docker-compose:
+
+```
+sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+```
+
+10. Apply executable permissions to the downloaded file: `sudo chmod +x /usr/local/bin/docker-compose`
+11. Check installation using: `docker-compose --version`
+
+_NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach listed above under WSL._
+
 ### SAML Setup
 - Run `bash ./generate_ssl_certs.sh` in terminal
 
-### Setup
+### Setup Telescope
 
 1. Navigate to the root directory of telescope.
 1. Copy env.example to .env to create a new environment configuration.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,6 +70,7 @@ We are using [Chocolatey package manager](https://chocolatey.org/) to install Re
 
 Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using the following methods:
 
+- Get [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) instead of Docker Desktop for Windows. Make sure that your system can do virtualization and enable virtualization.
 - Set up a virtual machine to run Linux Ubuntu
   1. [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
   1. [Follow this helpful youtube tutorial to create a virtual machine with Ubuntu](https://www.youtube.com/watch?v=ThsxqznrgCw&t=401s)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,11 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 ### Docker and docker-compose Set Up
 
+<<<<<<< HEAD
 #### Windows 10 (Professional, Enterprise, and Education Editions only
+=======
+#### Windows 10 Pro, Enterprise, or Education
+>>>>>>> Fixed links broken by husky
 
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.
@@ -43,13 +47,13 @@ Docker Desktop for Windows is not available on Home Edition, and you cannot run 
 - Set up a virtual machine to run Linux Ubuntu
   1. [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
   1. [Follow this helpful youtube tutorial to create a virtual machine with Ubuntu](https://www.youtube.com/watch?v=ThsxqznrgCw&t=401s)
-  1. Use the Linux installation instructions [below](<#linux-(Ubuntu)>).
+  1. Use the Linux installation instructions [below](#linux-Ubuntu).
 - Use Windows 10 Education Edition
   1. Download Windows 10 Education Edition from the [Seneca Software Center](https://senecacollege.onthehub.com/WebStore/OfferingDetails.aspx?o=c0bd2c36-a530-e511-940e-b8ca3a5db7a1)
   1. Update your OS using the installation instructions.
-  1. Use [Windows 10 Education Edition](<#windows-10-(professional,-Enterprise,-and-Education-Editions-only)>) set up instructions.
+  1. Use [Windows 10 Education Edition](#Windows-10-Pro,-Enterprise,-or-Education) set up instructions.
 
-#### Linux (Ubuntu)
+#### Linux-Ubuntu
 
 This guide is sourced from the official [Docker-CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [docker-compose](https://docs.docker.com/compose/install/) Installation Documentation.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,32 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 ### Prerequisites:
 
 - [Node.js (npm)](https://nodejs.org/en/download/)
-- [Docker and docker compose](#docker-and-docker-compose-set-up)
+- Redis (2 methods)
+  - Use [Docker and docker-compose](#docker-and-docker-compose-set-up)
+  - Install as a [native application](#using-redis-as-a-native-application)
+
+### Using Redis as a native application
+
+#### Linux:
+
+- Install Redis using your distribution's package manager, for example:
+- Ubuntu based: `sudo apt install redis`
+- Red Hat, Fedora: `sudo dnf install redis`
+
+_Once Redis is installed, you can start it in a terminal by running:_
+
+```
+redis-server
+```
+
+#### Windows:
+
+We are using chocolatey package manager to install Redis on Windows. To get chocolatey, simply follow this [guide](https://chocolatey.org/install) and run the following commands:
+
+1. To install redis: `choco install redis-64 -v`
+1. To set redis as a windows service: `redis-server --service-install`
+1. To start redis: `redis-server --service-start`
+1. To check if running and display server information: `redis-cli info`
 
 ### Docker and docker-compose Set Up
 
@@ -34,6 +59,7 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.
+1.
 
 #### MacOS (Sierra 10.12 or above)
 
@@ -107,14 +133,21 @@ _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach
 1. Navigate to the root directory of telescope.
 1. Copy env.example to .env to create a new environment configuration.
 1. Replace default key values in .env with credentials.
-1. Start the docker container for Redis using `docker-compose up -d redis`
-   - To stop the docker container for Redis, run `docker-compose stop redis`
+1. Start Redis using:
+
+   - Docker: `docker-compose up -d redis`
+
+   _To stop the docker container for Redis, run:_ `docker-compose stop redis`
+
+   - Native Install: `redis-service`
+
+   _To stop Redis, ctrl+c the window running the redis server._
+
 1. Run `npm install`.
 1. Run `npm test`
 1. IF eslint detect some issues run `npm run eslint-fix` before manually fixing the issue (Will save you time :smile:) and then run `npm test` again.
 1. Run `npm run jest-watch` to watch files for any changes and rerun tests related to changed files.
 1. Run `npm start` to start telescope.
-   _If you get a series of errors, you may have to start redis-server depending on your installation configuration, do this by running the command `redis-server` in a seperate command window)._
 
 ## Workflow in git and GitHub
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,11 +52,7 @@ We are using [Chocolatey package manager](https://chocolatey.org/) to install Re
 
 ### Docker and Docker-Compose Set Up
 
-<<<<<<< HEAD
-#### Windows 10 (Professional, Enterprise, and Education Editions only
-=======
 #### Windows 10 Pro, Enterprise, or Education
->>>>>>> Fixed links broken by husky
 
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 #### Windows 10 Home Edition and Windows Subsystem for Linux (WSL)
 
-**Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using the following methods:**
+Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using the following methods:
 
 - Set up a virtual machine to run Linux Ubuntu
   1. [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
@@ -51,7 +51,7 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 #### Linux (Ubuntu)
 
-**This guide is sourced from the official [Docker-CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [docker-compose](https://docs.docker.com/compose/install/) Installation Documentation.**
+This guide is sourced from the official [Docker-CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [docker-compose](https://docs.docker.com/compose/install/) Installation Documentation.
 
 **Install Docker Engine - Community Edition**
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -68,14 +68,15 @@ We are using [Chocolatey package manager](https://chocolatey.org/) to install Re
 
 #### Windows 10 Home Edition and Windows Subsystem for Linux (WSL)
 
-Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using the following methods:
+Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using **one** of these three methods:
 
 - Get [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) instead of Docker Desktop for Windows. Make sure that your system can do virtualization and enable virtualization.
 - Set up a virtual machine to run Linux Ubuntu
+  1. Make sure your system can do virtualization and enable it.
   1. [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
   1. [Follow this helpful youtube tutorial to create a virtual machine with Ubuntu](https://www.youtube.com/watch?v=ThsxqznrgCw&t=401s)
   1. Use the Linux installation instructions [below](#linux-Ubuntu).
-- Use Windows 10 Education Edition
+- Update your home edition to Windows 10 Education Edition
   1. Download Windows 10 Education Edition from the [Seneca Software Center](https://senecacollege.onthehub.com/WebStore/OfferingDetails.aspx?o=c0bd2c36-a530-e511-940e-b8ca3a5db7a1)
   1. Update your OS using the installation instructions.
   1. Use [Windows 10 Education Edition](#Windows-10-Pro,-Enterprise,-or-Education) set up instructions.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -87,13 +87,11 @@ This guide is sourced from the official [Docker-CE](https://docs.docker.com/inst
 
 **Install Docker Engine - Community Edition**
 
-_IMPORTANT: If you are not a superuser, then type `sudo` before each of the following commands_
-
-1. Update the apt package index: `apt-get update`
+1. Update the apt package index: `sudo apt-get update`
 2. Install packages to allow apt to use a repository over HTTPS:
 
 ```
-apt-get install \
+sudo apt-get install \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -102,25 +100,24 @@ apt-get install \
 ```
 
 3. Add Docker’s official GPG key: `curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -`
-4. Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint: `apt-key fingerprint 0EBFCD88`
+4. Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint: `sudo apt-key fingerprint 0EBFCD88`
 5. Use the following command to set up the stable repository:
 
 ```
-add-apt-repository \
+sudo add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
 ```
 
-6. Update the apt package index again: `apt-get update`
-7. Install the latest version of Docker Engine community: `apt-get install docker-ce docker-ce-cli containerd.io`
-8. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
-9. If you want to add yourself to the Docker group then follow these steps ([source](https://docs.docker.com/install/linux/linux-postinstall/)):
+6. Update the apt package index again: `sudo apt-get update`
+7. Install the latest version of Docker Engine community: `sudo apt-get install docker-ce docker-ce-cli containerd.io`
+8. Add yourself to the Docker group ([source](https://docs.docker.com/install/linux/linux-postinstall/)):
     1. Create the Docker group: `groupadd docker`
-    1. Add your user to the group: `usermod -aG docker $USER`
+    1. Add your user to the group: `sudo usermod -aG docker $USER`
     1. Log out and log back in (you may have to restart if you are running through a virtual machine)
-    1. Verify if you can still run docker: `docker run hello-world`
-_NOTE: This may cause errors if you have already run docker before, if so then run the following commands to reset it:_
+9. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
+_NOTE: This may cause errors if you have already tried to run docker before. If you get errors then run the following commands to reset it:_
 ```
 sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
 sudo chmod g+rwx "$HOME/.docker" -R

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 ### Prerequisites:
 
 - [Node.js (npm)](https://nodejs.org/en/download/)
-- Redis (2 methods)
+- [Redis](https://redis.io/) (2 methods)
   - Use [Docker and docker-compose](#docker-and-docker-compose-set-up)
   - Install as a [native application](#using-redis-as-a-native-application)
 
@@ -30,7 +30,8 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 #### Linux:
 
-- Install Redis using your distribution's package manager, for example:
+Install Redis using your distribution's package manager, for example:
+
 - Ubuntu based: `sudo apt install redis`
 - Red Hat, Fedora: `sudo dnf install redis`
 
@@ -42,14 +43,14 @@ redis-server
 
 #### Windows:
 
-We are using chocolatey package manager to install Redis on Windows. To get chocolatey, simply follow this [guide](https://chocolatey.org/install) and run the following commands:
+We are using [Chocolatey package manager](https://chocolatey.org/) to install Redis on Windows. To get Chocolatey, simply follow this [guide](https://chocolatey.org/install) and run the following commands:
 
-1. To install redis: `choco install redis-64 -v`
-1. To set redis as a windows service: `redis-server --service-install`
-1. To start redis: `redis-server --service-start`
+1. To install Redis: `choco install redis-64 -v`
+1. To set Redis as a windows service: `redis-server --service-install`
+1. To start Redis: `redis-server --service-start`
 1. To check if running and display server information: `redis-cli info`
 
-### Docker and docker-compose Set Up
+### Docker and Docker-Compose Set Up
 
 <<<<<<< HEAD
 #### Windows 10 (Professional, Enterprise, and Education Editions only
@@ -59,7 +60,6 @@ We are using chocolatey package manager to install Redis on Windows. To get choc
 
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.
-1.
 
 #### MacOS (Sierra 10.12 or above)
 
@@ -81,7 +81,7 @@ Docker Desktop for Windows is not available on Home Edition, and you cannot run 
 
 #### Linux-Ubuntu
 
-This guide is sourced from the official [Docker-CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [docker-compose](https://docs.docker.com/compose/install/) Installation Documentation.
+This guide is sourced from the official [Docker-CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/) and [Docker-Compose](https://docs.docker.com/compose/install/) Installation Documentation.
 
 **Install Docker Engine - Community Edition**
 
@@ -110,11 +110,11 @@ sudo add-apt-repository \
 
 6. Update the apt package index again: `sudo apt-get update`
 7. Install the latest version of Docker Engine community: `sudo apt-get install docker-ce docker-ce-cli containerd.io`
-8. Verify your installation by running `sudo docker run hello-world`. This should print a hello world paragraph that includes a confirmation that docker is working on your system.
+8. Verify your installation by running `sudo docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
 
-**Install docker-compose**
+**Install Docker-Compose**
 
-9. Run to download the current stable version of docker-compose:
+9. Run to download the current stable version of Docker-Compose:
 
 ```
 sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -137,7 +137,7 @@ _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach
 
    - Docker: `docker-compose up -d redis`
 
-   _To stop the docker container for Redis, run:_ `docker-compose stop redis`
+   _To stop the Docker container for Redis, run:_ `docker-compose stop redis`
 
    - Native Install: `redis-service`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,24 +19,71 @@ Please submit pull requests in response to open issues. If you have a bug or fea
 
 ## Environment Setup
 
-**Prerequisites:**
+### Prerequisites:
 
 - [Node.js (npm)](https://nodejs.org/en/download/)
-- [Redis](https://redis.io/download)
+- [Docker and docker compose](#docker-and-docker-compose-set-up)
 
-**Redis Set Up**
-Some helpful guides:
+### Docker and docker-compose Set Up
 
-- [Redis for Linux](https://redis.io/download#installation) (recommended but not required)
-- [Redis for Windows Subsystem for Linux](https://anggo.ro/note/installing-redis-in-ubuntu-wsl/) (not recommended by Redis)
-- Redis for Windows - You can use [this](https://github.com/tporadowski/redis/releases) installer to get up and running quickly for now.
-- Redis for MacOS - need instructions
-  An easier solution would be to use Docker.
+#### Windows 10 (Professional, Enterprise, and Education Editions only
 
-**SAML Setup**
+1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
+1. Docker for Desktop comes with docker-compose installed.
+
+#### MacOS (Sierra 10.12 or above)
+
+1. Get [Docker for Desktop For Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
+1. Docker for Desktop comes with docker-compose installed.
+
+#### Windows 10 Home Edition and Windows Subsystem for Linux (WSL)
+
+**Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using the following methods:**
+
+- Set up a virtual machine to run Linux Ubuntu
+  1. [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+  1. [Follow this helpful youtube tutorial to create a virtual machine with Ubuntu](https://www.youtube.com/watch?v=ThsxqznrgCw&t=401s)
+  1. Use the Linux installation instructions [below](<#linux-(Ubuntu)>).
+- Use Windows 10 Education Edition
+  1. Download Windows 10 Education Edition from the [Seneca Software Center](https://senecacollege.onthehub.com/WebStore/OfferingDetails.aspx?o=c0bd2c36-a530-e511-940e-b8ca3a5db7a1)
+  1. Update your OS using the installation instructions.
+  1. Use [Windows 10 Education Edition](<#windows-10-(professional,-Enterprise,-and-Education-Editions-only)>) set up instructions.
+
+#### Linux (Ubuntu)
+
+**This guide is sourced from the official [Docker Community Edition](https://docs.docker.com/install/linux/docker-ce/ubuntu/) Installation Documentation.**
+
+1. Update the apt package index: `sudo apt-get update`
+1. Install packages to allow apt to use a repository over HTTPS:
+
+```
+sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+```
+
+3. Add Docker’s official GPG key: `curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -`
+4. Verify that you now have the key with the fingerprint 9DC8 5822 9FC7 DD38 854A E2D8 8D81 803C 0EBF CD88, by searching for the last 8 characters of the fingerprint: `sudo apt-key fingerprint 0EBFCD88`
+5. Use the following command to set up the stable repository:
+
+```
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+```
+
+6. Update the apt package index again: `sudo apt-get update`
+7. Install the latest version of Docker Engine community: `sudo apt-get install docker-ce docker-ce-cli containerd.io`
+8. Verify your installation by running `sudo docker run hello-world`. This should print a hello world paragraph that includes a confirmation that docker is working on your system.
+   _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach listed above under WSL._
+### SAML Setup
 - Run `bash ./generate_ssl_certs.sh` in terminal
 
-**Setup**
+### Setup
 
 1. Navigate to the root directory of telescope.
 1. Copy env.example to .env to create a new environment configuration.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,17 +113,29 @@ sudo add-apt-repository \
 6. Update the apt package index again: `sudo apt-get update`
 7. Install the latest version of Docker Engine community: `sudo apt-get install docker-ce docker-ce-cli containerd.io`
 8. Verify your installation by running `sudo docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
-
+9. If you want to add yourself to the Docker group (and not be required to enter `sudo` before every docker command), then follow these steps ([source](https://docs.docker.com/install/linux/linux-postinstall/)):
+    1. Create the Docker group: `sudo groupadd docker`
+    1. Add your user to the group: `sudo usermod -aG docker $USER`
+    1. Log out and log back in (you may have to restart if you are running through a virtual machine)
+    1. Verify if you can run docker without `sudo`: `docker run hello-world`
+_NOTE: This may cause errors if you have already run docker before, if so then run the following commands to reset it:_
+```
+sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
+sudo chmod g+rwx "$HOME/.docker" -R
+```
+10. If you would like to run docker as a service on your machine:
+    1. Enable docker on startup: `sudo systemctl enable docker`
+    1. Disable docker on startup: `sudo systemctl disable docker`
 **Install Docker-Compose**
 
-9. Run to download the current stable version of Docker-Compose:
+11. Run to download the current stable version of Docker-Compose:
 
 ```
 sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 ```
 
-10. Apply executable permissions to the downloaded file: `sudo chmod +x /usr/local/bin/docker-compose`
-11. Check installation using: `docker-compose --version`
+12. Apply executable permissions to the downloaded file: `sudo chmod +x /usr/local/bin/docker-compose`
+13. Check installation using: `docker-compose --version`
 
 _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach listed above under WSL._
 


### PR DESCRIPTION
Addressing #386 , this pull request updates the CONTRIBUTING.md to include docker and docker-compose instructions. It also includes updated instructions on installing Redis. 

There are variables in the docker-compose file that use the .env file to create the environment, and I am unsure of how to replicate it in the native application instructions. In my mind, we should remove the native set up entirely, and focus on using docker.

Another aspect of this pull request is the .env file. Specifically how to fill out the credentials inside of it. I am working on this aspect but I thought I would put up a pull request and get some feedback before I continue. 
UPDATE: I have talked to some people and understood the .env file better, I will update the environment set up in a new pull request, as it is more complex than I initially thought.