### PR TITLE
Fix #496: refactor and expand Post class

### DIFF
--- a/src/backend/post.js
+++ b/src/backend/post.js
@@ -38,22 +38,31 @@ class Post {
    */
   static fromArticle(article) {
     // Validate the properties we get, and if we don't have them all, throw
-    if (
-      !(
-        article &&
-        article.author &&
-        article.title &&
-        article.description &&
-        article.pubdate &&
-        article.date &&
-        article.link &&
-        article.guid &&
-        article.meta &&
-        article.meta.link
-      )
-    ) {
-      logger.debug({ article }, 'article missing expected properties, not a valid post');
-      throw new Error('article missing expected properties, not a valid post');
+    if (!article) {
+      throw new Error('unable to parse, missing article');
+    }
+
+    // A valid RSS/Atom feed can have missing fields that we care about.
+    // Keep track of any that are missing, and throw if necessary.
+    let missing = [];
+    if (!article.author) missing.push('author');
+    if (!article.description) missing.push('description');
+    if (!article.pubdate) missing.push('pubdate');
+    if (!article.date) missing.push('date');
+    if (!article.link) missing.push('link');
+    if (!article.guid) missing.push('guid');
+    if (!(article.meta && article.meta.link)) missing.push('meta.link');
+
+    if (missing.length) {
+      let message = `invalid article: missing ${missing.join(', ')}`;
+      logger.debug(message);
+      throw new Error(message);
+    }
+
+    // Allow for missing title, but give it one
+    if (!article.title) {
+      logger.debug('article missing title, substituting "Untitled"');
+      article.title || 'Untitled';
     }
 
     // NOTE: feedparser article properties are documented here:

--- a/src/backend/post.js
+++ b/src/backend/post.js
@@ -1,20 +1,112 @@
-/**
- * This file contains the class Post with methods of it.
- * Class Post is used to generate objects that contain
- * data of each blog post.
- */
+const { getPost, addPost } = require('./utils/storage');
+const { logger } = require('./utils/logger');
+const sanitizeHTML = require('./utils/sanitize-html');
+
+function toDate(date) {
+  // Is this already a Date?
+  if (typeof date === 'object' && typeof date.getTime === 'function') {
+    return date;
+  }
+
+  return new Date(date);
+}
 
 class Post {
-  constructor(author, title, htmlContent, textContent, datePublished, dateUpdated, postLink, guid) {
+  constructor(author, title, html, text, datePublished, dateUpdated, postUrl, siteUrl, guid) {
     this.author = author;
     this.title = title;
-    this.content = htmlContent;
-    this.text = textContent;
-    this.published = datePublished;
-    this.updated = dateUpdated;
-    this.postLink = postLink;
+    this.html = html;
+    this.text = text;
+    this.published = toDate(datePublished);
+    this.updated = toDate(dateUpdated);
+    this.url = postUrl;
+    this.site = siteUrl;
     this.guid = guid;
-    this.wordCount = 0;
+  }
+
+  /**
+   * Save the current Post to the database.
+   */
+  async save() {
+    await addPost(this);
+  }
+
+  /**
+   * Parse an article object into a Post object.
+   * @param {Object} article parsed via feedparser, see:
+   * https://www.npmjs.com/package/feedparser#what-is-the-parsed-output-produced-by-feedparser
+   */
+  static fromArticle(article) {
+    // Validate the properties we get, and if we don't have them all, throw
+    if (
+      !(
+        article &&
+        article.author &&
+        article.title &&
+        article.description &&
+        article.pubdate &&
+        article.date &&
+        article.link &&
+        article.guid &&
+        article.meta &&
+        article.meta.link
+      )
+    ) {
+      logger.debug({ article }, 'article missing expected properties, not a valid post');
+      throw new Error('article missing expected properties, not a valid post');
+    }
+
+    // NOTE: feedparser article properties are documented here:
+    // https://www.npmjs.com/package/feedparser#list-of-article-properties
+    return new Post(
+      article.author,
+      article.title,
+      // description (frequently, the full article content).
+      // Clean it of any scripts or other dangerous attributes/elements
+      sanitizeHTML(article.description),
+      // TODO: run this through text parser
+      article.description,
+      // pubdate (original published date)
+      article.pubdate,
+      // date (most recent update)
+      article.date,
+      // link is the url to the post
+      article.link,
+      // meta.link is the url to the site
+      article.meta.link,
+      article.guid
+    );
+  }
+
+  /**
+   * Creates a Post by extracting data from the given post-like object.
+   * @param {Object} o - an Object containing the necessary fields
+   */
+  static parse(o) {
+    return new Post(
+      o.author,
+      o.title,
+      o.html,
+      o.text,
+      o.published,
+      o.updated,
+      o.url,
+      o.site,
+      o.guid
+    );
+  }
+
+  /**
+   * Returns a Post from the database using the given guid
+   * @param {String} guid - the guid of a post to get from the database.
+   */
+  static async byGuid(guid) {
+    const post = await getPost(guid);
+    // No post found using this guid
+    if (post && !post.guid) {
+      return null;
+    }
+    return Post.parse(post);
   }
 }
 

--- a/src/backend/post.js
+++ b/src/backend/post.js
@@ -44,7 +44,7 @@ class Post {
 
     // A valid RSS/Atom feed can have missing fields that we care about.
     // Keep track of any that are missing, and throw if necessary.
-    let missing = [];
+    const missing = [];
     if (!article.author) missing.push('author');
     if (!article.description) missing.push('description');
     if (!article.pubdate) missing.push('pubdate');
@@ -54,7 +54,7 @@ class Post {
     if (!(article.meta && article.meta.link)) missing.push('meta.link');
 
     if (missing.length) {
-      let message = `invalid article: missing ${missing.join(', ')}`;
+      const message = `invalid article: missing ${missing.join(', ')}`;
       logger.debug(message);
       throw new Error(message);
     }
@@ -62,7 +62,7 @@ class Post {
     // Allow for missing title, but give it one
     if (!article.title) {
       logger.debug('article missing title, substituting "Untitled"');
-      article.title || 'Untitled';
+      article.title = 'Untitled';
     }
 
     // NOTE: feedparser article properties are documented here:

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -34,28 +34,27 @@ module.exports = {
       .hmset(
         // using guid as keys as it is unique to posts
         post.guid,
-        'guid',
-        post.guid,
         'author',
         post.author,
         'title',
         post.title,
-        'link',
-        post.link,
-        'content',
-        post.content,
+        'html',
+        post.html,
         'text',
         post.text,
-        'updated',
-        post.updated,
         'published',
         post.published,
+        'updated',
+        post.updated,
         'url',
         post.url,
         'site',
-        post.site
+        post.site,
+        'guid',
+        post.guid
       )
-      .zadd(POSTS, post.published.getTime(), post.guid) // sort set by published date as scores
+      // sort set by published date as scores
+      .zadd(POSTS, post.published.getTime(), post.guid)
       .exec();
   },
 

--- a/src/backend/web/routes/post.js
+++ b/src/backend/web/routes/post.js
@@ -1,33 +1,30 @@
 const express = require('express');
-const { getPost } = require('../../utils/storage');
+const Post = require('../../post');
 const { logger } = require('../../utils/logger');
 
-const post = express.Router();
+const postRoute = express.Router();
 
 // Allow for the id to be a URI, possibly containing path separators
-post.get('/*', async (req, res) => {
+postRoute.get('/*', async (req, res) => {
   const guid = decodeURIComponent(req.params[0]);
 
-  let redisPost;
   try {
-    redisPost = await getPost(guid);
+    const post = await Post.byGuid(guid);
+
+    // If the object we get back is empty, use 404
+    if (!post) {
+      res.status(404).json({
+        message: `Post not found for id ${guid}`,
+      });
+    } else {
+      res.json(post);
+    }
   } catch (err) {
     logger.error({ err }, 'Unable to get posts from Redis');
     res.status(503).json({
       message: 'Unable to connect to database',
     });
-    return;
   }
-
-  // If the object we get back is empty, use 404
-  if (redisPost && !redisPost.guid) {
-    res.status(404).json({
-      message: `Post not found for id ${guid}`,
-    });
-    return;
-  }
-
-  res.json(redisPost);
 });
 
-module.exports = post;
+module.exports = postRoute;

--- a/src/frontend/scripts/main.js
+++ b/src/frontend/scripts/main.js
@@ -58,7 +58,7 @@ async function getPostsPage(perPage = 10) {
                 </header>
 
                 <section class="post-content">
-                    ${post.content}
+                    ${post.html}
                 </section>
             </article>
             `);

--- a/test/feed-parser.test.js
+++ b/test/feed-parser.test.js
@@ -10,7 +10,7 @@ test('passing a valid Atom feed URI and getting title of first post', async () =
   const feedURL = fixtures.getAtomUri();
   fixtures.nockValidAtomResponse();
   const data = await feedParser(feedURL);
-  expect(data[data.length - 1].title).toBe('XML Tutorial');
+  expect(data[data.length - 1].title).toBe('RSS Solutions for Schools and Colleges');
 });
 
 test('Passing an invalid ATOM feed URI should error', async () => {
@@ -22,7 +22,7 @@ test('Passing a valid RSS feed URI and getting title of first post', async () =>
   const feedURL = fixtures.getRssUri();
   fixtures.nockValidRssResponse();
   const data = await feedParser(feedURL);
-  expect(data[data.length - 1].title).toBe('XML Tutorial');
+  expect(data[data.length - 1].title).toBe('RSS Solutions for Schools and Colleges');
 });
 
 test('Passing an invalid RSS feed URI should error', async () => {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -12,27 +12,64 @@ const getHtmlUri = () => 'https://test321.blogspot.com/blog';
 // Remove leading protocol from a URI
 const stripProtocol = uri => uri.replace(/^https?:\/\//, '');
 
+// Portion of https://www.feedforall.com/sample.xml
 const getValidFeedBody = () =>
   `
-  <?xml version="1.0" encoding="UTF-8"?>
+  <?xml version="1.0" encoding="windows-1252"?>
   <rss version="2.0">
     <channel>
-      <title>W3Schools Home Page</title>
-      <link>https://www.w3schools.com</link>
-      <description>Free web building tutorials</description>
+      <title>FeedForAll Sample Feed</title>
+      <description>RSS is a fascinating technology. The uses for RSS are expanding daily. Take a closer look at how various industries are using the benefits of RSS in their businesses.</description>
+      <link>http://www.feedforall.com/industry-solutions.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <copyright>Copyright 2004 NotePage, Inc.</copyright>
+      <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+      <language>en-us</language>
+      <lastBuildDate>Tue, 19 Oct 2004 13:39:14 -0400</lastBuildDate>
+      <managingEditor>marketing@feedforall.com</managingEditor>
+      <pubDate>Tue, 19 Oct 2004 13:38:55 -0400</pubDate>
+      <webMaster>webmaster@feedforall.com</webMaster>
+      <generator>FeedForAll Beta1 (0.0.1.8)</generator>
+      <image>
+        <url>http://www.feedforall.com/ffalogo48x48.gif</url>
+        <title>FeedForAll Sample Feed</title>
+        <link>http://www.feedforall.com/industry-solutions.htm</link>
+        <description>FeedForAll Sample Feed</description>
+        <width>48</width>
+        <height>48</height>
+      </image>
       <item>
-        <title>RSS Tutorial</title>
-        <link>https://www.w3schools.com/xml/xml_rss.asp</link>
-        <description>New RSS tutorial on W3Schools</description>
+        <title>RSS Solutions for Restaurants</title>
+        <description>&lt;b&gt;FeedForAll &lt;/b&gt;helps Restaurant&apos;s communicate with customers. Let your customers know the latest specials or events.&lt;br&gt;
+  &lt;br&gt;
+  RSS feed uses include:&lt;br&gt;
+  &lt;i&gt;&lt;font color=&quot;#FF0000&quot;&gt;Daily Specials &lt;br&gt;
+  Entertainment &lt;br&gt;
+  Calendar of Events &lt;/i&gt;&lt;/font&gt;</description>
+        <link>http://www.feedforall.com/restaurant.htm</link>
+        <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+        <comments>http://www.feedforall.com/forum</comments>
+        <pubDate>Tue, 19 Oct 2004 11:09:11 -0400</pubDate>
       </item>
       <item>
-        <title>XML Tutorial</title>
-        <link>https://www.w3schools.com/xml</link>
-        <description>New XML tutorial on W3Schools</description>
+        <title>RSS Solutions for Schools and Colleges</title>
+        <description>FeedForAll helps Educational Institutions communicate with students about school wide activities, events, and schedules.&lt;br&gt;
+  &lt;br&gt;
+  RSS feed uses include:&lt;br&gt;
+  &lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Homework Assignments &lt;br&gt;
+  School Cancellations &lt;br&gt;
+  Calendar of Events &lt;br&gt;
+  Sports Scores &lt;br&gt;
+  Clubs/Organization Meetings &lt;br&gt;
+  Lunches Menus &lt;/i&gt;&lt;/font&gt;</description>
+        <link>http://www.feedforall.com/schools.htm</link>
+        <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+        <comments>http://www.feedforall.com/forum</comments>
+        <pubDate>Tue, 19 Oct 2004 11:09:09 -0400</pubDate>
       </item>
     </channel>
   </rss>
-  `;
+`;
 
 const getEmptyFeedBody = () =>
   `


### PR DESCRIPTION
**Issue This PR Addresses**

Fixes #496 

**Type of Change**

Bug fixes and enhancement

## Description

This PR alters the way our `Post` type works, expanding its behaviours to encompass all data parsing and database logic.  Specifically:

- Removes unneeded properties (e.g., `wordCount`)
- Renaming some of the properties to better reflect what they are (e.g., `html`)
- Adding both `url` and `site` info for a post
- Adding methods to parse a `Post` from the `article` object produced by the `feedparser`, and also from a regular JS object (e.g., from JSON or out of Redis)
- Added method to `save` a Post to redis
- Added method to get a Post `byGuid` from redis

All of the code in here is being used, but we should add more tests in another PR.  I'd do it now, but I'm building something else based on this code.

I'd also like to see us do something similar with `Posts`, `Feed`, `Feeds`, etc. later on.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionalty or configuration variables are added/changed or an explanation of why it does not(if applicable)
