### PR TITLE
Fixes #314: Client-side changes for server sent events

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -298,5 +298,7 @@
       src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit2"
     ></script>
     <script src="./dialogue.js"></script>
+    <!-- Server Sent Events Script -->
+    <script src="./server-sent-events.js"></script>
   </body>
 </html>

--- a/src/frontend/server-sent-events.js
+++ b/src/frontend/server-sent-events.js
@@ -1,5 +1,5 @@
 // Connect to server to recieve stream of updates
-const source = new EventSource('/stream');
+const source = new EventSource('/feed-updates');
 
 source.onopen = () => {
   console.log('Connection to server opened.');

--- a/src/frontend/server-sent-events.js
+++ b/src/frontend/server-sent-events.js
@@ -1,0 +1,13 @@
+// Connect to server to recieve stream of updates
+const source = new EventSource('/stream');
+
+source.onopen = () => {
+  console.log('Connection to server opened.');
+};
+source.onmessage = stream => {
+  console.log('Received stream, update data.', stream.data);
+};
+source.onerror = error => {
+  console.log('An error has occurred while receiving stream.', error);
+  source.close();
+};


### PR DESCRIPTION
Fixes issue #314. 

This PR addresses the client-side changes for server sent events.  Changes were made to allow listening to the stream endpoint using EventSource. Receives data whenever a job is completed in the queue.

Server-side PR for this fix can be found in #409