### PR TITLE
Improve error logging in worker

### DIFF
--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -7,24 +7,29 @@ const sanitizeHTML = require('../utils/sanitize-html');
 
 exports.workerCallback = async function(job) {
   const { url } = job.data;
-  const posts = await feedparser(url);
-  const processedPosts = await Promise.all(
-    posts.map(async post => {
-      // TODO: run this through text parser
-      const sanitizedHTML = await sanitizeHTML.run(post.description);
-      return new Post(
-        post.author,
-        post.title,
-        sanitizedHTML,
-        'textContent',
-        new Date(post.date),
-        new Date(post.pubDate),
-        post.link,
-        post.guid
-      );
-    })
-  );
-  return processedPosts;
+  try {
+    const posts = await feedparser(url);
+    return await Promise.all(
+      posts.map(async post => {
+        // TODO: run this through text parser
+        const sanitizedHTML = await sanitizeHTML.run(post.description);
+        return new Post(
+          post.author,
+          post.title,
+          sanitizedHTML,
+          'textContent',
+          new Date(post.date),
+          new Date(post.pubDate),
+          post.link,
+          post.guid
+        );
+      })
+    );
+  } catch (err) {
+    const message = `Unable to process feed ${url} for job ${job.id}`;
+    logger.error({ err }, message);
+    throw new Error(message);
+  }
 };
 
 exports.start = async function() {

--- a/src/backend/lib/queue.js
+++ b/src/backend/lib/queue.js
@@ -29,9 +29,9 @@ function createQueue(name) {
       }
     },
   })
-    .on('error', error => {
+    .on('error', err => {
       // An error occurred
-      log.error(`Queue ${name} error:`, error, ' Stack: ', error.stack);
+      log.error({ err }, `Queue ${name} error`);
     })
     .on('waiting', jobID => {
       // A job is waiting for the next idling worker


### PR DESCRIPTION
This improves our logging for errors while processing feeds in our queue.  Here's an example of what an error looks like now:

```
[ 2019-12-04 12:48:42.164 ] ERROR (43651 on brightness.local): Unable to process feed https:https://robertbegnatechblog.wordpress.com/category/open-source/feed for job 2060
    err: {
      "type": "Error",
      "message": "Invalid URI \"https:https://robertbegnatechblog.wordpress.com/category/open-source/feed\"",
      "stack":
          Error: Invalid URI "https:https://robertbegnatechblog.wordpress.com/category/open-source/feed"
              at Request.init (/Users/humphd/repos/telescope/node_modules/request/request.js:273:31)
              at new Request (/Users/humphd/repos/telescope/node_modules/request/request.js:127:8)
              at request (/Users/humphd/repos/telescope/node_modules/request/index.js:53:10)
              at Function.get (/Users/humphd/repos/telescope/node_modules/request/index.js:61:12)
              at /Users/humphd/repos/telescope/node_modules/feedparser-promised/lib/feedParserPromised.js:9:13
              at new Promise (<anonymous>)
              at parse (/Users/humphd/repos/telescope/node_modules/feedparser-promised/lib/feedParserPromised.js:8:10)
              at Queue.exports.workerCallback (/Users/humphd/repos/telescope/src/backend/feed/worker.js:11:25)
              at handlers.<computed> (/Users/humphd/repos/telescope/node_modules/bull/lib/queue.js:656:42)
              at Queue.processJob (/Users/humphd/repos/telescope/node_modules/bull/lib/queue.js:1050:22)
    }
[ 2019-12-04 12:48:42.165 ] ERROR (43651 on brightness.local): Job 2060 failed: {}
```

There's still some odd behaviour with the way that the `failed` event works, but I filed an issue upstream with Bull to see if they have ideas.