### PR TITLE
Add html-elements tool and docs for other tools/

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     ]
   },
   "bin": {
-    "add-feed": "./tools/add-feed.js"
+    "add-feed": "./tools/add-feed.js",
+    "html-elements": "./tools/html-elements.js"
   },
   "scripts": {
     "eslint": "eslint --ignore-path .gitignore .",

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,76 @@
+# Telescope Tools
+
+This directory contains a number of useful tools for doing development
+and analysis in the Telescope project.
+
+Where possible, we try to write tools that will work cross-platform, and prefer
+node to shell scripts. This is not always possible.
+
+## Tools
+
+A number of the tools can be run as binary scripts via node.js, linked to this
+directory. To do this, you should first run the following command in the root
+of the project:
+
+```
+npm link
+```
+
+### [add-feed](add-feed.js)
+
+`add-feed` allows you to manually insert feeds into the queue, specifying the
+`name` and `url` of a feed:
+
+```
+add-feed --name "Bender Bending Rodriguez" --url futurama.wordpress.com/feed
+```
+
+### [html-elements](html-elements.js)
+
+`html-elements` allows you to get a list and count of all HTML elements seen
+in the posts that are indexed in the Redis database. You call it like so:
+
+```
+$ html-elements
+Processing 5534 posts...
+Processing 194,922 elements...
+1. <br> (69,015)
+2. <p> (36,408)
+3. <a> (19,760)
+4. <div> (15,244)
+5. <li> (8,779)
+6. <td> (7,124)
+7. <strong> (6,432)
+8. <img> (6,205)
+9. <code> (4,448)
+10. <pre> (4,076)
+11. <b> (3,176)
+12. <em> (2,699)
+13. <ul> (2,325)
+14. <tr> (1,790)
+15. <h3> (1,726)
+16. <i> (1,380)
+17. <h4> (1,075)
+18. <blockquote> (1,004)
+19. <ol> (538)
+20. <hr> (441)
+21. <table> (365)
+22. <tbody> (364)
+23. <th> (269)
+24. <h5> (133)
+25. <iframe> (63)
+26. <strike> (37)
+27. <h6> (27)
+28. <thead> (14)
+29. <caption> (5)
+```
+
+NOTE: this will only work after you have processed posts into Redis using
+`npm start` to run the server for a while.
+
+### [generate-ssl-certs](generate-ssl-certs.sh)
+
+`generate-ssl-certs` is used to generate SSL Certificates necessary for our
+login routes. See the [login docs](../docs/Local_Login.md) for more details.
+
+NOTE: this script currently only works in Linux and macOS.

--- a/tools/README.md
+++ b/tools/README.md
@@ -16,6 +16,8 @@ of the project:
 npm link
 ```
 
+NOTE: if you have issues running `npm link` (e.g., `Error: EACCESS: permission denied`), see [this discussion of possible solutions](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally).
+
 ### [add-feed](add-feed.js)
 
 `add-feed` allows you to manually insert feeds into the queue, specifying the

--- a/tools/html-elements.js
+++ b/tools/html-elements.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/**
+ * Once the Redis database is full of posts, this utility can be run
+ * to get info about all the posts, and the HTML elements they contain.
+ */
+
+const jsdom = require('jsdom');
+
+const { getPost } = require('../src/backend/utils/storage');
+const processPosts = require('./lib/process-posts');
+
+const { JSDOM } = jsdom;
+
+/**
+ * Return a unique list of elements for the given list (no duplicates)
+ * @param {Array} list - list of items with duplicates
+ */
+function uniq(list) {
+  return [...new Set(list)];
+}
+
+/**
+ * Return an array of all element names used for the HTML in a post
+ * @param {String} guid - Redis key for this post
+ */
+async function processPost(guid) {
+  const { content } = await getPost(guid);
+  const frag = JSDOM.fragment(content);
+  return Array.from(frag.querySelectorAll('*')).map(elem => elem.tagName.toLowerCase());
+}
+
+/**
+ * Return an Object with tag names as keys, counts as values
+ * @param {Array[String]} elements - list of element (i.e., tag names)
+ */
+function countTags(elements) {
+  const tagCounts = {};
+  elements.forEach(elem => {
+    const count = tagCounts[elem] || 0;
+    tagCounts[elem] = count + 1;
+  });
+  return tagCounts;
+}
+
+/**
+ * Process all posts in the database, and print the list of HTML elements used.
+ */
+async function run() {
+  try {
+    const elements = (await processPosts(processPost)).flat();
+    console.error(`Processing ${elements.length.toLocaleString()} elements...`);
+
+    // Get counts for every tag we've seen
+    const tagCounts = countTags(elements);
+    // Get a sorted list of tags by count
+    const uniqTags = uniq(elements).sort((a, b) => tagCounts[b] - tagCounts[a]);
+    // Print our list of tags and counts in descending order
+    uniqTags.forEach((tag, idx) =>
+      console.log(`${idx + 1}. <${tag}> (${tagCounts[tag].toLocaleString()})`)
+    );
+
+    process.exit(0);
+  } catch (err) {
+    console.error('Unable to process posts', err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/tools/lib/process-posts.js
+++ b/tools/lib/process-posts.js
@@ -1,0 +1,18 @@
+/**
+ * Helper for iterating over posts in Redis.
+ */
+
+const { getPosts } = require('../../src/backend/utils/storage');
+
+/**
+ * Process all posts in the database, calling the processPosts function on each.
+ * The processPost function is expected to return a Promise.
+ */
+async function processPosts(processPost) {
+  const posts = await getPosts(0, 0);
+  console.error(`Processing ${posts.length} posts...`);
+
+  return Promise.all(posts.map(processPost));
+}
+
+module.exports = processPosts;


### PR DESCRIPTION
**Type of Change**

Enhancement

## Description

This adds a new `html-elements` tool, which allows us to get info about all the HTML elements used in blog posts, and their counts.  I wanted to know what people actually use, so we can build our UI and other tools to accommodate it.

You run it like this:

```
$ npm link
$ html-elements
Processing 5534 posts...
Processing 194,922 elements...
1. <br> (69,015)
2. <p> (36,408)
3. <a> (19,760)
4. <div> (15,244)
5. <li> (8,779)
6. <td> (7,124)
7. <strong> (6,432)
8. <img> (6,205)
9. <code> (4,448)
10. <pre> (4,076)
11. <b> (3,176)
12. <em> (2,699)
13. <ul> (2,325)
14. <tr> (1,790)
15. <h3> (1,726)
16. <i> (1,380)
17. <h4> (1,075)
18. <blockquote> (1,004)
19. <ol> (538)
20. <hr> (441)
21. <table> (365)
22. <tbody> (364)
23. <th> (269)
24. <h5> (133)
25. <iframe> (63)
26. <strike> (37)
27. <h6> (27)
28. <thead> (14)
29. <caption> (5)
```

I've also added docs for our `tools/` dir, so people can figure out what things do.

My code was done in such a way that we can write other analysis tools to iterate over posts easily.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionalty or configuration variables are added/changed or an explanation of why it does not(if applicable)
