### PR TITLE
Added guid when storing a post

### DIFF
--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -34,6 +34,8 @@ module.exports = {
       .hmset(
         // using guid as keys as it is unique to posts
         post.guid,
+        'guid',
+        post.guid,
         'author',
         post.author,
         'title',


### PR DESCRIPTION
While making changes during class, adding `guid` when storing a post (in `storage.js`) didn't get merged with the rest of the code.
Here's a fix for that.