### PR TITLE
Fixes Issue #462 Integrate inactive blog url and include logic to filter inactive feeds

### DIFF
--- a/src/backend/feed.js
+++ b/src/backend/feed.js
@@ -2,34 +2,31 @@ const storage = require('./utils/storage');
 
 class Feed {
   /**
-   * Saves current feed to appropriate set in Redis
+   * Saves current feed to Redis
    */
   async save() {
     this.feedId = await storage.addFeed(this);
+    await storage.storeFeed(this.feedId);
   }
 
   /**
    * Checks if feed is part active feeds list. If it is, will move feed from active FEEDS set to INACTIVE_FEEDS set
+   * else will move ffeed from INACTIVE_FEEDS to FEEDS
    */
-  async inactive() {
-    const isActive = await this.isActive(this);
+  async move() {
+    const isActive = await storage.isActive(this);
     if (isActive === 1) {
-      await storage.addInactiveFeed();
+      await storage.moveFeed(this.feedId, 'feeds', 'inactive_feeds');
+    } else {
+      await storage.moveFeed(this.feedId, 'inactive_feeds', 'feeds');
     }
-  }
-
-  /**
-   * Marks the feed as active and moves feed to active set
-   */
-  async active() {
-    await this.save();
   }
 
   /**
    * Checks if the feed is in the active feeds(FEEDS) set
    */
   async isActive() {
-    return this.getFeedStatus();
+    return storage.isFeedActive(this.feedId);
   }
 }
 

--- a/src/backend/feed.js
+++ b/src/backend/feed.js
@@ -1,0 +1,33 @@
+const storage = require('./utils/storage');
+
+/**
+ * Feed Object, upon being created all feeds will be active and have a feedId of 0 until saved into Redis
+ * @param url url of feed
+ * @param name author name of feed
+ * @param feedId unique id for feed
+ */
+class Feed {
+  constructor(url, name) {
+    this.url = url;
+    this.name = name;
+    this.inactive = false;
+    this.feedId = 0;
+  }
+
+  /**
+   * Saves current feed to appropriate set in Redis
+   */
+  async save() {
+    this.feedId = await storage.addFeed(this);
+  }
+
+  /**
+   * Marks the feed as inactive
+   */
+  inactive() {
+    this.inactive = true;
+    this.save();
+  }
+}
+
+module.exports = Feed;

--- a/src/backend/feed.js
+++ b/src/backend/feed.js
@@ -1,19 +1,6 @@
 const storage = require('./utils/storage');
 
-/**
- * Feed Object, upon being created all feeds will be active and have a feedId of 0 until saved into Redis
- * @param url url of feed
- * @param name author name of feed
- * @param feedId unique id for feed
- */
 class Feed {
-  constructor(url, name) {
-    this.url = url;
-    this.name = name;
-    this.inactive = false;
-    this.feedId = 0;
-  }
-
   /**
    * Saves current feed to appropriate set in Redis
    */
@@ -22,11 +9,27 @@ class Feed {
   }
 
   /**
-   * Marks the feed as inactive
+   * Checks if feed is part active feeds list. If it is, will move feed from active FEEDS set to INACTIVE_FEEDS set
    */
-  inactive() {
-    this.inactive = true;
-    this.save();
+  async inactive() {
+    const isActive = await this.isActive(this);
+    if (isActive === 1) {
+      await storage.addInactiveFeed();
+    }
+  }
+
+  /**
+   * Marks the feed as active and moves feed to active set
+   */
+  async active() {
+    await this.save();
+  }
+
+  /**
+   * Checks if the feed is in the active feeds(FEEDS) set
+   */
+  async isActive() {
+    return this.getFeedStatus();
   }
 }
 

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -72,9 +72,9 @@ module.exports = {
   getPost: async guid => redis.hgetall(guid),
 
   /**
-   * Moves a feed from active(FEEDS) to inactive(INACTIVE_FEEDS)
-   * @param feedId lower index
-   * @return feedId of feed being moved
+   * Moves a feed from active(FEEDS) to inactive(INACTIVE_FEEDS), will check if the set exists first before moving
+   * @param feedId key of set being moved
+   * @return feedId of key being moved
    */
   addInactiveFeed: async feedId => {
     if ((await redis.exists(INACTIVE_FEEDS)) === 1) {
@@ -90,11 +90,16 @@ module.exports = {
         .hmset(feedId, 'name', name, 'url', url)
         .sadd(INACTIVE_FEEDS, feedId)
         .exec();
-      return feedId;
     }
     return feedId;
   },
 
+  /**
+   * Gets an array of guids from redis
+   * @param from lower index
+   * @param to higher index, it needs -1 because redis includes the element at this index in the returned array
+   * @return Array of guids
+   */
   getInactiveFeeds: () => redis.smembers(INACTIVE_FEEDS),
 
   getInactiveFeed: feedID => redis.hgetall(feedID),

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -5,6 +5,7 @@ const FEED_ID = 'feed_id';
 const FEEDS = 'feeds';
 
 const POSTS = 'posts';
+const INACTIVE_FEEDS = 'inactive_feeds';
 
 module.exports = {
   addFeed: async (name, url) => {
@@ -69,4 +70,34 @@ module.exports = {
   getPostsCount: () => redis.zcard(POSTS),
 
   getPost: async guid => redis.hgetall(guid),
+
+  /**
+   * Moves a feed from active(FEEDS) to inactive(INACTIVE_FEEDS)
+   * @param feedId lower index
+   * @return feedId of feed being moved
+   */
+  addInactiveFeed: async feedId => {
+    if ((await redis.exists(INACTIVE_FEEDS)) === 1) {
+      await redis.smove(FEEDS, INACTIVE_FEEDS, feedId);
+    } else {
+      const name = await redis.hget(feedId, 'name');
+      const url = await redis.hget(feedId, 'url');
+      await redis
+        .multi()
+        // Using hmset() until hset() fully supports multiple fields:
+        // https://github.com/stipsan/ioredis-mock/issues/345
+        // https://github.com/luin/ioredis/issues/551
+        .hmset(feedId, 'name', name, 'url', url)
+        .sadd(INACTIVE_FEEDS, feedId)
+        .exec();
+      return feedId;
+    }
+    return feedId;
+  },
+
+  getInactiveFeeds: () => redis.smembers(INACTIVE_FEEDS),
+
+  getInactiveFeed: feedID => redis.hgetall(feedID),
+
+  getInactiveFeedsCount: () => redis.scard(INACTIVE_FEEDS),
 };

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -94,12 +94,6 @@ module.exports = {
     return feedId;
   },
 
-  /**
-   * Gets an array of guids from redis
-   * @param from lower index
-   * @param to higher index, it needs -1 because redis includes the element at this index in the returned array
-   * @return Array of guids
-   */
   getInactiveFeeds: () => redis.smembers(INACTIVE_FEEDS),
 
   getInactiveFeed: feedID => redis.hgetall(feedID),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
#462 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
-  **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
There is no logic for handling inactive feeds in storage.js. I added a few functions that allows for active feeds to be moved to inactive feeds, get all inactive feeds and get count of all inactive feeds. There is one function that should be debated which is getInactiveFeed.

Still a WIP but would like some feedback on current changes before continuing

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
