### PR TITLE
fix #451 testing certs for windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,13 @@ before_install:
       redis-server --daemonize yes
       redis-cli info
     else
-      # TODO: need script for Windows to generate SSL certs...
       # Install Redis
       choco install redis-64 -v
+      # Install Open SSL to run Scripts
+      choco install openssl.light
+      # Make certs folder if it doesn't exist.
+      mkdir -p certs
+      ./tools/generate-ssl-certs.sh
       redis-server --service-install
       redis-server --service-start
       redis-cli info
@@ -45,7 +49,3 @@ before_install:
 script:
   - npm run test-ci
 matrix:
-  allow_failures:
-    # Windows can fail if choco can't download redis
-    # https://github.com/Seneca-CDOT/telescope/issues/387
-    - os: windows


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

#451  fixed for windows certs. 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This installs openssl on our travis CI, and then runs a shell script that should generate the scripts needed to create our own certificates.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


Travis CI is run on the github repository, so it will be using the travis ci build here to do the testing.