### PR TITLE
Move coverage to its own npm script, allow passing args to Jest

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -193,14 +193,29 @@ When working on fixing bugs, please use the following workflow:
 
 ### Testing Your Code
 
-1. Run the test suite, using `npm test`. Fix any lint errors, warnings, or other failures (NOTE: if you're not sure what an eslint rule means, [look it up in the docs](https://eslint.org/docs/rules/)):
-   ```
-   npm test
-   ...if there are lint errors, try having eslint fix them for you
-   npm run eslint-fix
-   npm test
-   ...manually fix any errors yourself, rerunning npm test each time to confirm
-   ```
+Run the test suite, using `npm test`. Fix any lint errors, warnings, or other failures (NOTE: if you're not sure what an eslint rule means, [look it up in the docs](https://eslint.org/docs/rules/)):
+
+```
+npm test
+...if there are lint errors, try having eslint fix them for you
+npm run eslint-fix
+npm test
+...manually fix any errors yourself, rerunning npm test each time to confirm
+```
+
+You can also run the tests in _watch_ mode, so that they will automatically ru-run
+when you make changes:
+
+```
+npm run jest-watch
+```
+
+In addition, you can run individual tests, in both normal or watch mode, by
+adding the name of a file. For example, to run tests in a file called parser.test.js:
+
+```
+npm test parser
+```
 
 You can add feeds to the queue manually using `add-feed` followed by the name of the blogger and url of the feed. This can be useful for testing purposes.
 
@@ -293,7 +308,7 @@ There are a number of reports that get generated, and can aid in developer under
 The first is test coverage information. To generate the report, run the tests:
 
 ```
-npm test
+npm run coverage
 ```
 
 After the tests complete, a text summary report is printed. However, a much more

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "A tool for tracking blogs in orbit around Seneca's open source involvement",
   "jest": {
-    "collectCoverage": true,
     "testEnvironment": "node",
     "coveragePathIgnorePatterns": [
       "/node_modules/"
@@ -27,8 +26,9 @@
     "prettier-check": "prettier --check \"./**/*.{md,json,html,css,js,yml}\"",
     "pretest": "npm run lint",
     "test": "npm run jest",
-    "jest": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest",
-    "jest-watch": "cross-env MOCK_REDIS=1 jest --watch",
+    "jest": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest --",
+    "coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest --collectCoverage --",
+    "jest-watch": "cross-env MOCK_REDIS=1 jest --watch --",
     "start": "node src/backend",
     "server": "node src/backend/web/server",
     "hint": "hint http://localhost:3000",


### PR DESCRIPTION
This tweaks our Jest setup a bit, and adjusts the docs accordingly.

First, it moves `coverage` to its own script vs. doing it every time we run the tests.  I find it annoying to have to scroll up to see what failed.  If someone wants coverage info (not the norm), they can run it manually.

Second, it allows passing file name patterns to jest so you don't have to run all the tests every time if you only want to test one thing.