### PR TITLE
Parallelize feed parser, make it run forever

### DIFF
--- a/env.example
+++ b/env.example
@@ -57,7 +57,12 @@ BLOG_INACTIVE_TIME=360
 GITHUB_TOKEN=
 
 # Feed job queue attempts
-FEED_QUEUE_ATTEMPTS=8
+FEED_QUEUE_ATTEMPTS=2
 
 # Feed job queue delay(ms)
-FEED_QUEUE_DELAY_MS=60000
+FEED_QUEUE_DELAY_MS=30000
+
+# Number of concurrent worker processors to run. Use * if you want to run
+# one per CPU. Use a number if you want to set it manually, up to a max
+# of the CPU count.  If not set, we'll assume 1.
+FEED_QUEUE_PARALLEL_WORKERS=1

--- a/src/backend/feed/queue.js
+++ b/src/backend/feed/queue.js
@@ -1,6 +1,7 @@
 const { setQueues } = require('bull-board');
 
 require('../lib/config');
+const { logger } = require('../utils/logger');
 const { createQueue } = require('../lib/queue');
 
 // Create a Bull Redis Queue
@@ -8,5 +9,31 @@ const queue = createQueue('feed-queue');
 
 // For visualizing queues using bull board
 setQueues(queue);
+
+/**
+ * Provide a helper for adding a feed with our desired default options.
+ * The `feedInfo` is an Object with `name` (i.e., name of author) and `url`
+ * (i.e., url of feed) properties, matching what we parse from the wiki.
+ */
+queue.addFeed = async function(feedInfo) {
+  const options = {
+    // Use the feed URL as the job key, so we don't double add it.
+    // Bull will not add a job there already exists a job with the same id.
+    id: feedInfo.url,
+    attempts: process.env.FEED_QUEUE_ATTEMPTS || 2,
+    backoff: {
+      type: 'exponential',
+      delay: process.env.FEED_QUEUE_DELAY_MS || 30 * 1000,
+    },
+    removeOnComplete: true,
+    removeOnFail: true,
+  };
+
+  try {
+    queue.add(feedInfo, options);
+  } catch (err) {
+    logger.error({ err, feedInfo }, 'Unable to add job to queue');
+  }
+};
 
 module.exports = queue;

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -1,33 +1,50 @@
-const { parse } = require('feedparser-promised');
+const { cpus } = require('os');
+const path = require('path');
 
 const feedQueue = require('./queue');
 const { logger } = require('../utils/logger');
 const Post = require('../post');
 
-exports.workerCallback = async function(job) {
-  const { url } = job.data;
-  let articles;
+/**
+ * We determine the number of parallel feed processor functions to run
+ * based on the value of the environment variable FEED_QUEUE_PARALLEL_WORKERS.
+ * Possible values are:
+ *
+ *  *: use the number of available CPUs
+ *  <a Number>: use the given number, up to the number of available CPUs
+ *  <not set>: use 1 by default
+ */
+function getFeedWorkersCount() {
+  const { FEED_QUEUE_PARALLEL_WORKERS } = process.env;
+  const cpuCount = cpus().length;
 
-  try {
-    articles = await parse(url);
-  } catch (err) {
-    logger.error({ err }, `Unable to process feed ${url}`);
-    throw err;
+  if (FEED_QUEUE_PARALLEL_WORKERS === '*') {
+    return cpuCount;
   }
 
-  return articles.map(article => Post.fromArticle(article));
-};
+  const count = Number(FEED_QUEUE_PARALLEL_WORKERS);
+  if (typeof count === 'number') {
+    return Math.min(count, cpuCount);
+  }
 
-exports.start = async function() {
-  // Start processing jobs from the feed queue...
-  feedQueue.process(exports.workerCallback);
+  return 1;
+}
+
+exports.start = function() {
+  const concurrency = getFeedWorkersCount();
+  logger.info(`Starting ${concurrency} instance${concurrency > 1 ? 's' : ''} of feed processor.`);
+  feedQueue.process(concurrency, path.resolve(__dirname, 'processor.js'));
 
   // When posts are returned from the queue, save them to the database
   feedQueue.on('completed', async (job, posts) => {
     try {
-      await Promise.all(posts.map(post => post.save()));
+      // The posts we get back will be Objects, and we need to convert
+      // to a full Post, then save to Redis.
+      await Promise.all(posts.map(post => Post.parse(post).save()));
     } catch (err) {
       logger.error({ err }, 'Error inserting posts into database');
     }
   });
+
+  return feedQueue;
 };

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,7 +1,7 @@
 require('./lib/config.js');
 const feedQueue = require('./feed/queue');
 const feedWorker = require('./feed/worker');
-const { logger: log } = require('./utils/logger');
+const { logger } = require('./utils/logger');
 const wikiFeed = require('./utils/wiki-feed-parser');
 const shutdown = require('./lib/shutdown');
 
@@ -19,30 +19,58 @@ process.on('unhandledRejection', shutdown('UNHANDLED REJECTION'));
 process.on('uncaughtException', shutdown('UNCAUGHT EXCEPTION'));
 
 /**
+ * Add a feed URL job to the queue. It may fail, if there is already
+ * a job in the queue with the same URL.
+ */
+async function addFeedJob(feedInfo) {
+  const options = {
+    // Use the feed URL as the job key, so we don't double add it.
+    // Bull will not add a job there already exists a job with the same id.
+    id: feedInfo.url,
+    attempts: process.env.FEED_QUEUE_ATTEMPTS || 2,
+    backoff: {
+      type: 'exponential',
+      delay: process.env.FEED_QUEUE_DELAY_MS || 30 * 1000,
+    },
+    removeOnComplete: true,
+    removeOnFail: true,
+  };
+
+  try {
+    feedQueue.add(feedInfo, options);
+  } catch (err) {
+    logger.error({ err }, 'Unable to add job to queue');
+  }
+}
+
+/**
  * Adds feed URL jobs to the feed queue for processing
  * @param {Array[Object]} feedJobs - list of feed URL jobs to be processed
  */
 async function enqueueWikiFeed() {
-  const data = await wikiFeed.parseData();
-  await Promise.all(
-    data.map(feedJob =>
-      feedQueue.add(feedJob, {
-        attempts: process.env.FEED_QUEUE_ATTEMPTS || 8,
-        backoff: {
-          type: 'exponential',
-          delay: process.env.FEED_QUEUE_DELAY_MS || 60 * 1000,
-        },
-        removeOnComplete: true,
-        removeOnFail: true,
-      })
-    )
-  ).catch(err => log.error({ err }, 'Error queuing wiki feeds'));
+  try {
+    const data = await wikiFeed.parseData();
+    await Promise.all(data.map(feedInfo => addFeedJob(feedInfo)));
+  } catch (err) {
+    logger.error({ err }, 'Error queuing wiki feeds');
+  }
 }
 
-enqueueWikiFeed()
-  .then(() => {
-    feedWorker.start();
-  })
-  .catch(error => {
-    log.error({ error }, 'Unable to enqueue wiki feeds');
+function loadFeedsIntoQueue() {
+  logger.info('Loading all feeds into feed queue for processing');
+  enqueueWikiFeed().catch(error => {
+    logger.error({ error }, 'Unable to enqueue wiki feeds');
   });
+}
+
+/**
+ * When the feed queue is drained (all feeds are processed in the queue),
+ * restart the process again, and repeat forever.
+ */
+feedQueue.on('drained', loadFeedsIntoQueue);
+
+/**
+ * Also load all feeds now and begin processing.
+ */
+loadFeedsIntoQueue();
+feedWorker.start();

--- a/test/feed-processor.test.js
+++ b/test/feed-processor.test.js
@@ -1,44 +1,44 @@
 const fixtures = require('./fixtures');
-const feedWorker = require('../src/backend/feed/worker');
+const processor = require('../src/backend/feed/processor');
 
 test('Passing a valid Atom feed URI should pass', async () => {
   const feedURL = fixtures.getAtomUri();
   fixtures.nockValidAtomResponse();
   const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(feedWorker.workerCallback(job)).resolves.toBeTruthy();
+  await expect(processor(job)).resolves.toBeTruthy();
 });
 
 test('Passing a valid RSS feed URI should pass', async () => {
   const feedURL = fixtures.getRssUri();
   fixtures.nockValidRssResponse();
   const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(feedWorker.workerCallback(job)).resolves.toBeTruthy();
+  await expect(processor(job)).resolves.toBeTruthy();
 });
 
 test('Passing a valid URI, but not a feed URI should error', async () => {
   const url = fixtures.getHtmlUri();
   fixtures.nockValidHtmlResponse();
   const job = fixtures.createMockJobObjectFromURL(url);
-  await expect(feedWorker.workerCallback(job)).rejects.toThrow();
+  await expect(processor(job)).rejects.toThrow();
 });
 
 test('Passing an invalid RSS category feed should pass', async () => {
   const feedURL = fixtures.getRssUri();
   fixtures.nockInvalidRssResponse();
   const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(feedWorker.workerCallback(job)).resolves.toBeTruthy();
+  await expect(processor(job)).resolves.toBeTruthy();
 });
 
 test('Passing a valid RSS category feed should pass', async () => {
   const feedURL = fixtures.getRssUri();
   fixtures.nockValidRssResponse();
   const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(feedWorker.workerCallback(job)).resolves.toBeTruthy();
+  await expect(processor(job)).resolves.toBeTruthy();
 });
 
 test('Non existent feed failure case: 404 should error', async () => {
   const url = fixtures.getHtmlUri();
   fixtures.nock404Response();
   const job = fixtures.createMockJobObjectFromURL(url);
-  await expect(feedWorker.workerCallback(job)).rejects.toThrow();
+  await expect(processor(job)).rejects.toThrow();
 });

--- a/tools/add-feed.js
+++ b/tools/add-feed.js
@@ -27,10 +27,10 @@ async function add() {
 
   await feedQueue
     .add(feed, {
-      attempts: process.env.FEED_QUEUE_ATTEMPTS || 8,
+      attempts: process.env.FEED_QUEUE_ATTEMPTS || 2,
       backoff: {
         type: 'exponential',
-        delay: process.env.FEED_QUEUE_DELAY_MS || 60 * 1000,
+        delay: process.env.FEED_QUEUE_DELAY_MS || 30 * 1000,
       },
       removeOnComplete: true,
       removeOnFail: true,

--- a/tools/add-feed.js
+++ b/tools/add-feed.js
@@ -23,22 +23,13 @@ async function add() {
     process.exit(1);
   }
 
-  const feed = { name, url };
+  const feedInfo = { name, url };
 
-  await feedQueue
-    .add(feed, {
-      attempts: process.env.FEED_QUEUE_ATTEMPTS || 2,
-      backoff: {
-        type: 'exponential',
-        delay: process.env.FEED_QUEUE_DELAY_MS || 30 * 1000,
-      },
-      removeOnComplete: true,
-      removeOnFail: true,
-    })
-    .catch(err => {
-      log.error({ err }, 'Error enqueuing feed');
-      process.exit(1);
-    });
-  process.exit(0);
+  try {
+    await feedQueue.addFeed(feedInfo);
+    process.exit(0);
+  } catch (err) {
+    process.exit(1);
+  }
 }
 add();


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #503

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR improves our feed parser.  Specifically, it makes it run forever, continually downloading the feeds and parsing them into Redis.  It also allows for parallelization, so we can run multiple instances of our feed worker in different processes.

In order to make this work, I've also done a few other things:

- Moved the feed parsing to its own file, `src/backend/feed/processor.js`, so that we can run it in a separate process or processes
- Altered our retry attempts and delay timing when feeds fail.  What I have still isn't quite right, but what we had before was way to extreme, and the queue would back-up with failed jobs
- Added a new `env` variable: `FEED_QUEUE_PARALLEL_WORKERS`.  This is the number of parallel worker instances to run in separate processes, and can be 1, 2, 3... up to `*`, which means "one per CPU."  I cap this at the CPU count so it doesn't bring the server down.
- I've started passing HTTP options to `request` via the feedparser `parse` function.  I wanted to shorten the timeout length, so dead blogs don't block a worker for so long.  I've also enabled gzip, which makes things faster.
- I've used the `drained` event on the feed queue to trigger another round of updates.  Whenever we finish processing one set of feeds, and `drained` occurs, we'll start over.  This is our infinite loop.
- I've changed the `job.id` to be the feed URL instead of an auto-incrementing integer.  This allows some extra logic so that multiple jobs for the same feed don't get added to the queue (Bull will reject attempts to add the same job/URL more than once).

This is only the beginning of this work.  We can do a bunch more to improve things, especially with blacklisting blogs that fail over and over, adding cache headers so we don't re-process feeds that haven't changed since the last time we updated, etc.  But for now, this will get us a server that does what we expect: auto update in an infinite loop.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
