### PR TITLE
Closes #431: Add tests for HTTP /posts route

### DIFF
--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -7,9 +7,9 @@ describe('test /posts endpoint', async () => {
   const requestedItems = 50;
   const maxItems = 100;
 
-  const posts = [...Array(150).keys()].map(index => {
+  const posts = [...Array(150).keys()].map(guid => {
     return {
-      guid: `${index}`,
+      guid: `${guid}`,
       author: 'foo',
       title: 'foo',
       link: 'foo',

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -27,7 +27,6 @@ describe('test /posts endpoint', async () => {
   });
 
   it('requests default number of items', async () => {
-    // Requests default number of items
     const res = await request(app).get('/posts');
 
     expect(res.status).toEqual(200);

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -26,22 +26,26 @@ describe('test /posts endpoint', async () => {
     Promise.all(posts.map(post => addPost(post)));
   });
 
-  it('testing returning default number of items: 30', async () => {
+  it('requests default number of items', async () => {
+    // Requests default number of items
     const res = await request(app).get('/posts');
+
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
     expect(res.body.length).toBe(defaultItems);
   });
 
-  it('testing returning requested number of items: 50', async () => {
+  it('requests a specific number of items', async () => {
     const res = await request(app).get('/posts?per_page=50');
+
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
     expect(res.body.length).toBe(requestedItems);
   });
 
-  it('testing returning max number of items: 100', async () => {
+  it('requests more items than the limit set by the server', async () => {
     const res = await request(app).get('/posts?per_page=150');
+
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
     expect(res.body.length).toBe(maxItems);

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -2,10 +2,10 @@ const request = require('supertest');
 const app = require('../src/backend/web/app');
 const { addPost } = require('../src/backend/utils/storage');
 
-describe('test fetching data for a valid user URL', async () => {
+describe('test /posts endpoint', async () => {
   const defaultItems = 30;
   const requestedItems = 50;
-  const cappedItems = 100;
+  const maxItems = 100;
 
   const posts = [...Array(150).keys()].map(index => {
     return {
@@ -26,31 +26,24 @@ describe('test fetching data for a valid user URL', async () => {
     Promise.all(posts.map(post => addPost(post)));
   });
 
-  /* const res1 = [...Array(150).keys()].reverse().map(index => {
-    return {
-      id: `${index}`,
-      url: `/post/${index}`,
-    };
-  }); */
-
-  it('testing returning default number of items', async () => {
+  it('testing returning default number of items: 30', async () => {
     const res = await request(app).get('/posts');
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
-    expect(res.body.length).toStrictEqual(defaultItems);
+    expect(res.body.length).toBe(defaultItems);
   });
 
-  it('testing returning requested number of items', async () => {
+  it('testing returning requested number of items: 50', async () => {
     const res = await request(app).get('/posts?per_page=50');
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
-    expect(res.body.length).toStrictEqual(requestedItems);
+    expect(res.body.length).toBe(requestedItems);
   });
 
-  it('testing returning max number of items', async () => {
+  it('testing returning max number of items: 100', async () => {
     const res = await request(app).get('/posts?per_page=150');
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
-    expect(res.body.length).toStrictEqual(cappedItems);
+    expect(res.body.length).toBe(maxItems);
   });
 });

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const app = require('../src/backend/web/app');
+const { addPost } = require('../src/backend/utils/storage');
+
+describe('test fetching data for a valid user URL', async () => {
+  const defaultItems = 30;
+  const requestedItems = 50;
+  const cappedItems = 100;
+
+  const posts = [...Array(150).keys()].map(index => {
+    return {
+      guid: `${index}`,
+      author: 'foo',
+      title: 'foo',
+      link: 'foo',
+      content: 'foo',
+      text: 'foo',
+      updated: new Date('2009-09-07T22:23:00.544Z'),
+      published: new Date('2009-09-07T22:20:00.000Z'),
+      url: 'foo',
+      site: 'foo',
+    };
+  });
+
+  beforeAll(() => {
+    Promise.all(posts.map(post => addPost(post)));
+  });
+
+  /* const res1 = [...Array(150).keys()].reverse().map(index => {
+    return {
+      id: `${index}`,
+      url: `/post/${index}`,
+    };
+  }); */
+
+  it('testing returning default number of items', async () => {
+    const res = await request(app).get('/posts');
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body.length).toStrictEqual(defaultItems);
+  });
+
+  it('testing returning requested number of items', async () => {
+    const res = await request(app).get('/posts?per_page=50');
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body.length).toStrictEqual(requestedItems);
+  });
+
+  it('testing returning max number of items', async () => {
+    const res = await request(app).get('/posts?per_page=150');
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body.length).toStrictEqual(cappedItems);
+  });
+});


### PR DESCRIPTION
Initial set of tests for `/posts` route.

It checks for:
-  `/posts` should return 30 items by default
- `/posts?per_page=15` should return 15 items
- `/posts?per_page=150` should return 100 items (100 is our max value)

This can be expanded in the future adding tests for paging and count.