### PR TITLE
Fix logic for picking FEED_QUEUE_PARALLEL_WORKERS with missing env var

### DIFF
--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -22,12 +22,8 @@ function getFeedWorkersCount() {
     return cpuCount;
   }
 
-  const count = Number(FEED_QUEUE_PARALLEL_WORKERS);
-  if (typeof count === 'number') {
-    return Math.min(count, cpuCount);
-  }
-
-  return 1;
+  const count = Number(FEED_QUEUE_PARALLEL_WORKERS) || 1;
+  return Math.min(count, cpuCount);
 }
 
 exports.start = function() {


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This fixes a bug introduced with https://github.com/Seneca-CDOT/telescope/pull/547.  Specifically, if the `env` doesn't have `FEED_QUEUE_PARALLEL_WORKERS` set, it won't start any processor functions to deal with posts, and Redis won't have anything in it.

To test this, try starting the server with various `env` settings:

- Nothing set: `#FEED_QUEUE_PARALLEL_WORKERS`
- 1 Worker Process: `FEED_QUEUE_PARALLEL_WORKERS=1`
- 2 Worker Processes: `FEED_QUEUE_PARALLEL_WORKERS=2`
- As many Worker Processes as CPUs: `FEED_QUEUE_PARALLEL_WORKERS=*`

When the server starts, it will log out the number of parallel workers it is using, and it should match what you set in the env:

```
[ 2020-01-20 21:10:45.787 ] INFO  (42097 on brightness.local): Starting 4 instances of feed processor.
```
