### PR TITLE
Closes #509: Move /posts/count to X-Total-Count header for /posts

### DIFF
--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -53,6 +53,8 @@ posts.get('/', async (req, res) => {
   const nextPage = to >= postsCount ? 1 : page + 1;
   const prevPage = from === 0 ? Math.floor(postsCount / perPage) : page - 1;
 
+  res.set('X-Total-Count', postsCount);
+
   res.links({
     next: `/posts?per_page=${perPage}&page=${nextPage}`,
     prev: `/posts?per_page=${perPage}&page=${prevPage}`,

--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -71,18 +71,6 @@ posts.get('/', async (req, res) => {
   );
 });
 
-posts.get('/count', async (req, res) => {
-  try {
-    const count = await getPostsCount();
-    res.json(count);
-  } catch (err) {
-    logger.error({ err }, 'Unable to get posts from Redis');
-    res.status(500).json({
-      message: 'Unable to connect to database',
-    });
-  }
-});
-
 // The guid is likely a URI, and must be encoded by the client
 posts.get('/:guid', async (req, res) => {
   const guid = decodeURIComponent(req.params.guid);

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -33,7 +33,7 @@ describe('test /posts endpoint', () => {
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
-    expect(res.get('X-Total-Count')).toContain(createdItems.toString());
+    expect(res.get('X-Total-Count')).toBe(createdItems.toString());
     expect(res.body.length).toBe(defaultItems);
     expect(res.body instanceof Array).toBe(true);
   });
@@ -43,7 +43,7 @@ describe('test /posts endpoint', () => {
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
-    expect(res.get('X-Total-Count')).toContain(createdItems.toString());
+    expect(res.get('X-Total-Count')).toBe(createdItems.toString());
     expect(res.body.length).toBe(requestedItems);
     expect(res.body instanceof Array).toBe(true);
   });
@@ -53,7 +53,7 @@ describe('test /posts endpoint', () => {
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
-    expect(res.get('X-Total-Count')).toContain(createdItems.toString());
+    expect(res.get('X-Total-Count')).toBe(createdItems.toString());
     expect(res.body.length).toBe(maxItems);
     expect(res.body instanceof Array).toBe(true);
   });

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -7,8 +7,9 @@ describe('test /posts endpoint', () => {
   const defaultItems = 30;
   const requestedItems = 50;
   const maxItems = 100;
+  const createdItems = 150;
 
-  const posts = [...Array(150).keys()].map(guid => {
+  const posts = [...Array(createdItems).keys()].map(guid => {
     return {
       guid: `${guid}`,
       author: 'foo',
@@ -32,6 +33,7 @@ describe('test /posts endpoint', () => {
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
+    expect(res.get('X-Total-Count')).toContain(createdItems.toString());
     expect(res.body.length).toBe(defaultItems);
     expect(res.body instanceof Array).toBe(true);
   });
@@ -41,6 +43,7 @@ describe('test /posts endpoint', () => {
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
+    expect(res.get('X-Total-Count')).toContain(createdItems.toString());
     expect(res.body.length).toBe(requestedItems);
     expect(res.body instanceof Array).toBe(true);
   });
@@ -50,16 +53,9 @@ describe('test /posts endpoint', () => {
 
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
+    expect(res.get('X-Total-Count')).toContain(createdItems.toString());
     expect(res.body.length).toBe(maxItems);
     expect(res.body instanceof Array).toBe(true);
-  });
-
-  it('returns correct number of posts', async () => {
-    const res = await request(app).get('/posts/count');
-
-    expect(res.status).toEqual(200);
-    expect(res.get('Content-type')).toContain('application/json');
-    expect(res.body).toBe(150);
   });
 });
 


### PR DESCRIPTION
Closes #509

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Removed `/count` endpoint and added total number of posts to `X-Total-Count` header.
Also, added tests to check the value of `X-Total-Count` and removed test for `/count`.

![Screenshot_20191216_222411](https://user-images.githubusercontent.com/23108901/70963389-47142400-2056-11ea-8569-cc17ecc8e7bd.png)

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
