### PR TITLE
Make post.text a dynamic getter instead of storing

### DIFF
--- a/src/backend/data/post.js
+++ b/src/backend/data/post.js
@@ -12,13 +12,12 @@ function toDate(date) {
 }
 
 class Post {
-  constructor(author, title, html, text, datePublished, dateUpdated, postUrl, siteUrl, guid) {
+  constructor(author, title, html, datePublished, dateUpdated, postUrl, siteUrl, guid) {
     // Use the post's guid as our unique identifier
     this.id = hash(guid);
     this.author = author;
     this.title = title;
     this.html = html;
-    this.text = text;
     this.published = datePublished ? toDate(datePublished) : new Date();
     this.updated = dateUpdated ? toDate(dateUpdated) : new Date();
     this.url = postUrl;
@@ -32,6 +31,13 @@ class Post {
    */
   save() {
     addPost(this);
+  }
+
+  /**
+   * Generate the plain text version of this post on demand vs. storing
+   */
+  get text() {
+    return textParser(this.html);
   }
 
   /**
@@ -80,13 +86,10 @@ class Post {
     }
 
     let sanitizedHTML;
-    let plainText;
     try {
       // The article.description is frequently the full HTML article content.
       // Sanitize it of any scripts or other dangerous attributes/elements
       sanitizedHTML = sanitizeHTML(article.description);
-      // Also generate plain text from the sanitized HTML
-      plainText = textParser(sanitizedHTML);
     } catch (error) {
       logger.error({ error }, 'Unable to sanitize and parse HTML for feed');
       throw error;
@@ -99,8 +102,6 @@ class Post {
       article.title,
       // sanitized HTML version of the post
       sanitizedHTML,
-      // plain text version of the post
-      plainText,
       // pubdate (original published date)
       article.pubdate,
       // date (most recent update)
@@ -118,17 +119,7 @@ class Post {
    * @param {Object} o - an Object containing the necessary fields
    */
   static parse(o) {
-    return new Post(
-      o.author,
-      o.title,
-      o.html,
-      o.text,
-      o.published,
-      o.updated,
-      o.url,
-      o.site,
-      o.guid
-    );
+    return new Post(o.author, o.title, o.html, o.published, o.updated, o.url, o.site, o.guid);
   }
 
   /**

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -52,8 +52,6 @@ module.exports = {
         post.title,
         'html',
         post.html,
-        'text',
-        post.text,
         'published',
         post.published,
         'updated',

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -5,11 +5,12 @@ const Post = require('../src/backend/data/post');
 const hash = require('../src/backend/data/hash');
 
 describe('Post data class tests', () => {
+  const text = 'post text';
+
   const data = {
     author: 'Post Author',
     title: 'Post Title',
     html: '<p>post text</p>',
-    text: 'post text',
     published: new Date('Thu, 20 Nov 2014 18:59:18 UTC'),
     updated: new Date('Thu, 20 Nov 2014 18:59:18 UTC'),
     url: 'https://user.post.com/?post-id=123',
@@ -23,7 +24,6 @@ describe('Post data class tests', () => {
       data.author,
       data.title,
       data.html,
-      data.text,
       data.published,
       data.updated,
       data.url,
@@ -41,6 +41,14 @@ describe('Post data class tests', () => {
 
   test('Post.parse() should be able to parse an Object into a Post', () => {
     expect(Post.parse(data)).toEqual(createPost());
+  });
+
+  test('Posts should have a (dynamic) text property', () => {
+    const post1 = Post.parse(data);
+    const post2 = createPost();
+
+    expect(post1.text).toEqual(text);
+    expect(post2.text).toEqual(text);
   });
 
   test('Post.parse() should work with missing fields', () => {

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -17,11 +17,10 @@ describe('test /posts endpoint', () => {
     return {
       id,
       guid,
-      author: 'foo',
-      title: 'foo',
-      link: 'foo',
-      content: 'foo',
-      text: 'foo',
+      author: 'author',
+      title: 'title',
+      link: 'link',
+      html: 'html',
       updated: new Date('2009-09-07T22:23:00.544Z'),
       published: new Date('2009-09-07T22:20:00.000Z'),
       url: 'foo',
@@ -62,34 +61,32 @@ describe('test /posts endpoint', () => {
   });
 });
 
-describe('test /posts/:guid responses', () => {
+describe('test /posts/:id responses', () => {
   // an array of keys.
   const existingGuid = 'http://existing-guid';
   const missingGuid = 'http://missing-guid';
 
-  // an object to be added for testing purposes
+  // Post Object
   const addedPost1 = new Post(
-    'foo',
-    'foo',
-    '',
-    'foo',
+    'author',
+    'title',
+    'html',
     new Date('2009-09-07T22:20:00.000Z'),
     new Date('2009-09-07T22:23:00.000Z'),
-    'foo',
-    'foo',
+    'url',
+    'site',
     existingGuid
   );
 
-  // an object, expected to be returned by a correct query
+  // Raw JS Object, expected to be returned by a correct query
   const receivedPost1 = {
-    author: 'foo',
-    title: 'foo',
-    html: '',
-    text: 'foo',
+    author: 'author',
+    title: 'title',
+    html: 'html',
     published: '2009-09-07T22:20:00.000Z',
     updated: '2009-09-07T22:23:00.000Z',
-    url: 'foo',
-    site: 'foo',
+    url: 'url',
+    site: 'site',
     guid: 'http://existing-guid',
     id: hash('http://existing-guid'),
   };


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR modifies a `Post` Object's `text` property from being a static member to a dynamic getter.  In other words, we'll only generate `.text` on demand, and don't need to store it in Redis.  This will save us a bunch of duplication in the database.

This change will require flushing Redis, so we get rid of the `text` field in our `Post` hash:

```
redis-cli flushall
```

This doesn't affect our GraphQL code at all, it still works as before.  For the HTTP route, once #443 is finished, we can update to have that be the preferred way to get plain text over HTTP.  cc @yatsenko-julia .

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
