### PR TITLE
Fix #469: change feed worker tests to use nock

### DIFF
--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -101,3 +101,7 @@ exports.nockValidHtmlResponse = function() {
 exports.nock404Response = function() {
   nockResponse(getHtmlUri(), 'Not Found', 404, 'text/html');
 };
+
+exports.createMockJobObjectFromURL = function(feedURL) {
+  return { data: { url: feedURL } };
+};


### PR DESCRIPTION
Change tests in `feed-worker.test.js` to use mocked up responses from `fixtures.js` instead of going out to web to get real responses, similar to how tests are being done in  `feed-parser.test.js`.

referencing issue #469