### PR TITLE
Addresses #406: specify node engine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
     "stylelint-config-prettier": "7.0.0",
     "stylelint-prettier": "1.1.1",
     "supertest": "4.0.2"
+  },
+  "engines": {
+    "node": ">=10.0.0"
   }
 }


### PR DESCRIPTION
Addresses #406 by updating `package.json` to specify that Telescope developers must use node version 10.0.0 or later.

As suggested by https://github.com/Seneca-CDOT/telescope/issues/406#issuecomment-560959353, this pull request alone may not fully resolve that issue.