### PR TITLE
Fix #388: reuse the same puppeteer browser and page instance for all calls of textParser.parse()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
     node: true,
     es2017: true,
   },
+  globals: {
+    page: true,
+  },
   rules: {
     'prettier/prettier': ['error'],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A tool for tracking blogs in orbit around Seneca's open source involvement",
   "jest": {
     "collectCoverage": true,
-    "testEnvironment": "node",
+    "globalSetup": "jest-environment-puppeteer/setup",
+    "globalTeardown": "jest-environment-puppeteer/teardown",
+    "testEnvironment": "jest-environment-puppeteer",
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ],
@@ -58,6 +60,7 @@
     "get-urls": "9.2.0",
     "ioredis": "4.14.1",
     "ioredis-mock": "4.18.4",
+    "jest-environment-puppeteer": "4.3.0",
     "jsdom": "15.2.1",
     "minimist": "1.2.0",
     "node-fetch": "2.6.0",
@@ -89,6 +92,7 @@
     "husky": "3.1.0",
     "jest": "24.9.0",
     "jest-fetch-mock": "2.1.2",
+    "jest-puppeteer": "4.3.0",
     "lighthouse": "5.6.0",
     "nock": "11.7.0",
     "npm-run-all": "4.1.5",

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,6 +1,7 @@
 require('./lib/config.js');
 const feedQueue = require('./feed/queue');
 const feedWorker = require('./feed/worker');
+const textParser = require('./utils/text-parser');
 const { logger: log } = require('./utils/logger');
 const wikiFeed = require('./utils/wiki-feed-parser');
 const shutdown = require('./lib/shutdown');
@@ -17,6 +18,15 @@ process.on('SIGINT', shutdown('SIGINT'));
 process.on('SIGQUIT', shutdown('SIGQUIT'));
 process.on('unhandledRejection', shutdown('UNHANDLED REJECTION'));
 process.on('uncaughtException', shutdown('UNCAUGHT EXCEPTION'));
+
+textParser
+  .initialize()
+  .then(() => {
+    log.info('Successfully initialized text parser');
+  })
+  .catch(error => {
+    log.error({ error }, 'Unable to initialize text parser');
+  });
 
 /**
  * Adds feed URL jobs to the feed queue for processing

--- a/src/backend/utils/spam-checker.js
+++ b/src/backend/utils/spam-checker.js
@@ -25,7 +25,7 @@ module.exports = async function(content) {
   if (content.title != null) {
     if (content.title !== '' && !filter.isSpam(content.title)) {
       // The main body of the blog post with all HTML tags removed
-      const noTagsDesc = await textParser(content.description);
+      const noTagsDesc = await textParser.parse(content.description);
       // If the word count is under MINWORDS, all characters are capital,
       // or spam-filter returns true, post is considered spam
       if (

--- a/test/text-parser.test.js
+++ b/test/text-parser.test.js
@@ -1,22 +1,78 @@
 const textParser = require('../src/backend/utils/text-parser');
 
 /**
- * textParser.run() will convert the html to text plain
+ * textParser.parse() will convert the html to text plain
  * Function should only extract what in the body
  */
-test('Testing text-parser', async () => {
-  const result = await textParser('<!DOCTYPE html><p>Hello World</p>');
+test('Testing text-parser with basic document', async () => {
+  const result = await textParser.parse('<!DOCTYPE html><p>Hello World</p>', page);
   expect(result).toBe('Hello World');
 });
 
 test('Testing text-parser with new line', async () => {
-  const result = await textParser(
-    '<!DOCTYPE html><html><head><title>OSD600</title></head><body style = "text-align:center;"><h1>Seneca</h1><div>OpenSource Telescope</div></body></html>'
-  );
+  const content = `
+  <!DOCTYPE html>
+    <html>
+      <head>
+        <title>OSD600</title>
+      </head>
+      <body style = "text-align:center;">
+        <h1>Seneca</h1>
+        <div>OpenSource Telescope</div>
+      </body>
+  </html>
+  `;
+  const result = await textParser.parse(content, page);
   expect(result).toBe('Seneca\nOpenSource Telescope');
 });
 
 test('Testing text-parser with Document Fragment', async () => {
-  const result = await textParser('<p>OSD600</p>');
+  const result = await textParser.parse('<p>OSD600</p>', page);
   expect(result).toBe('OSD600');
+});
+
+test('Testing text-parser with a dictionary', async () => {
+  const result = await textParser.parse({ dictKey: 'dictValue' }, page);
+  expect(result).toBe('[object Object]');
+});
+
+test('Testing text-parser with an integer', async () => {
+  const result = await textParser.parse(234423, page);
+  expect(result).toBe('234423');
+});
+
+test('Testing text-parser with a float', async () => {
+  const result = await textParser.parse(2323.12, page);
+  expect(result).toBe('2323.12');
+});
+
+test('Testing text-parser with a string', async () => {
+  const result = await textParser.parse('blahblajdklsfj', page);
+  expect(result).toBe('blahblajdklsfj');
+});
+
+test('Testing text-parser with an error object', async () => {
+  const result = await textParser.parse(new Error('hey this is an error'), page);
+  expect(result).toBe('[object Object]');
+});
+
+test('Testing text-parser with an array', async () => {
+  const result = await textParser.parse(['item1', 2323.4, 'item3', { what: 'okay' }], page);
+  expect(result).toBe('item1,2323.4,item3,[object Object]');
+});
+
+test('Testing text-parser with an error synchronously thrown', async () => {
+  const result = await textParser.parse(() => {
+    throw new Error('qwerty');
+  }, page);
+  expect(result).toBe('undefined');
+});
+
+test('Testing text-parser with an error asynchronously thrown', async () => {
+  const result = await textParser.parse(() => {
+    return Promise(() => {
+      throw new Error('error in promise');
+    });
+  }, page);
+  expect(result).toBe('undefined');
 });


### PR DESCRIPTION
**status update: ready for review**

**Types of change:** enhancement

Reference issue #388 

This PR does the following:
1. reuse the same puppeteer `browser` and `page` instance for all function calls of `textParser.parse()`

2. due to bugs in using `jest` to test `puppeteer`, which results in globally defined variables `browser` and `page` to become `undefined`, resulting in calling `browser.close` later to clean up the resources to fail. Therefore, the package `jest-environment-puppeteer` is used for testing. The setup for this module is here: https://www.npmjs.com/package/jest-environment-puppeteer, which outlines the necessary changes to configurations of jest inside `package.json`.

3. in order to support testing purposes, parse now takes in an optional `page` argument, which normally does not need to be passed in during regular usage.

4. during testing with `jest`, lazy initialization will cause the `browser` and `page` resources to become `undefined` after their creation. This prevents these resources being freed up, therefore jest hangs and returns the error message `jest did not exit one second after completion, check to see if you have asynchronous processes running`. Therefore, `text-parser.js` now needs to be explicitly initialized and shut down. The initialization logic is currently in `index.js`, shutdown logic is in `shutdown.js`.

5. because
```
globals: {
    page: true,
},
``` 
was added to `.eslintrc.js` in order to make `jest-environment-puppeteer` pass linting phase. The instructions for doing this are here: https://github.com/smooth-code/jest-puppeteer, under section **Configure ESLint**

6. because node keeps on throwing the following:
```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: woops
DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
which apparently is due to exceptions thrown or rejected promises in an async function that are not being handled properly with `catch()`, therefore, all `async` functions in `text-parser.js` has been switched to using promise chaining with proper `catch()`
```
func = () => return new Promise((resolve, reject) => {
   resolve();
   reject();
...
});

func.then().catch();
```
instead of
```
async () => {
   await blah();
...
}
```

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionalty or configuration variables are added/changed or an explanation of why it does not(if applicable)


~~Switch from `puppeteer` to using `puppeteer-cluster` for `text-parser.js`~~

~~This PR does the following:~~
~~1. add `puppeteer-cluster` node module to list of dependencies in `package.json`~~
~~2. switch `text-parser.js` to using `puppeteer-cluster` instead of `puppeteer`~~
~~3. The same cluster is being used for all calls of `parse()`~~
~~4. implement proper graceful shutdown in `shutdown.js` via `shutdownTextParser()`~~
~~5. update tests and other usages of `text-parser` to call `textParser.parse()`~~
~~6. added cases of failures in tests as well~~