### PR TITLE
Use Let's Encrypt for certs on staging 

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,6 +3,7 @@ NODE_ENV=development
 
 # PORT is the port used by the web server
 PORT=3000
+HTTPS=4443
 
 # LOG_LEVEL is used to set the level of debugging for the logs.
 # info, error and debug are commonly used levels. See http://getpino.io/#/docs/api?id=level for more info on levels.

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "express-session": "1.17.0",
     "feedparser-promised": "2.0.1",
     "get-urls": "9.2.0",
+    "helmet": "3.21.2",
     "ioredis": "4.14.1",
     "ioredis-mock": "4.18.4",
     "jsdom": "15.2.1",

--- a/src/backend/web/app.js
+++ b/src/backend/web/app.js
@@ -4,6 +4,7 @@ const expressHandlebars = require('express-handlebars');
 const healthcheck = require('express-healthcheck');
 const cors = require('cors');
 const { ApolloServer } = require('apollo-server-express');
+const helmet = require('helmet');
 
 const logger = require('../utils/logger');
 const router = require('./routes');
@@ -29,7 +30,11 @@ app.set('view engine', 'handlebars');
 app.set('logger', logger);
 app.use(logger);
 
+app.use(express.static(`${__dirname}/static`, { dotfiles: 'allow' }));
+
 app.use(cors());
+
+app.use(helmet());
 
 app.use('/health', healthcheck());
 

--- a/src/backend/web/server.js
+++ b/src/backend/web/server.js
@@ -1,11 +1,30 @@
 require('../lib/config');
+const https = require('https');
+const fs = require('fs');
+
 const app = require('./app.js');
 
 const { logger } = app.get('logger');
 const HTTP_PORT = process.env.PORT || 3000;
+const HTTPS_PORT = process.env.HTTPS_PORT || 4443;
+
+const { key, cert } = (() => {
+  const certdir = fs
+    .readdirSync('/etc/letsencrypt/live', { withFileTypes: true })
+    .filter(file => file.isDirectory())[0].name;
+
+  return {
+    key: fs.readFileSync(`/etc/letsencrypt/live/${certdir}/privkey.pem`),
+    cert: fs.readFileSync(`/etc/letsencrypt/live/${certdir}/fullchain.pem`),
+  };
+})();
 
 const server = app.listen(HTTP_PORT, () => {
   logger.info(`Telescope listening on port ${HTTP_PORT}`);
 });
+
+https
+  .createServer({ key, cert }, app)
+  .listen(HTTPS_PORT, () => console.log(`HTTPS server listening on ${HTTPS_PORT}`));
 
 module.exports = server;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

closes #519 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

Ok so this should add ssl to telescope on the specified port. I've beenr eading a few guides and most of them keep port 80 open and the redirect any connection to the ssl server. I have not included this as we have not had a discussion as to what we would like to do with http (shut it down or simply redirect), but apparently the usualy thing to do is redirect any http connections to https and keep both servers running.

In order to get the certificate the first time, letsencrypt asks for the domain name of the machine running the server and attempts to fetch a static file with a random generated name and content. To serve this file, adding the `app.use(express.static(`${__dirname}/static`, { dotfiles: 'allow' }));
` line in server.js is needed. I am not sure if we need to do this for the auto-renewal so I've left the line in just in case. We can get rid of it in the future if needed. 

letsencrypt certs expire every 90 days. We can automate this using a crone job as such:
`0 */12 * * * <user/root> path/to/certbot/bin renew >/dev/null 2>&1` 
The above says ‘run it every 12 hours, every day: at 00:00 and at 12:00’.

These are the guides I used for reference:

https://advancedweb.hu/how-to-use-lets-encrypt-with-node-js-and-express/#scenario-3-http-redirect-with-a-public-folder

https://flaviocopes.com/express-letsencrypt-ssl/#setup-the-renewal

https://medium.com/@yash.kulshrestha/using-lets-encrypt-with-express-e069c7abe625

![image](https://user-images.githubusercontent.com/32024054/72847823-51d36180-3c71-11ea-973f-eae4f19593c0.png)
