### PR TITLE
Fix #4: Adds files needed for deployment on Kubernetes

### DIFF
--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -1,0 +1,62 @@
+# This file will produce the telescope's image needed for deployment (ex. on Kubernetes)
+#
+# CLI command to create an image using this file:
+# Assumption: `telescope-deploy` would be the image name. If you change this name, change the image name also on `telescope.yaml`
+# $ docker build -f Dockerfile-deploy -t telescope-deploy .            ----> notice the dot at the end!
+# to put the image on Docker Hub:
+# $ docker login                                                       ----> you need an account; use your credential
+# $ docker tag telescope-deploy <DockerId>/telescope-deploy:<version>  ----> ex. $ docker tag telescope-deploy username/telescope-deploy
+#          needs Docker Hub ID. We may ignore version (we are using latest in `telescope.yaml` which is the default version)
+#          otherwise make them consistent in image tag and in YAML file.
+# $ docker push <DockerId>/telescope-deploy:<version>                  ----> ignore version if you ignored in image tag
+
+
+# Dockerfile-deploy
+
+# First stage of building image
+###############################
+
+# Use `node` long term stable image as the parent to build this image
+FROM node:lts as builder
+
+# Change working directory on the image
+WORKDIR "/telescope"
+
+# Copy package.json and .npmrc from local to the image
+# Copy before bundle app source to make sure package-lock.json never gets involved
+COPY package.json ./
+COPY .npmrc ./
+
+# Install all Node.js modules on the image
+RUN npm install --no-package-lock --production
+
+
+# Second stage, making the final image
+# only keep run-requirment from last stage
+##########################################
+
+# Use `node` long term stable and slim version image as the parent to build final image
+# The slim version has minimal packages needed to run application
+# It doesn't have version control, compiler, and etc which makes it significantly smaller and more secure
+FROM node:lts-slim
+
+# Change working directory on the image
+WORKDIR "/telescope"
+
+# Copy dependencies from last stage
+COPY --from=builder /telescope/node_modules /telescope/node_modules
+
+# Bundle app source
+COPY . .
+
+# Set the environment to production
+ENV NODE_ENV production
+
+# Change the run time user to not be root any more
+# The node image has a run time user already set up
+USER node
+
+# Expose (manage) the server port on Kuberbetes
+
+# run the image with this command
+CMD ["npm", "start"]

--- a/telescope.yaml
+++ b/telescope.yaml
@@ -1,0 +1,121 @@
+# This file creates replicas number of Pods, all served with one Kubernetes Service resource
+# each pod has 2 containers (telescope and redis) as has been specified in following Deployment resource
+
+# Change <DockerID> with the Docker Hub namespace (ID/username) in this file
+# To deploy project on Kubernetes we must have telescope image from `Dockerfile-deploy` file pushed on Docker Hub (instruction in `Dockerfile-deploy`).
+# We need `kubectl` installed, and for local simulation of the deployment, `minikube` installed and running.
+# deploy the app using following command
+# $ kubectl create -f telescope.yaml
+# to watch the pods as they gets created
+# $ kubectl get pods --watch
+# to see stdout of containers (telescope or redis) in one specific instance (pod)
+# $ kubctl logs <pod name as shown by above command> -c [telescope | redis]   ---> ex. $ kubectl logs telescope-7b567445fc-pn7cb -c telescope
+# finally access to the app which is running in Kubernetes cluster using this command
+# $ minikube service telescope
+# we can scale the app using the following command (example: from 3 replicas to 5)
+# $ kubectl scale --replicas=5 telescope
+# re-creating and replacing resources defined in a YAML file (ONLY IN MINIKUBE):
+# $ kubectl replace --force -f telescope.yaml   -----> Will cause service outage; Do not use in real deployment in Kubernetes
+
+# Service resource
+## telescope needs a service resource to be accessible to the outside the cluster
+## Service resource also guarantees the same IP address after each restart
+
+# version of Kubernetes API- using stable version
+apiVersion: v1
+# resource type and label
+kind: Service
+metadata:
+  name: telescope
+# specifications of resource
+spec:
+  selector:
+    name: telescope
+  ports:
+    # the port that cluster is listening (exposed)
+    - port: 3000
+      # the port in each pod that Service maps traffic on
+      targetPort: 3000
+      # the exposed port will be manipulated as nodePort. If we don't define it, it would be a random number greater than/equal 30000
+      # this is the port number we will see when we access to service by cluster's IP address
+      nodePort: 30000
+  # This resource needs to communicate with outside of the cluster
+  # and share traffic between instances of app
+  type: LoadBalancer
+---
+# Deployment resource
+
+# version of Kubernetes API- stable version for deployment resource
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telescope
+  labels:
+    # related to the service
+    app: telescope
+spec:
+  # at least 3 instances (pods) for resilient deployment, proper traffic management, and smooth updating the app
+  replicas: 3
+  selector:
+    matchLabels:
+      app: telescope
+  # label and specification of Pod
+  template:
+    metadata:
+      labels:
+        app: telescope
+    spec:
+      # shared file system between containers (redis and telescope)
+      volumes:
+        - name: storage
+          emptyDir: {}
+      # containers in this Pod (we have two)
+      containers:
+        # first container
+        - name: telescope
+          # change DockerID to telescope's Docker Hub username
+          image: <DockerID>/telescope-deploy:latest
+          # Always pull, because we are using the latest image version
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              # this path is implemented in our app. we can also check with home page ('/') to get 200 response
+              path: /health
+              port: 3000
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+
+        # second container
+        - name: redis
+          image: redis:latest
+          # Always pull, because we are using the latest image version
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 6379
+          # mount storage to the shared file system
+          volumeMounts:
+            - name: storage
+              mountPath: /from-redis
+          # container health checks to apply restart policy on Pod
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            timeoutSeconds: 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

**Fixes #4**

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

**Type of Change: Enhancement**

<!-- bug fix, feature, documentation, UI, etc. -->

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

This PR will hopefully close the Kubernetes related issue, but there are some goals that I couldn't achieve, and we may reach them with your reviews and helps in this PR, or we may make new issues about them. We can also keep #4 open. This pull request is not as well as the perfect picture that I have expected for # 4.

What is missing in this PR:
- The issue that I had with the 'localhost not showing' in the Dockerfiles, I have it here as well. I can't get the UI of the website while the backend is working.
- I couldn't find a way to pass variables to the .yaml file as it can't understand (I think) the variable substitution. So there are many magic numbers. Helm seems to have a solution for this matter, but I found it itself bulky and hard to maintain. The config mapping and Secret resource of the Kubernetes seem useless for this concern and I failed while trying them. Although I think we will need a Secret resource to be added to our deployment later.

This will add two files to the repo.
- `Dockerfile-deploy`: This helps to make a more secure image with about half of the size of our current development image which we can eventually deploy it, for example, on Kubernetes.
- `telescope.yaml`: This file builds a telescope app using the image we have made from the previous file and a Redis image. It orchestrates 3 instances of the app beside a Service resource of Kubernetes in a cluster so that we can have a resilient, manageable and seamlessly updatable deployment. Moreover, this file specifies the health check instruction for Kubernetes to verify the healthiness of each instance of the app and restart the instance if required.

Documents:
- I have provided instruction in both files about working with them and my assumptions. I will make an issue about updating the related documents.

About test:
- I think the only way to test this PR is running them, and I expect everybody can have the results as is being demonstrated in the below images: 

creating the image and push it on Docker Hub
![Screen Shot 2019-12-05 at 3 38 20 AM](https://user-images.githubusercontent.com/35855389/70381628-9f8f4700-191b-11ea-987b-9761286ed5c5.png)

deploy on the cluster and watching pods are running
![Screen Shot 2019-12-07 at 5 19 27 PM](https://user-images.githubusercontent.com/35855389/70381637-c6e61400-191b-11ea-8390-6da12d871b96.png)

checking out one instance of the app is running and it is doing the health checks
![Screen Shot 2019-12-07 at 5 21 24 PM](https://user-images.githubusercontent.com/35855389/70381641-e54c0f80-191b-11ea-996f-41b2d904a558.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)