### PR TITLE
Closes #441: Update /posts route to support paging

### DIFF
--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -59,12 +59,13 @@ module.exports = {
       .exec();
   },
 
-  getPosts: (from, to) =>
-    /**
-     * 'counter' needs -1 because 'zrevrange()' includes the element at index 'counter'
-     * in the array it returns
-     */
-    redis.zrevrange(POSTS, from, to - 1),
+  /**
+   * Gets an array of guids from redis
+   * @param from lower index
+   * @param to higher index, it needs -1 because redis includes the element at this index in the returned array
+   * @return Array of guids
+   */
+  getPosts: (from, to) => redis.zrevrange(POSTS, from, to - 1),
 
   getPostsCount: () => redis.zcard(POSTS),
 

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -59,12 +59,12 @@ module.exports = {
       .exec();
   },
 
-  getPosts: counter =>
+  getPosts: (from, to) =>
     /**
      * 'counter' needs -1 because 'zrevrange()' includes the element at index 'counter'
      * in the array it returns
      */
-    redis.zrevrange(POSTS, 0, counter - 1),
+    redis.zrevrange(POSTS, from, to - 1),
 
   getPostsCount: () => redis.zcard(POSTS),
 

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -6,14 +6,15 @@ const { getPostsCount } = require('../../utils/storage');
 const posts = express.Router();
 
 posts.get('/', async (req, res) => {
+  const defaultNumberOfPosts = 30;
+  const capNumOfPosts = 100;
+  const page = req.query.page || 1;
+
   let redisGuids;
   let perPage;
   let postsInDB;
   let from;
   let to;
-  const defaultNumberOfPosts = 30;
-  const capNumOfPosts = 100;
-  const page = req.query.page || 1;
 
   /**
    * Set 'perPage' to a value under within the limits or
@@ -40,8 +41,8 @@ posts.get('/', async (req, res) => {
     return;
   }
 
-  const nextPage = to === postsInDB ? page : page + 1;
-  const prevPage = from === 0 ? page : page - 1;
+  const nextPage = to === postsInDB ? 1 : page + 1;
+  const prevPage = from === 0 ? postsInDB / perPage : page - 1;
 
   res.links({
     next: `/posts?per_page=${perPage}&page=${nextPage}`,

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -17,7 +17,7 @@ posts.get('/', async (req, res) => {
   let to;
 
   /**
-   * Set 'perPage' to a value under within the limits or
+   * Set 'perPage' to a value within the limits or
    * to default if per_page is not present
    */
   if (req.query.per_page)
@@ -27,7 +27,10 @@ posts.get('/', async (req, res) => {
   try {
     postsInDB = await getPostsCount();
 
-    // Set the range of posts we want to get from our DB
+    /**
+     * Set the range of posts that will be requested
+     * {from, to}
+     */
     from = perPage * (page - 1);
     // Make sure the upper limit is not higher than the total number of posts in the DB
     to = perPage * page > postsInDB ? postsInDB : perPage * page;
@@ -41,6 +44,9 @@ posts.get('/', async (req, res) => {
     return;
   }
 
+  /**
+   *
+   */
   const nextPage = to === postsInDB ? 1 : page + 1;
   const prevPage = from === 0 ? postsInDB / perPage : page - 1;
 

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -12,14 +12,22 @@ posts.get('/', async (req, res) => {
   const capNumOfPosts = 100;
   const page = req.query.page || 1;
 
+  /**
+   * Set 'perPage' to a value under within the limits or
+   * to default if per_page is not present
+   */
   if (req.query.per_page)
     perPage = req.query.per_page > capNumOfPosts ? capNumOfPosts : req.query.per_page;
   else perPage = defaultNumberOfPosts;
 
   try {
     const postsInDB = await getPostsCount();
+
+    // Set the range of posts we want to get from our DB
     const from = perPage * (page - 1);
+    // Make sure the upper limit is not higher than the total number of posts in the DB
     const to = perPage * page > postsInDB ? postsInDB : perPage * page;
+
     redisGuids = await getPosts(from, to);
   } catch (err) {
     logger.error({ err }, 'Unable to get posts from Redis');

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -45,16 +45,19 @@ posts.get('/', async (req, res) => {
   }
 
   /**
-   *
+   * Add prev, next, first and last in the response's header.
+   * It's been implemented to work circularly.
+   * Once reached the last set of posts, 'next' points at the first set.
+   * Same case with 'prev' and the first set of posts.
    */
-  const nextPage = to === postsInDB ? 1 : page + 1;
-  const prevPage = from === 0 ? postsInDB / perPage : page - 1;
+  const nextPage = to >= postsInDB ? 1 : parseInt(page, 10) + 1;
+  const prevPage = from === 0 ? Math.floor(postsInDB / perPage) : page - 1;
 
   res.links({
     next: `/posts?per_page=${perPage}&page=${nextPage}`,
     prev: `/posts?per_page=${perPage}&page=${prevPage}`,
     first: `/posts?per_page=${perPage}&page=${1}`,
-    last: `/posts?per_page=${perPage}&page=${postsInDB / perPage}`,
+    last: `/posts?per_page=${perPage}&page=${Math.floor(postsInDB / perPage)}`,
   });
   res.json(
     redisGuids

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const { getPosts, getPostsCount } = require('../../utils/storage');
 const { logger } = require('../../utils/logger');
-const { getPostsCount } = require('../../utils/storage');
 
 const posts = express.Router();
 

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -1,99 +1,107 @@
-const storage = require('../src/backend/utils/storage');
+const {
+  addFeed,
+  getFeed,
+  getFeeds,
+  getFeedsCount,
+  addPost,
+  getPost,
+  getPosts,
+  getPostsCount,
+} = require('../src/backend/utils/storage');
 
-describe('Tests for storage', () => {
+describe('Tests for feeds', () => {
   const feed = { name: 'James Smith', url: 'http://seneca.co/jsmith' };
   const feed2 = { name: 'James Smith 2', url: 'http://seneca.co/jsmith/2' };
 
   it('inserting a feed returns a feed id', async () => {
-    const feedId = await storage.addFeed(feed.name, feed.url);
+    const feedId = await addFeed(feed.name, feed.url);
     expect(typeof feedId).toBe('number');
   });
 
   it('should allow retrieving a feed by id after inserting', async () => {
-    const feedId = await storage.addFeed(feed2.name, feed2.url);
-    const result = await storage.getFeed(feedId);
+    const feedId = await addFeed(feed2.name, feed2.url);
+    const result = await getFeed(feedId);
     expect(result).toEqual(feed2);
   });
 
   it('check feed count', async () => {
-    const count1 = await storage.getFeedsCount();
-    await storage.addFeed(feed.name, feed.url);
-    const count2 = await storage.getFeedsCount();
+    const count1 = await getFeedsCount();
+    await addFeed(feed.name, feed.url);
+    const count2 = await getFeedsCount();
     expect(count2 - count1).toEqual(1);
   });
 
   it('should return ids of all the feeds', async () => {
-    const feedId1 = await storage.addFeed(feed.name, feed.url);
-    const feedId2 = await storage.addFeed(feed2.name, feed2.url);
-    const result = await storage.getFeeds();
+    const feedId1 = await addFeed(feed.name, feed.url);
+    const feedId2 = await addFeed(feed2.name, feed2.url);
+    const result = await getFeeds();
     expect(result).toContain(feedId1.toString());
     expect(result).toContain(feedId2.toString());
   });
+});
 
-  const post = {
-    guid: 'tag:blogger.com,1999:blog-7100164112302197371.post-522285656016053350',
-    author: 'Neil David',
-    title: 'My First Blog',
-    link: 'http://nadavid.blogspot.com/2008/09/my-first-blog.html',
-    content:
-      "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
-    text: 'post one text',
+describe('Tests for posts', () => {
+  const testPost = {
+    guid: '0',
+    author: 'foo',
+    title: 'foo',
+    link: 'foo',
+    content: 'foo',
+    text: 'foo',
     updated: new Date('2009-09-07T22:23:00.544Z'),
     published: new Date('2009-09-07T22:20:00.000Z'),
-    url: 'http://seneca.co/jsmith',
-    site: 'wordpress.com',
+    url: 'foo',
+    site: 'foo',
   };
 
-  const post2 = {
-    guid: '2tag:blogger.com,1999:blog-7100164112302197371.post-522285656016053350',
-    author: 'Neil David2',
-    title: 'My First Blog2',
-    link: 'http://nadavid2.blogspot.com/2008/09/my-first-blog.html',
-    content:
-      "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
-    text: 'post one text2',
-    updated: new Date('2008-09-07T22:12:00.544Z'),
-    published: new Date('2008-09-07T22:09:00.000Z'),
-    url: 'http://seneca.co/jsmith',
-    site: 'wordpress.com',
+  const testPost2 = {
+    guid: '1',
+    author: 'foo',
+    title: 'foo',
+    link: 'foo',
+    content: 'foo',
+    text: 'foo',
+    updated: new Date('2009-09-07T22:23:00.544Z'),
+    published: new Date('2009-09-07T22:20:00.000Z'),
+    url: 'foo',
+    site: 'foo',
   };
 
-  const post3 = {
-    guid: '3tag:blogger.com,1999:blog-7100164112302197371.post-522285656016053350',
-    author: 'Neil David3',
-    title: 'My First Blog3',
-    link: 'http://nadavid2.blogspot.com/2008/09/my-first-blog.html',
-    content:
-      "I have never done this before, so let's make this short. This post is just a test on how my blog post will look like.",
-    text: 'post one text3',
-    updated: new Date('2008-09-07T22:12:00.544Z'),
-    published: new Date('2008-09-07T22:09:00.000Z'),
-    url: 'http://seneca.co/jsmith',
-    site: 'wordpress.com',
+  const testPost3 = {
+    guid: '2',
+    author: 'foo',
+    title: 'foo',
+    link: 'foo',
+    content: 'foo',
+    text: 'foo',
+    updated: new Date('2009-09-07T22:23:00.544Z'),
+    published: new Date('2009-09-07T22:20:00.000Z'),
+    url: 'foo',
+    site: 'foo',
   };
+
+  beforeAll(() => {
+    Promise.all([testPost, testPost2, testPost3].map(post => addPost(post)));
+  });
 
   it('should allow retrieving a post by guid after inserting', async () => {
-    await storage.addPost(post);
-    const result = await storage.getPost(post.guid);
-    expect(result.link).toEqual(post.link);
+    const result = await getPost(testPost.guid);
+    expect(result.link).toEqual(testPost.link);
   });
 
   it('get all posts returns current number of posts', async () => {
-    await storage.addPost(post2);
-    const result = await storage.getPosts(0, -1);
-    expect(result.length).toEqual(2);
+    const result = await getPosts(0, 0);
+    expect(result.length).toEqual(3);
   });
 
   it('get all posts returns sorted posts by date', async () => {
-    const result = await storage.getPosts(0, -1);
-    expect(result[0]).toEqual(post.guid);
-    expect(result[1]).toEqual(post2.guid);
+    const result = await getPosts(0, 0);
+    expect(result[0]).toEqual(testPost3.guid);
+    expect(result[1]).toEqual(testPost2.guid);
   });
 
   it('check post count', async () => {
-    const count1 = await storage.getPostsCount();
-    await storage.addPost(post3);
-    const count2 = await storage.getPostsCount();
-    expect(count2 - count1).toEqual(1);
+    const count = await getPostsCount();
+    expect(count).toEqual(3);
   });
 });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -9,7 +9,7 @@ const {
   getPostsCount,
 } = require('../src/backend/utils/storage');
 
-describe('Tests for feeds', () => {
+describe('Storage tests for feeds', () => {
   const feed = { name: 'James Smith', url: 'http://seneca.co/jsmith' };
   const feed2 = { name: 'James Smith 2', url: 'http://seneca.co/jsmith/2' };
 
@@ -40,7 +40,7 @@ describe('Tests for feeds', () => {
   });
 });
 
-describe('Tests for posts', () => {
+describe('Storage tests for posts', () => {
   const testPost = {
     guid: '0',
     author: 'foo',
@@ -86,7 +86,7 @@ describe('Tests for posts', () => {
 
   it('should allow retrieving a post by guid after inserting', async () => {
     const result = await getPost(testPost.guid);
-    expect(result.link).toEqual(testPost.link);
+    expect(result.guid).toEqual(testPost.guid);
   });
 
   it('get all posts returns current number of posts', async () => {


### PR DESCRIPTION
Paging added to `/posts`.
Using `page` now it's possible to request a set of posts with `per_page` number of posts in it, or `default` number of posts if `per_page` is not present.

Examples:
- `/posts` should return 30 items
- `/posts?page=2` should return 30 items, but the second 30 items in our set
- `/posts?per_page=15` should return 15 items
- `/posts?page=3&per_page=15` should return 15 items, but the third page of 15 items

`Link` headers have been added with URLs for `next`, `prev`, `first`, `last`.
These will allow the browser to navigate without having to construct URLs for the other pages.
Example:
- for `/posts?page3=per_page=15`
  - `</posts?per_page=15&page=4>; rel="next"`
  - `</posts?per_page=15&page=2>; rel="prev"`
  - `</posts?per_page=15&page=1>; rel="first"`
  - `</posts?per_page=15&page=268>; rel="last"`

Also, changed tests in `storage.tests.js` to split feed tests and posts tests in 2 different sections.