### PR TITLE
Fix#487 add figure tag to allowedTag for sanitize-html

### DIFF
--- a/src/backend/utils/sanitize-html.js
+++ b/src/backend/utils/sanitize-html.js
@@ -7,6 +7,6 @@ module.exports = function(dirty) {
   return sanitizeHtml(dirty, {
     // Add <img> to the list of allowed tags, see:
     // https://github.com/apostrophecms/sanitize-html#what-are-the-default-options
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'figure']),
   });
 };

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -25,12 +25,12 @@ describe('Sanitize HTML', () => {
     expect(data).toBe('<p>Here is color <strong>blue</strong></p>');
   });
 
-  test('<figure> with <img> should remove <figure>', () => {
+  test('<figure> with <img> should strip inline style as both are added to allowed tags', () => {
     const data = sanitizeHTML(
       '<figure class="wp-block-image size-large"><img src="https://paulopensourceblog.files.wordpress.com/2019/12/image-3.png?w=1024" alt="" class="wp-image-2226"></figure>'
     );
     expect(data).toBe(
-      '<img src="https://paulopensourceblog.files.wordpress.com/2019/12/image-3.png?w=1024" />'
+      '<figure><img src="https://paulopensourceblog.files.wordpress.com/2019/12/image-3.png?w=1024" /></figure>'
     );
   });
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

**Issue This PR Addresses**
Add ```<figure>``` tag to allowedTag for sanitize-html as it is common for blog post.
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

**Type of Change**

<!-- bug fix, feature, documentation, UI, etc. -->
feature improvement
## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Added 'figure' to allowedTag and changed one related test case.
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionalty or configuration variables are added/changed or an explanation of why it does not(if applicable)
