### PR TITLE
Add link for #telescope Slack channel to various docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A tool for tracking blogs in orbit around Seneca's open source involvement. We w
 An initial discussion of the project is available in the [Overview](docs/overview.md) document.
 For contribution, the docs can be found here [Contribution](docs/CONTRIBUTING.md)
 
+For community discussions, join our [#telescope Slack channel](https://seneca-open-source.slack.com/archives/CS5DGCAE5).
+
 ## Quick Setup Guide
 
 Clone the source locally:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 We are all eager to work on telescope, and this document will help you to get started!
 
+For community discussions, join our [#telescope Slack channel](https://seneca-open-source.slack.com/archives/CS5DGCAE5).
+
 ## Issues
 
 Before creating an issue:


### PR DESCRIPTION
Adds a link to our new Slack channel, so people can find it.  I put it in multiple places so it won't be missed.