### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Create a report to help us improve Telescope
-labels: "type/bug"
+labels: "type: bug"
 ---
 
 <!-- Please use this template while reporting a bug and provide as much info as possible. Thanks!

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Create a report to help us improve Telescope
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+---
+name: Bug Report
+about: Report a bug encountered while using Telescope
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Thanks!
+-->
+
+
+**What happened**:
+
+**What should have happened**:
+
+**How to reproduce it (as precise as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- OS:

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,7 @@
 ---
 name: Bug Report
 about: Create a report to help us improve Telescope
-labels: type: enhancement
-
+labels: "type/bug"
 ---
 
 <!-- Please use this template while reporting a bug and provide as much info as possible. Thanks!

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,9 +1,7 @@
 ---
 name: Bug Report
 about: Create a report to help us improve Telescope
-title: ''
-labels: kind/bug
-assignees: ''
+labels: type: enhancement
 
 ---
 
@@ -21,3 +19,4 @@ assignees: ''
 
 **Environment**:
 - OS:
+- Browser: 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,15 +2,8 @@
 name: Bug Report
 about: Create a report to help us improve Telescope
 title: ''
-labels: ''
-assignees: ''
-
----
-
----
-name: Bug Report
-about: Report a bug encountered while using Telescope
 labels: kind/bug
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -2,17 +2,11 @@
 name: Enhancement
 about: Suggest an idea for Telescope
 title: ''
-labels: ''
+labels: kind/feature
 assignees: ''
 
 ---
 
----
-name: Enhancement Request
-about: Suggest an enhancement to Telescope
-labels: kind/feature
-
----
 <!-- Please only use this template for submitting enhancement requests -->
 
 **What would you like to be added**:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,10 +1,7 @@
 ---
 name: Enhancement
 about: Suggest an idea for Telescope
-title: ''
-labels: kind/feature
-assignees: ''
-
+labels: "type: enhancement"
 ---
 
 <!-- Please only use this template for submitting enhancement requests -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,20 @@
+---
+name: Enhancement
+about: Suggest an idea for Telescope
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+---
+name: Enhancement Request
+about: Suggest an enhancement to Telescope
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why would you like this to be added**:


### PR DESCRIPTION
In regards to issue #347, these are the issue templates for bug reports and enhancements. They are built with the default GitHub templates and the ones used by Kubernetes in mind.

These can likely be improved and iterated on further. If there are any other things to add that would be useful, please let me know.