### PR TITLE
Closes #262: Add routes for getting posts and a post

### DIFF
--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -57,11 +57,18 @@ module.exports = {
       .exec();
   },
 
-  getPosts: (startDate, endDate) =>
-    // Get all posts between start and end dates in the sorted set
-    redis.zrangebyscore(POSTS, startDate.getTime(), endDate.getTime()),
+  getPosts: () =>
+    // Get all posts
+    redis.zrange(POSTS, 0, -1),
 
   getPostsCount: () => redis.zcard(POSTS),
 
-  getPost: guid => redis.hgetall(guid),
+  getPost: async guid => {
+    const post = await redis.hgetall(guid);
+
+    if (Object.keys(post).length !== 0) post.guid = guid;
+    else return null;
+
+    return post;
+  },
 };

--- a/src/backend/web/routes/index.js
+++ b/src/backend/web/routes/index.js
@@ -2,6 +2,8 @@ const express = require('express');
 const path = require('path');
 const admin = require('./admin');
 const opml = require('./opml');
+const post = require('./post');
+const posts = require('./posts');
 
 const router = express.Router();
 
@@ -9,5 +11,7 @@ router.use(express.static(path.join(__dirname, '../../../frontend')));
 
 router.use('/admin', admin);
 router.use('/opml', opml);
+router.use('/post', post);
+router.use('/posts', posts);
 
 module.exports = router;

--- a/src/backend/web/routes/post.js
+++ b/src/backend/web/routes/post.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { getPost } = require('../../utils/storage');
+
+const post = express.Router();
+
+post.get('/:id', async (req, res) => {
+  const redisPost = await getPost(req.params.id);
+
+  res.json(redisPost);
+});
+
+module.exports = post;

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -4,12 +4,9 @@ const { getPost, getPosts } = require('../../utils/storage');
 const posts = express.Router();
 
 posts.get('/', async (req, res) => {
-  const arrayOfPosts = [];
-
   const redisGuids = await getPosts();
 
-  redisGuids.forEach(guid => arrayOfPosts.push(getPost(guid)));
-  const processedPosts = await Promise.all(arrayOfPosts);
+  const processedPosts = await Promise.all(redisGuids.map(guid => getPost(guid)));
 
   const listOfPosts = processedPosts
     // Return id and url for a specific post

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const { getPost, getPosts } = require('../../utils/storage');
+
+const posts = express.Router();
+
+posts.get('/', async (req, res) => {
+  const arrayOfPosts = [];
+
+  const redisGuids = await getPosts();
+
+  redisGuids.forEach(guid => arrayOfPosts.push(getPost(guid)));
+  const processedPosts = await Promise.all(arrayOfPosts);
+
+  const telescopeURL = env === 'production' ? 'telescope.cdot.systems' : 'localhost';
+  const listOfPosts = processedPosts
+    // Return id and url for a specific post
+    .map(processed => {
+      return {
+        id: processed.guid,
+        url: `/post/:${processed.guid}`,
+      };
+    });
+
+  res.json(listOfPosts);
+});
+
+module.exports = posts;

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -11,7 +11,6 @@ posts.get('/', async (req, res) => {
   redisGuids.forEach(guid => arrayOfPosts.push(getPost(guid)));
   const processedPosts = await Promise.all(arrayOfPosts);
 
-  const telescopeURL = env === 'production' ? 'telescope.cdot.systems' : 'localhost';
   const listOfPosts = processedPosts
     // Return id and url for a specific post
     .map(processed => {


### PR DESCRIPTION
This PR only has the endpoints so it can be reviewed and merged easily so front-end contributors can have something to work with. Tests can be added later.

Endpoints added:

`GET /post/:id`
`id` is the identifier for a specific post
Returns:
```js
{
    'title':  '(String) the title of the blog post',
    'author': '(String) the author of the post',
    'content': '(String) the content of the post, what was originally named description run through our HTML sanitizer (#18)',
    'text': '(String) the content of the post after being run through our text parser (no HTML). We could make this a method, and only generate it on demand, or could store it on the Object.'
    'updated': '(Date) the date/time of the most recent update to the post'
    'published': '(Date) the date/time when the post was originally published'
    'url': '(String) the URL of the original post'
    'site': '(String) the URL of the site from which this was published (e.g., blog). This is available in meta.link'
    'guid': '(String) a unique ID for this post (e.g., use the guid property from the feed)'
}
```
The structure of the data returned was decided in #259.

`GET /posts`
Returns:
```js
[
    {
        'id': 'id of the post'
        'url': 'URL to get the post e.g. development: localhost3000/post/{id}',
    },
    {
        'id': 'id of the post'
        'url': 'URL to get the post e.g. production: telescope.cdot.systems:3000/post/{id}',
    }
...
]
```
`NODE_ENV` and `PORT` in `.env` are used for the URLs in the returned array.

### Update
At the moment, `/posts` returns all the stored posts. In the future, filters can be implemented to return sets posts using different types of ranges (date, number of posts...).