### PR TITLE
Add test-ci script to also check prettier on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,4 +16,4 @@ jobs:
           command: npm install
       - run:
           name: Execute tests
-          command: npm test
+          command: npm run test-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_install:
       redis-server --service-start
       redis-cli info
     fi
+script:
+  - npm run test-ci
 matrix:
   allow_failures:
     # Windows can fail if choco can't download redis

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "npm run eslint",
     "postlint": "npm run stylelint",
     "prettier": "prettier --write \"./**/*.{md,json,html,css,js,yml}\"",
+    "prettier-check": "prettier --check \"./**/*.{md,json,html,css,js,yml}\"",
     "pretest": "npm run lint",
     "test": "npm run jest",
     "jest": "cross-env MOCK_REDIS=1 jest",
@@ -29,7 +30,8 @@
     "hint": "hint http://localhost:3000",
     "webhint": "cross-env PORT=3000 npm-run-all -r -p server hint",
     "lighthouse-index": "lighthouse http://localhost:3000 --output-path=./lighthouse-report.html --view",
-    "lighthouse": "cross-env PORT=3000 npm-run-all -r -p server lighthouse-index"
+    "lighthouse": "cross-env PORT=3000 npm-run-all -r -p server lighthouse-index",
+    "test-ci": "run-s prettier-check test"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
We've had a few PRs recently that missed running Prettier (probably it wasn't installed via Husky in their environment).  This adds another script to `package.json` to run [`prettier --check`](https://prettier.io/docs/en/cli.html#--check), and use it in CI to help catch PRs with missing prettier formatting.

On development machines, running `npm test` is fine, since we don't want to error if files aren't committed yet (i.e., husky+prettier haven't run yet).