### PR TITLE
Issue 430: Added tests for the post/ route

### DIFF
--- a/test/routes.post.test.js
+++ b/test/routes.post.test.js
@@ -22,7 +22,7 @@ describe('test /post responses', () => {
     existingGuid
   );
 
-  // an object, expected to be returned by a correct querry
+  // an object, expected to be returned by a correct query
   const receivedPost1 = {
     author: 'foo',
     title: 'foo',
@@ -48,7 +48,7 @@ describe('test /post responses', () => {
     existingNeedingEncoding
   );
 
-  // an object, expected to be returned by a correct querry
+  // an object, expected to be returned by a correct query
   const receivedPost2 = {
     author: 'bar',
     title: 'bar',

--- a/test/routes.post.test.js
+++ b/test/routes.post.test.js
@@ -36,12 +36,12 @@ describe('test /post responses', () => {
 
   // add the post to the storage
   beforeAll(() => {
-    new Promise(() => addPost(toBeAdded));
+    addPost(toBeAdded);
   });
 
   // tests
   it("pass a guid that doesn't exist", async () => {
-    const res = await request(app).get('/post/' + keys[1]);
+    const res = await request(app).get(`/post/${keys[1]}`);
 
     expect(res.status).toEqual(404);
     expect(res.get('Content-type')).toContain('application/json');
@@ -49,7 +49,7 @@ describe('test /post responses', () => {
   });
 
   it('pass a guid that exists', async () => {
-    const res = await request(app).get('/post/' + keys[0]);
+    const res = await request(app).get(`/post/${keys[0]}`);
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
@@ -57,7 +57,7 @@ describe('test /post responses', () => {
   });
 
   it("pass an encoded guid that doesn't exist", async () => {
-    const res = await request(app).get(encodeURI('/post/' + keys[1]));
+    const res = await request(app).get(encodeURI(`/post/${keys[1]}`));
 
     expect(res.status).toEqual(404);
     expect(res.get('Content-type')).toContain('application/json');
@@ -65,7 +65,7 @@ describe('test /post responses', () => {
   });
 
   it('pass an encoded guid that exists', async () => {
-    const res = await request(app).get(encodeURI('/post/' + keys[0]));
+    const res = await request(app).get(encodeURI(`/post/${keys[0]}`));
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');

--- a/test/routes.post.test.js
+++ b/test/routes.post.test.js
@@ -1,0 +1,74 @@
+const request = require('supertest');
+const app = require('../src/backend/web/app');
+const { addPost } = require('../src/backend/utils/storage');
+
+describe('test /post responses', () => {
+  // an array of keys.
+  const keys = [100, 101];
+
+  // an object to be added to the storage for testing purposes
+  const toBeAdded = {
+    guid: `${keys[0]}`,
+    author: 'foo',
+    title: 'foo',
+    link: 'foo',
+    content: 'foo',
+    text: 'foo',
+    updated: new Date('2009-09-07T22:23:00.544Z'),
+    published: new Date('2009-09-07T22:20:00.000Z'),
+    html: '',
+    url: 'foo',
+    site: 'foo',
+  };
+
+  // an object, expected to be returned by a correct querry
+  const returned = {
+    guid: '100',
+    author: 'foo',
+    title: 'foo',
+    html: '',
+    text: 'foo',
+    published: '2009-09-07T22:20:00.000Z',
+    updated: '2009-09-07T22:23:00.000Z',
+    url: 'foo',
+    site: 'foo',
+  };
+
+  // add the post to the storage
+  beforeAll(() => {
+    new Promise(() => addPost(toBeAdded));
+  });
+
+  // tests
+  it("pass a guid that doesn't exist", async () => {
+    const res = await request(app).get('/post/' + keys[1]);
+
+    expect(res.status).toEqual(404);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body.message).toEqual('Post not found for id 101');
+  });
+
+  it('pass a guid that exists', async () => {
+    const res = await request(app).get('/post/' + keys[0]);
+
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body).toEqual(returned);
+  });
+
+  it("pass an encoded guid that doesn't exist", async () => {
+    const res = await request(app).get(encodeURI('/post/' + keys[1]));
+
+    expect(res.status).toEqual(404);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body.message).toEqual('Post not found for id 101');
+  });
+
+  it('pass an encoded guid that exists', async () => {
+    const res = await request(app).get(encodeURI('/post/' + keys[0]));
+
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body).toEqual(returned);
+  });
+});


### PR DESCRIPTION
## Fixes #430 

### Type of Change

Added tests for `post/` route

### Description

In this PR, I have implemented tests for `/post/:guid` route.

Tests cover the following cases:  

- `404` - a post with a passed `guid` not found;
- `200` - a post with a passed `guid` found and returned;
- both _encoded_ and _not encoded_ cases are tested

### Quality Check

While testing on my local machine with the latest version of the `master` branch, `inactive-blogs-filter` was failing - and so it did on my branch. 