### PR TITLE
Fix #319: add script to generate ssl certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ hint-report/
 
 #Redis dump file
 dump.rdb
+
+# SAML certificates
+certs/*

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,6 +33,9 @@ Some helpful guides:
 - Redis for MacOS - need instructions
   An easier solution would be to use Docker.
 
+**SAML Setup**
+- Run `bash ./generate_ssl_certs.sh` in terminal
+
 **Setup**
 
 1. Navigate to the root directory of telescope.

--- a/generate_ssl_certs.sh
+++ b/generate_ssl_certs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir certs
+openssl req -x509 -newkey rsa:4096 -keyout certs/key.pem -out certs/cert.pem -nodes -days 900


### PR DESCRIPTION
Fixes issue #319 

This PR does the following:
- Add bash shell script to generate ssl certificates using openSSL
- Add instructions on how to do it in CONTRIBUTING.md.
- Add certs/ folder to .gitignore

Documentation update:
![image](https://user-images.githubusercontent.com/33646954/70031371-140f6200-1579-11ea-943a-852b8aaa9362.png)

Generating a a new certificate:
![image](https://user-images.githubusercontent.com/33646954/70031331-fb9f4780-1578-11ea-8fc5-1ad4410a707a.png)
