### PR TITLE
Fixed #283 added lighthouse testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ yarn-error.log*
 *.obj
 *.o
 
+lighthouse-report.html
+
 # web-hint report
 hint-report/
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "start": "node src/backend",
     "server": "node src/backend/web/server",
     "hint": "hint http://localhost:3000",
-    "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint"
+    "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint",
+    "lighthouse-index": "lighthouse http://localhost:3000 --output-path=./lighthouse-report.html --view",
+    "lighthouse": "cross-env PORT=3000 npm-run-all -r -p server lighthouse-index"
   },
   "husky": {
     "hooks": {
@@ -81,6 +83,7 @@
     "husky": "3.1.0",
     "jest": "24.9.0",
     "jest-fetch-mock": "2.1.2",
+    "lighthouse": "5.6.0",
     "nock": "11.7.0",
     "npm-run-all": "4.1.5",
     "prettier": "1.19.1",


### PR DESCRIPTION
This pull request is to address #283. After a discussion with @humphd the decision was to use lighthouse. I have added two npm scripts, lighthouse-index, and lighthouse-login, to allow testing of the front-end. The results are presented in an HTML file and are displayed after executing the commands. Also added the extension to .gitignore to ensure the report results are not pushed.