### PR TITLE
Fix #352: switch away from DOMPurify/JSDOM to sanitize-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "bull": "3.12.1",
     "bull-board": "0.5.0",
-    "dompurify": "2.0.7",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-healthcheck": "0.1.0",
@@ -66,6 +65,7 @@
     "pino-pretty": "3.4.0",
     "puppeteer": "2.0.0",
     "reading-level": "0.0.7",
+    "sanitize-html": "1.20.1",
     "sentiment": "5.0.2",
     "spam-filter": "1.1.1",
     "valid-url": "1.0.9",

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -12,11 +12,10 @@ exports.workerCallback = async function(job) {
     return await Promise.all(
       posts.map(async post => {
         // TODO: run this through text parser
-        const sanitizedHTML = await sanitizeHTML.run(post.description);
         return new Post(
           post.author,
           post.title,
-          sanitizedHTML,
+          sanitizeHTML(post.description),
           'textContent',
           new Date(post.date),
           new Date(post.pubDate),

--- a/src/backend/utils/sanitize-html.js
+++ b/src/backend/utils/sanitize-html.js
@@ -1,11 +1,12 @@
-// Sanitize HTML and prevent XSS attacks using DOMPurify
-// eg. DOMPurify.sanitize('<img src=x onerror=alert(1)//>'); // becomes <img src="x">
+// Sanitize HTML and prevent XSS attacks
+// <img src=x onerror=alert(1)> becomes <img src="x">
 
-const createDOMPurify = require('dompurify');
-const { JSDOM } = require('jsdom');
+const sanitizeHtml = require('sanitize-html');
 
-module.exports.run = async function(text) {
-  const { window } = new JSDOM();
-  const DOMPurify = createDOMPurify(window);
-  return Promise.resolve(DOMPurify.sanitize(text));
+module.exports = function(dirty) {
+  return sanitizeHtml(dirty, {
+    // Add <img> to the list of allowed tags, see:
+    // https://github.com/apostrophecms/sanitize-html#what-are-the-default-options
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+  });
 };

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -1,8 +1,8 @@
-// Test for sanitize html
-
 const sanitizeHTML = require('../src/backend/utils/sanitize-html');
 
-test('Tests for sanitized HTML', async () => {
-  const data = await sanitizeHTML.run('<img onerror="alert(1)">');
-  expect(data).toBe('<img>');
+describe('Sanitize HTML', () => {
+  test('<img> should work, but inline js should not', () => {
+    const data = sanitizeHTML('<img src="x" onerror="alert(1)" onload="alert(1)" />');
+    expect(data).toBe('<img src="x" />');
+  });
 });


### PR DESCRIPTION
This fixes #352, moving away from DOMPurify and JSDOM, and using [sanitize-html and htmlparser2](https://github.com/apostrophecms/sanitize-html).  This fixes a number of test failures we're seeing.

As we start using the server more, we can tweak the settings for what gets cleaned/ignored by the sanitizer.  For now, by default it allows the following:

```js
allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
  'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
  'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe' ],
allowedAttributes: {
  a: [ 'href', 'name', 'target' ],
  // We don't currently allow img itself by default, but this
  // would make sense if we did. You could add srcset here,
  // and if you do the URL is checked for safety
  img: [ 'src' ]
},
// Lots of these won't come up by default because we don't allow them
selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
// URL schemes we permit
allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
allowedSchemesByTag: {},
allowedSchemesAppliedToAttributes: [ 'href', 'src', 'cite' ],
allowProtocolRelative: true
```