### PR TITLE
Closes #432, #437: Limit number of posts returned by HTTP /posts route

### DIFF
--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -59,7 +59,7 @@ module.exports = {
       .exec();
   },
 
-  getPosts: (counter = 0) =>
+  getPosts: counter =>
     /**
      * 'counter' needs -1 because 'zrevrange()' includes the element at index 'counter'
      * in the array it returns

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -59,9 +59,12 @@ module.exports = {
       .exec();
   },
 
-  getPosts: () =>
-    // Get all posts
-    redis.zrevrange(POSTS, 0, -1),
+  getPosts: (counter = 0) =>
+    /**
+     * 'counter' needs -1 because 'zrevrange()' includes the element at index 'counter'
+     * in the array it returns
+     */
+    redis.zrevrange(POSTS, 0, counter - 1),
 
   getPostsCount: () => redis.zcard(POSTS),
 

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -61,7 +61,7 @@ module.exports = {
 
   getPosts: () =>
     // Get all posts
-    redis.zrange(POSTS, 0, -1),
+    redis.zrevrange(POSTS, 0, -1),
 
   getPostsCount: () => redis.zcard(POSTS),
 

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -6,9 +6,10 @@ const posts = express.Router();
 
 posts.get('/', async (req, res) => {
   let redisGuids;
-  const defaultNumberOfPosts = 10;
+  const defaultNumberOfPosts = 30;
   try {
-    redisGuids = await getPosts(req.query.counter ? req.query.counter : defaultNumberOfPosts);
+    req.query.per_page = req.query.per_page || defaultNumberOfPosts;
+    redisGuids = await getPosts(req.query.per_page > 100 ? 100 : req.query.per_page);
   } catch (err) {
     logger.error({ err }, 'Unable to get posts from Redis');
     res.status(503).json({

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -6,6 +6,7 @@ const posts = express.Router();
 
 posts.get('/', async (req, res) => {
   let redisGuids;
+  const defaultNumberOfPosts = 10;
   try {
     redisGuids = await getPosts(req.query.counter ? req.query.counter : defaultNumberOfPosts);
   } catch (err) {

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -7,7 +7,7 @@ const posts = express.Router();
 posts.get('/', async (req, res) => {
   let redisGuids;
   try {
-    redisGuids = await getPosts();
+    redisGuids = await getPosts(req.query.counter ? req.query.counter : defaultNumberOfPosts);
   } catch (err) {
     logger.error({ err }, 'Unable to get posts from Redis');
     res.status(503).json({

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -7,9 +7,12 @@ const posts = express.Router();
 posts.get('/', async (req, res) => {
   let redisGuids;
   const defaultNumberOfPosts = 30;
+  const capNumOfPosts = 100;
   try {
     req.query.per_page = req.query.per_page || defaultNumberOfPosts;
-    redisGuids = await getPosts(req.query.per_page > 100 ? 100 : req.query.per_page);
+    redisGuids = await getPosts(
+      req.query.per_page > capNumOfPosts ? capNumOfPosts : req.query.per_page
+    );
   } catch (err) {
     logger.error({ err }, 'Unable to get posts from Redis');
     res.status(503).json({

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -78,16 +78,16 @@ describe('Tests for storage', () => {
     expect(result.link).toEqual(post.link);
   });
 
-  it('get all posts returns corrent number of posts', async () => {
+  it('get all posts returns current number of posts', async () => {
     await storage.addPost(post2);
-    const result = await storage.getPosts(post2.published, post.published);
+    const result = await storage.getPosts(0, -1);
     expect(result.length).toEqual(2);
   });
 
   it('get all posts returns sorted posts by date', async () => {
-    const result = await storage.getPosts(post2.published, post.published);
-    expect(result[0]).toEqual(post2.guid);
-    expect(result[1]).toEqual(post.guid);
+    const result = await storage.getPosts(0, -1);
+    expect(result[0]).toEqual(post.guid);
+    expect(result[1]).toEqual(post2.guid);
   });
 
   it('check post count', async () => {


### PR DESCRIPTION
`GET /posts` now accepts a [query parameter](https://guides.emberjs.com/release/routing/query-params/) to request a specific number of posts, with a max of 100 posts.
If no parameter is passed, it'll returned 30 posts.

For testing:
 - Run telescope `npm start` (with redis)
- In a browser, go to:
  - `localhost:3000/posts`, the number of posts shown should be 30
  - `localhost:3000/posts?counter=50`,  the number of posts shown should be 50
  - `localhost:3000/posts?counter=200`,  the number of posts shown should be 100
