### PR TITLE
Fixes 335: Remove duplicity caused by using both async and Promise in a function 

### DIFF
--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -22,6 +22,7 @@ exports.workerCallback = async function(job) {
       });
       // We can pass these objects into another queue, For now just printing to the console.
       console.log(processedPosts);
+      return processedPosts;
     }
   } catch (err) {
     throw Error('The error here is ' + err);

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -25,7 +25,7 @@ exports.workerCallback = async function(job) {
       return processedPosts;
     }
   } catch (err) {
-    throw Error('The error here is ' + err);
+    console.log(err);
   }
 };
 

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -20,11 +20,11 @@ exports.workerCallback = async function(job) {
         processedPosts.push(processedPost);
         extractUrls.extract(post.description);
       });
-      return Promise.resolve(processedPosts);
+      // We can pass these objects into another queue, For now just printing to the console.
+      console.log(processedPosts);
     }
-    return Promise.reject(new Error(`Failed to extract posts from url: ${url}`));
   } catch (err) {
-    return Promise.reject(err);
+    throw Error('The error here is ' + err);
   }
 };
 


### PR DESCRIPTION
@humphd 
Sorry for the delay for this fix
As you suggested, I got rid of the additional promises and simplified the try catch block to just throw the error generated, rather than using Promise.reject()... since await function implicitly does that
