### PR TITLE
Fixes #428: Encode guids in URLs returned in posts JSON results #428

### DIFF
--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -21,7 +21,7 @@ posts.get('/', async (req, res) => {
       // Return id and url for a specific post
       .map(guid => ({
         id: guid,
-        url: `/post/:${guid}`,
+        url: `/post/${encodeURIComponent(guid)}`,
       }))
   );
 });


### PR DESCRIPTION
Added encoding the url passed to the front-end.

For testing
- run telescope: `npm start` (and redis)
- requests all the posts using a browser: `localhost:3000/posts`
It returns:
```js
[
  {
    id: 'http://wordpress.com'
    url: '/post/http://wordpress.com'
  }
...
]
```
- use `url` from the json returned in the previous step to request one post
  - 'localhost:3000/post/http://wordpress/com'

The expected result should be a [Post](https://github.com/Seneca-CDOT/telescope/blob/5b583c63f88d1fdf9b0aac077f744ad8ccddcb74/src/backend/post.js#L7) object

