### PR TITLE
Fixes #264: Store Posts into Redis

### DIFF
--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -1,19 +1,48 @@
-const feedparser = require('./parser');
 const feedQueue = require('./queue');
+const feedParser = require('./parser');
+const extractUrls = require('../utils/extract-urls');
+const storage = require('../utils/storage');
+// const logger = require('./../utils/logger');
 
 exports.workerCallback = async function(job) {
   const { url } = job.data;
-  const posts = await feedparser(url);
-  return posts.map(post => ({
-    author: post.author,
-    date: post.date,
-    title: post.title,
-    description: post.description,
-    postURL: post.link,
-  }));
+  try {
+    const posts = await feedParser(url);
+    const processedPosts = [];
+    if (posts.length > 0) {
+      posts.forEach(post => {
+        // We can extract any other information from the post that we need here.
+        const processedPost = {
+          author: post.author,
+          date: post.date,
+          title: post.title,
+          description: post.description,
+          postURL: post.link,
+        };
+        processedPosts.push(processedPost);
+        extractUrls.extract(post.description);
+      });
+      return processedPosts;
+    }
+    return processedPosts;
+    // return processedPosts;
+  } catch (err) {
+    return err;
+  }
 };
 
+// eslint-disable-next-line prettier/prettier
 exports.start = function() {
   // Start processing jobs from the feed queue...
-  feedQueue.process(this.workerCallback);
+  feedQueue.process(exports.workerCallback);
+  feedQueue.on('completed', (job, results) => {
+    if (results.length > 0) {
+      results.forEach(result => {
+        console.log(`Result: ${result.title}`);
+        // We have an issure here, addPost is an async function. Should we make the start
+        // function an async one too..?
+        storage.addPost(result);
+      });
+    }
+  });
 };

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -31,18 +31,12 @@ exports.workerCallback = async function(job) {
   }
 };
 
-// eslint-disable-next-line prettier/prettier
-exports.start = function() {
+exports.start = async function() {
   // Start processing jobs from the feed queue...
   feedQueue.process(exports.workerCallback);
   feedQueue.on('completed', (job, results) => {
     if (results.length > 0) {
-      results.forEach(result => {
-        console.log(`Result: ${result.title}`);
-        // We have an issure here, addPost is an async function. Should we make the start
-        // function an async one too..?
-        storage.addPost(result);
-      });
+      Promise.all(async result => storage.addPost(result));
     }
   });
 };


### PR DESCRIPTION
This PR is still a WIP and builds on top of the work done for storage.js. 
1. It will process feeds in the workerCallback function using `feedParser`
2. Grab the relevant data from the post as defined by `const processedPost`

On completion of the processing, it should then store each individual post(result) into Redis by using `storage.addPost()`. There's something we may have to look at though as storage.addPost is an async function. Should we make the exports.start function an async function so we can use await?