### PR TITLE
Reduce eslint Promise warnings, refactor wiki parser

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -2,7 +2,7 @@ require('./lib/config.js');
 const feedQueue = require('./feed/queue');
 const feedWorker = require('./feed/worker');
 const { logger } = require('./utils/logger');
-const wikiFeed = require('./utils/wiki-feed-parser');
+const getWikiFeeds = require('./utils/wiki-feed-parser');
 const shutdown = require('./lib/shutdown');
 
 // Start the web server
@@ -24,7 +24,7 @@ process.on('uncaughtException', shutdown('UNCAUGHT EXCEPTION'));
  */
 async function enqueueWikiFeed() {
   try {
-    const data = await wikiFeed.parseData();
+    const data = await getWikiFeeds();
     await Promise.all(data.map(feedInfo => feedQueue.addFeed(feedInfo)));
   } catch (err) {
     logger.error({ err }, 'Error queuing wiki feeds');

--- a/src/backend/lib/shutdown.js
+++ b/src/backend/lib/shutdown.js
@@ -6,24 +6,32 @@ const server = require('../web/server');
 
 let isShuttingDown = false;
 
-function stopQueue() {
-  return feedQueue
-    .close()
-    .then(() => logger.info('Feed queue shut down.'))
-    .catch(err => logger.error({ err }, 'Unable to close feed queue gracefully'));
+async function stopQueue() {
+  try {
+    await feedQueue.close();
+    logger.info('Feed queue shut down.');
+  } catch (error) {
+    logger.error({ error }, 'Unable to close feed queue gracefully');
+  }
 }
 
-function stopWebServer() {
+async function stopWebServer() {
   const serverClose = promisify(server.close.bind(server));
-  return serverClose()
-    .then(() => logger.info('Web server shut down.'))
-    .catch(err => logger.error({ err }, 'Unable to close web server gracefully'));
+  try {
+    await serverClose();
+    logger.info('Web server shut down.');
+  } catch (error) {
+    logger.error({ error }, 'Unable to close web server gracefully');
+  }
 }
 
-function cleanShutdown() {
-  return Promise.all([stopQueue(), stopWebServer()])
-    .then(() => logger.info('Completing shut down.'))
-    .catch(err => logger.error({ err }, 'Failed to perform clean shutdown'));
+async function cleanShutdown() {
+  try {
+    await Promise.all([stopQueue(), stopWebServer()]);
+    logger.info('Completing shut down.');
+  } catch (error) {
+    logger.error({ error }, 'Failed to perform clean shutdown');
+  }
 }
 
 function shutdown(signal) {

--- a/test/wiki-feed-parser.test.js
+++ b/test/wiki-feed-parser.test.js
@@ -1,4 +1,4 @@
-const parser = require('../src/backend/utils/wiki-feed-parser');
+const getWikiFeeds = require('../src/backend/utils/wiki-feed-parser');
 global.fetch = require('node-fetch');
 
 const mockFeed = `################# Failing Feeds Commented Out [Start] #################
@@ -41,31 +41,6 @@ beforeEach(() => {
   fetch.resetMocks();
 });
 
-test('Testing wiki-feed-parser.getData with pre tag', async () => {
-  const mockBody = `<html><pre>${mockFeed}</pre></html>`;
-  fetch.mockResponseOnce(mockBody);
-
-  const response = await parser.getData();
-  expect(response).toStrictEqual(mockFeed.split('\n'));
-});
-
-test('Testing wiki-feed-parser.getData with no pre tag', async () => {
-  const mockBody = `<html>${mockFeed}</html>`;
-
-  fetch.mockResponseOnce(mockBody);
-
-  await parser.getData().catch(err => {
-    expect(err).toStrictEqual(noPreErr);
-  });
-});
-
-test('Testing wiki-feed-parser.getData when fetch fails', async () => {
-  fetch.mockReject(new Error('fake error message'));
-  await parser.getData().catch(err => {
-    expect(err).toStrictEqual(Error('fake error message'));
-  });
-});
-
 test('Testing wiki-feed-parser.parseData', async () => {
   const mockBody = `<html><pre>${mockFeed}</pre></html>`;
   fetch.mockResponseOnce(mockBody);
@@ -82,7 +57,7 @@ test('Testing wiki-feed-parser.parseData', async () => {
       url: 'http://armenzg.blogspot.com/feeds/posts/default/-/open%20source',
     },
   ];
-  const response = await parser.parseData();
+  const response = await getWikiFeeds();
   expect(response).toStrictEqual(expectedData);
 });
 
@@ -90,7 +65,7 @@ test('Testing wiki-feed-parser.parseData when getData fails with no pre tag', as
   const mockBody = `<html>${mockFeed}</html>`;
   fetch.mockResponseOnce(mockBody);
 
-  await parser.parseData().catch(err => {
+  await getWikiFeeds().catch(err => {
     expect(err).toStrictEqual(noPreErr);
   });
 });


### PR DESCRIPTION
## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This is follow-up to the work done to add eslint for Promises and async/await.  I've reduced the warnings we get down to 1.  Do do it, I made the following changes:

- switched to async/await in the shutdown code
- rewrote the wiki-feed-parser to use async/await
- refactored the wiki-feed-parser so that it doesn't expose the `getData()` function anymore.  There is no need to expose this.  I've also removed the tests for this.  The other tests we have already run that code.

There is still one warning:

```
/Users/humphd/repos/telescope/src/backend/utils/email-sender.js
  67:22  warning  Avoid callbacks. Prefer Async/Await  promise/prefer-await-to-callbacks
```

My guess is we'll rip this code out soon, so I didn't bother fighting with it.
