### PR TITLE
Fixes #122: add logging to inform user of Redis connection failure

### DIFF
--- a/src/backend/lib/queue.js
+++ b/src/backend/lib/queue.js
@@ -9,7 +9,11 @@ const { logger } = require('../utils/logger');
 
 const client = createRedisClient();
 const subscriber = createRedisClient();
-let redisErrorLogged = false;
+
+/**
+ * Tracks whether an informative message has been logged following a Redis connection failure
+ */
+let redisConnectionRefusalLogged = false;
 
 /**
  * Create a Queue with the given `name` (String).
@@ -32,15 +36,13 @@ function createQueue(name) {
   })
     .on('error', err => {
       // An error occurred
-      if (err.code === 'ECONNREFUSED') {
-        if (!redisErrorLogged) {
-          logger.error(
-            '\n\n\t💡  It appears that Redis is not running on your machine.',
-            '\n\t   Please see our documentation for how to install and run Redis:',
-            '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'
-          );
-          redisErrorLogged = true;
-        }
+      if (err.code === 'ECONNREFUSED' && !redisConnectionRefusalLogged) {
+        logger.error(
+          '\n\n\t💡  It appears that Redis is not running on your machine.',
+          '\n\t   Please see our documentation for how to install and run Redis:',
+          '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'
+        );
+        redisConnectionRefusalLogged = true;
       } else {
         logger.error({ err }, `Queue ${name} error`);
       }

--- a/src/backend/lib/queue.js
+++ b/src/backend/lib/queue.js
@@ -32,7 +32,7 @@ function createQueue(name) {
     .on('error', err => {
       // An error occurred
       if (err.code === 'ECONNREFUSED') {
-        logger.info(
+        logger.error(
           '\n\n\t💡  It appears that Redis is not running on your machine.',
           '\n\t   Please see our documentation for how to install and run Redis:',
           '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'

--- a/src/backend/lib/queue.js
+++ b/src/backend/lib/queue.js
@@ -9,6 +9,7 @@ const { logger } = require('../utils/logger');
 
 const client = createRedisClient();
 const subscriber = createRedisClient();
+let redisErrorLogged = false;
 
 /**
  * Create a Queue with the given `name` (String).
@@ -32,11 +33,14 @@ function createQueue(name) {
     .on('error', err => {
       // An error occurred
       if (err.code === 'ECONNREFUSED') {
-        logger.error(
-          '\n\n\t💡  It appears that Redis is not running on your machine.',
-          '\n\t   Please see our documentation for how to install and run Redis:',
-          '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'
-        );
+        if (!redisErrorLogged) {
+          logger.error(
+            '\n\n\t💡  It appears that Redis is not running on your machine.',
+            '\n\t   Please see our documentation for how to install and run Redis:',
+            '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'
+          );
+          redisErrorLogged = true;
+        }
       } else {
         logger.error({ err }, `Queue ${name} error`);
       }

--- a/src/backend/lib/queue.js
+++ b/src/backend/lib/queue.js
@@ -31,7 +31,15 @@ function createQueue(name) {
   })
     .on('error', err => {
       // An error occurred
-      logger.error({ err }, `Queue ${name} error`);
+      if (err.code === 'ECONNREFUSED') {
+        logger.info(
+          '\n\n\t💡  It appears that Redis is not running on your machine.',
+          '\n\t   Please see our documentation for how to install and run Redis:',
+          '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'
+        );
+      } else {
+        logger.error({ err }, `Queue ${name} error`);
+      }
     })
     .on('waiting', jobID => {
       // A job is waiting for the next idling worker


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #122

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

As suggested in https://github.com/Seneca-CDOT/telescope/issues/48#issuecomment-550079621, added logic to handle 'ECONNREFUSED' errors within the Bull queue: 'ECONNREFUSED' are now logged an informative blurb instead of a stack trace.

https://github.com/Silvyre/telescope/blob/818ba4c9404f2cd5f2a70b7826a3650f1c215587/src/backend/lib/queue.js#L32-L43

<img width="611" alt="Redis error" src="https://user-images.githubusercontent.com/13500769/72688762-67f9ea00-3ad8-11ea-8c3d-5a0f8df2a130.png">



## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
