### PR TITLE
Use ETag and Last-Modified headers to cache feeds

### DIFF
--- a/src/backend/data/feed.js
+++ b/src/backend/data/feed.js
@@ -6,11 +6,20 @@ const hash = require('./hash');
 const urlToId = url => hash(normalizeUrl(url));
 
 class Feed {
-  constructor(author, url) {
+  constructor(author, url, etag, lastModified) {
+    if (!url) {
+      throw new Error('missing url for feed');
+    }
+    if (!author) {
+      throw new Error('missing author for feed');
+    }
     // Use the feed's normalized url as our unique identifier
     this.id = urlToId(url);
     this.author = author;
     this.url = url;
+    // We may or may not have these cache values when we create a feed.
+    this.etag = etag === '' ? null : etag;
+    this.lastModified = lastModified === '' ? null : lastModified;
   }
 
   /**
@@ -26,7 +35,7 @@ class Feed {
    * @param {Object} o - an Object containing the necessary fields for a feed
    */
   static parse(o) {
-    return new Feed(o.author, o.url);
+    return new Feed(o.author, o.url, o.etag, o.lastModified);
   }
 
   /**

--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -5,27 +5,163 @@
  */
 
 const { parse } = require('feedparser-promised');
+const fetch = require('node-fetch');
 
 const { logger } = require('../utils/logger');
 const Post = require('../data/post');
+const Feed = require('../data/feed');
 
-module.exports = async function processor(job) {
-  const { url } = job.data;
-  const httpOptions = {
-    url,
-    // ms to wait for a connection to be assumed to have failed
-    timeout: 20 * 1000,
-    gzip: true,
+// Check for cached ETag and Last-Modified info on the feed.
+function hasHeaders(feed) {
+  return feed.etag || feed.lastModified;
+}
+
+/**
+ * If we have extra cache/modification info about this feed, add it to the headers.
+ * @param {Feed} feed - the feed Object, possibly with etag and lastModified info
+ */
+function addHeaders(options, feed) {
+  // If there aren't any cached headers for this feed, return options unmodified
+  if (!hasHeaders(feed)) {
+    return options;
+  }
+
+  // Add conditional headers as appropriate for this feed
+  options.headers = {};
+  if (feed.etag) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
+    options.headers['If-None-Match'] = feed.etag;
+  }
+  if (feed.lastModified) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
+    options.headers['If-Modified-Since'] = feed.lastModified;
+  }
+
+  return options;
+}
+
+/**
+ * Get information about the resource at the other end of this feed's url.
+ * Specifically, we care about ETag and Last-Modified headers, Content-Type,
+ * and whether or not we should try to download it.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests
+ */
+async function getFeedInfo(feed) {
+  const info = {
+    status: null,
+    etag: null,
+    lastModified: null,
+    contentType: null,
+    shouldDownload: true,
   };
-  let articles;
 
+  let response;
   try {
-    articles = await parse(httpOptions);
+    // Do a HEAD request, and see what the current version info for this URL is
+    response = await fetch(feed.url, addHeaders({ method: 'HEAD' }, feed));
+    info.status = `[HTTP ${response.status} - ${response.statusText}]`;
+    info.contentType = response.headers.get('Content-Type');
   } catch (error) {
-    logger.error({ error }, `Unable to process feed ${url}`);
+    logger.error({ error }, `Unable to fetch HEAD info for feed ${feed.url}`);
     throw error;
   }
 
-  // Transform the list of articles to a list of Post objects
-  return articles.map(article => Post.fromArticle(article));
+  // We didn't get a 200 after adding the conditional headers, stop now.
+  if (!(response && response.ok)) {
+    info.shouldDownload = false;
+    return info;
+  }
+
+  // Resource version identifier (e.g., W/"ae1acbdfe7ece35f8651d741fcf94465"),
+  // unique to the contents of the URL (it if changes, the ETag changes).
+  // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+  const etag = response.headers.get('ETag');
+  if (etag) {
+    info.etag = etag;
+  }
+
+  // Date and Time the server thinks this resource was last modified
+  // (e.g., Mon, 16 Dec 2019 14:15:47 GMT).  This may or may not be
+  // the actual date/time it was modified. The ETag is more accurate. See:
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified)
+  const lastModified = response.headers.get('Last-Modified');
+  if (lastModified) {
+    info.lastModified = lastModified;
+  }
+
+  return info;
+}
+
+module.exports = async function processor(job) {
+  const feed = Feed.parse(job.data);
+  let articles;
+  let info;
+
+  try {
+    info = await getFeedInfo(feed);
+    // If we get no new version info, there's nothing left to do.
+    if (!info.shouldDownload) {
+      // Log some common cases we see, with a general message if none of these
+      switch (info.status) {
+        case 304:
+          logger.debug(`${info.status} Feed is up-to-date: ${feed.url}`);
+          break;
+        case 404:
+          logger.warn(`${info.status} Feed not found: ${feed.url}`);
+          break;
+        case 410:
+          logger.warn(`${info.status} Feed no longer available: ${feed.url}`);
+          break;
+        case 429:
+          logger.warn(`${info.status} Feed requested too many times: ${feed.url}`);
+          break;
+        case 500:
+        case 599:
+          logger.warn(`${info.status} Feed server error: ${feed.url}`);
+          break;
+        default:
+          logger.debug(`${info.status} Feed not downloaded: ${feed.url}`);
+          break;
+      }
+
+      // No posts were processed, return an empty list.
+      return [];
+    }
+
+    // Download the updated feed contents
+    logger.debug(`${info.status} Feed has new content: ${feed.url}`);
+    articles = await parse(
+      addHeaders(
+        {
+          url: feed.url,
+          // ms to wait for a connection to be assumed to have failed
+          timeout: 20 * 1000,
+          gzip: true,
+        },
+        feed
+      )
+    );
+    // Transform the list of articles to a list of Post objects
+    articles = articles.map(article => Post.fromArticle(article));
+
+    // Version info for this feed changed, so update the database
+    feed.etag = feed.etag || info.etag;
+    feed.lastModified = feed.lastModified || info.lastModified;
+    await feed.save();
+  } catch (error) {
+    // If the feedparser can't parse this, we get a 'Not a feed' error
+    if (error.message === 'Not a feed') {
+      logger.info(
+        `Skipping resource at ${feed.url}, not a valid feed ${
+          info.contentType ? `(${info.contentType})` : ''
+        }`
+      );
+      articles = [];
+    } else {
+      logger.error({ error }, `Unable to process feed ${feed.url}`);
+      throw error;
+    }
+  }
+
+  return articles;
 };

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -4,6 +4,7 @@ const feedWorker = require('./feed/worker');
 const { logger } = require('./utils/logger');
 const getWikiFeeds = require('./utils/wiki-feed-parser');
 const shutdown = require('./lib/shutdown');
+const Feed = require('./data/feed');
 
 // Start the web server
 require('./web/server');
@@ -19,24 +20,54 @@ process.on('unhandledRejection', shutdown('UNHANDLED REJECTION'));
 process.on('uncaughtException', shutdown('UNCAUGHT EXCEPTION'));
 
 /**
- * Adds feed URL jobs to the feed queue for processing
- * @param {Array[Object]} feedJobs - list of feed URL jobs to be processed
+ * Adds the feed to the database if necessary, or gets a more complete
+ * version of the feed if we have better data already.
+ * @param {Feed} feed - a feed Object parsed from the wiki feed list.
+ * Returns the most appropriate Feed Object to use.
  */
-async function enqueueWikiFeed() {
+async function updateFeed(feed) {
+  let currentFeed;
+
+  // If we have an existing feed in the database for this id, prefer that,
+  // since it might have updated cache info (e.g., etag)
+  const existingFeed = await Feed.byId(feed.id);
+  if (existingFeed) {
+    // We have a version of this feed in the database already, prefer that
+    currentFeed = existingFeed;
+  } else {
+    // First time we're seeing this feed, add it to the database
+    currentFeed = feed;
+    await currentFeed.save();
+  }
+
+  return currentFeed;
+}
+
+/**
+ * Process all of these Feed objects into Redis and the feed queue.
+ * @param {Array<Feed>} feeds - the parsed feed Objects to be processed.
+ */
+function processFeeds(feeds) {
+  return Promise.all(
+    feeds.map(async feed => {
+      // Save this feed into the database if necessary.
+      const currentFeed = await updateFeed(feed);
+      // Add a job to the feed queue to process all of this feed's posts.
+      await feedQueue.addFeed(currentFeed);
+    })
+  );
+}
+
+/**
+ * Download and parse feed author/URL info from the wiki, and process
+ * these into Feed Objects to be added to the database and feed queue.
+ */
+async function processWikiFeeds() {
   try {
     // Get an Array of Feed objects from the wiki feed list
     const feeds = await getWikiFeeds();
-    // Process all of these Feed objects into Redis and the feed queue
-    await Promise.all(
-      feeds.map(feed =>
-        Promise.all([
-          // Store this feed in Redis
-          feed.save(),
-          // Add a job to the feed queue to process all of its posts
-          feedQueue.addFeed(feed),
-        ])
-      )
-    );
+    // Process these feeds into the database and feed queue
+    await processFeeds(feeds);
   } catch (err) {
     logger.error({ err }, 'Error queuing wiki feeds');
   }
@@ -44,7 +75,7 @@ async function enqueueWikiFeed() {
 
 function loadFeedsIntoQueue() {
   logger.info('Loading all feeds into feed queue for processing');
-  enqueueWikiFeed().catch(error => {
+  processWikiFeeds().catch(error => {
     logger.error({ error }, 'Unable to enqueue wiki feeds');
   });
 }

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -24,7 +24,19 @@ module.exports = {
       // Using hmset() until hset() fully supports multiple fields:
       // https://github.com/stipsan/ioredis-mock/issues/345
       // https://github.com/luin/ioredis/issues/551
-      .hmset(key, 'id', feed.id, 'author', feed.author, 'url', feed.url)
+      .hmset(
+        key,
+        'id',
+        feed.id,
+        'author',
+        feed.author,
+        'url',
+        feed.url,
+        'etag',
+        feed.etag,
+        'lastModified',
+        feed.lastModified
+      )
       .sadd(feedsKey, feed.id)
       .exec();
   },

--- a/test/feed-processor.test.js
+++ b/test/feed-processor.test.js
@@ -15,11 +15,13 @@ test('Passing a valid RSS feed URI should pass', async () => {
   await expect(processor(job)).resolves.toBeTruthy();
 });
 
-test('Passing a valid URI, but not a feed URI should error', async () => {
+test('Passing a valid URI with HTML response should return an empty Array', async () => {
   const url = fixtures.getHtmlUri();
   fixtures.nockValidHtmlResponse();
   const job = fixtures.createMockJobObjectFromURL(url);
-  await expect(processor(job)).rejects.toThrow();
+  const result = await processor(job);
+  expect(Array.isArray(result)).toBe(true);
+  expect(result.length).toBe(0);
 });
 
 test('Passing an invalid RSS category feed should pass', async () => {
@@ -36,9 +38,11 @@ test('Passing a valid RSS category feed should pass', async () => {
   await expect(processor(job)).resolves.toBeTruthy();
 });
 
-test('Non existent feed failure case: 404 should error', async () => {
+test('Non existent feed failure case: 404 should return an empty Array', async () => {
   const url = fixtures.getHtmlUri();
   fixtures.nock404Response();
   const job = fixtures.createMockJobObjectFromURL(url);
-  await expect(processor(job)).rejects.toThrow();
+  const result = await processor(job);
+  expect(Array.isArray(result)).toBe(true);
+  expect(result.length).toBe(0);
 });

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -69,6 +69,7 @@ describe('Fost data class tests', () => {
       await feed.save();
       const persisted = await Feed.byId(feed.id);
       expect(persisted.etag).toEqual('etag');
+      expect(persisted.lastModified).toBe(null);
     });
 
     test('Setting lastModified on a feed should persist', async () => {
@@ -77,6 +78,7 @@ describe('Fost data class tests', () => {
       await feed.save();
       const persisted = await Feed.byId(feed.id);
       expect(persisted.lastModified).toEqual('lastModified');
+      expect(persisted.etag).toBe(null);
     });
   });
 });

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -22,6 +22,14 @@ describe('Fost data class tests', () => {
     expect(createFeed()).toEqual(data);
   });
 
+  test('Feed constructor should throw if missing url', () => {
+    expect(() => new Feed('author', undefined)).toThrow();
+  });
+
+  test('Feed constructor should throw if missing author and url', () => {
+    expect(() => new Feed(undefined, undefined)).toThrow();
+  });
+
   test('Feed.parse() should be able to parse an Object into a Feed', () => {
     expect(Feed.parse(data)).toEqual(createFeed());
   });
@@ -53,6 +61,22 @@ describe('Fost data class tests', () => {
     test('Feed.byId() for an invalid url should return null', async () => {
       const feed = await Feed.byUrl('http://invalid.url.com');
       expect(feed).toBe(null);
+    });
+
+    test('Setting etag on a feed should persist', async () => {
+      const feed = new Feed('author', 'http://url.com/with/etag');
+      feed.etag = 'etag';
+      await feed.save();
+      const persisted = await Feed.byId(feed.id);
+      expect(persisted.etag).toEqual('etag');
+    });
+
+    test('Setting lastModified on a feed should persist', async () => {
+      const feed = new Feed('author', 'http://url.com/with/lastModified');
+      feed.lastModified = 'lastModified';
+      await feed.save();
+      const persisted = await Feed.byId(feed.id);
+      expect(persisted.lastModified).toEqual('lastModified');
     });
   });
 });

--- a/test/feeds.test.js
+++ b/test/feeds.test.js
@@ -37,6 +37,8 @@ describe('test /feeds/:id responses', () => {
     author: 'foo',
     url: existingUrl,
     id: hash(existingUrl),
+    etag: null,
+    lastModified: null,
   };
 
   // add the feed to the storage

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -3,6 +3,8 @@ const url = require('url');
 const fs = require('fs');
 const path = require('path');
 
+const Feed = require('../src/backend/data/feed');
+
 /**
  * This is a fixture module for telescope tests which contains measures to
  * maintain a reproducible environment for system testing
@@ -108,12 +110,13 @@ const getValidHtmlBody = () =>
  * @param {Number} httpResponseCode - the HTTP result code
  * @param {String} mimeType  - the mime type to use for the response
  */
-function nockResponse(uri, body, httpResponseCode, mimeType) {
+function nockResponse(uri, body, httpResponseCode, mimeType, headers) {
   const { protocol, host, pathname, search } = url.parse(uri);
   nock(`${protocol}//${host}`)
     .get(`${pathname}${search || ''}`)
     .reply(httpResponseCode, body, {
       'Content-Type': mimeType,
+      ...headers,
     });
 }
 
@@ -127,30 +130,28 @@ exports.getValidFeedBody = getValidFeedBody;
 exports.getEmptyFeedBody = getEmptyFeedBody;
 exports.getValidHtmlBody = getValidHtmlBody;
 
-exports.nockValidAtomResponse = function() {
-  nockResponse(getAtomUri(), getValidFeedBody(), 200, 'application/rss+xml');
+exports.nockValidAtomResponse = function(headers = {}) {
+  nockResponse(getAtomUri(), getValidFeedBody(), 200, 'application/rss+xml', headers);
 };
 
-exports.nockValidRssResponse = function() {
-  nockResponse(getRssUri(), getValidFeedBody(), 200, 'application/rss+xml');
+exports.nockValidRssResponse = function(headers = {}) {
+  nockResponse(getRssUri(), getValidFeedBody(), 200, 'application/rss+xml', headers);
 };
 
-exports.nockInvalidRssResponse = function() {
-  nockResponse(getRssUri(), getEmptyFeedBody(), 200, 'application/rss+xml');
+exports.nockInvalidRssResponse = function(headers = {}) {
+  nockResponse(getRssUri(), getEmptyFeedBody(), 200, 'application/rss+xml', headers);
 };
 
-exports.nockValidHtmlResponse = function() {
-  nockResponse(getHtmlUri(), getValidHtmlBody(), 200, 'text/html');
+exports.nockValidHtmlResponse = function(headers = {}) {
+  nockResponse(getHtmlUri(), getValidHtmlBody(), 200, 'text/html', headers);
 };
 
-exports.nock404Response = function() {
-  nockResponse(getHtmlUri(), 'Not Found', 404, 'text/html');
+exports.nock404Response = function(headers = {}) {
+  nockResponse(getHtmlUri(), 'Not Found', 404, 'text/html', headers);
 };
 
-exports.nockRealWorldRssResponse = function() {
-  nockResponse(getRealWorldRssUri(), getRealWorldRssBody(), 200, 'application/rss+xml');
+exports.nockRealWorldRssResponse = function(headers = {}) {
+  nockResponse(getRealWorldRssUri(), getRealWorldRssBody(), 200, 'application/rss+xml', headers);
 };
 
-exports.createMockJobObjectFromURL = function(feedURL) {
-  return { data: { url: feedURL } };
-};
+exports.createMockJobObjectFromURL = feedUrl => ({ data: new Feed('author', feedUrl) });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -15,20 +15,42 @@ const hash = require('../src/backend/data/hash');
 describe('Storage tests for feeds', () => {
   const feed1 = new Feed('James Smith', 'http://seneca.co/jsmith');
   const feed2 = new Feed('James Smith 2', 'http://seneca.co/jsmith/2');
+  const feed3 = new Feed('James Smith 2', 'http://seneca.co/jsmith/3', 'etag');
+  const feed4 = new Feed('James Smith 2', 'http://seneca.co/jsmith/4', 'etag', 'last-modified');
 
-  beforeAll(() => Promise.all([addFeed(feed1), addFeed(feed2)]));
+  beforeAll(() => Promise.all([addFeed(feed1), addFeed(feed2), addFeed(feed3), addFeed(feed4)]));
 
   it('should allow retrieving a feed by id after inserting', async () => {
-    const result = await getFeed(feed1.id);
-    expect(result).toEqual(feed1);
+    const feed = await getFeed(feed1.id);
+    expect(feed.id).toEqual(feed1.id);
+    expect(feed.author).toEqual(feed1.author);
+    expect(feed.url).toEqual(feed1.url);
+    expect(feed.etag).toEqual('');
+    expect(feed.lastModified).toEqual('');
   });
 
   it('should return expected feed count', async () => {
-    expect(await getFeedsCount()).toEqual(2);
+    expect(await getFeedsCount()).toEqual(4);
   });
 
   it('should return expected feeds', async () => {
-    expect(await getFeeds()).toEqual([feed1.id, feed2.id]);
+    expect(await getFeeds()).toEqual([feed1.id, feed2.id, feed3.id, feed4.id]);
+  });
+
+  it('should deal with etag property correctly when available and missing', async () => {
+    const feeds = await Promise.all((await getFeeds()).map(id => getFeed(id)));
+    expect(feeds[0].etag).toBe('');
+    expect(feeds[1].etag).toBe('');
+    expect(feeds[2].etag).toBe('etag');
+    expect(feeds[3].etag).toBe('etag');
+  });
+
+  it('should deal with lastModified property correctly when available and missing', async () => {
+    const feeds = await Promise.all((await getFeeds()).map(id => getFeed(id)));
+    expect(feeds[0].lastModified).toBe('');
+    expect(feeds[1].lastModified).toBe('');
+    expect(feeds[2].lastModified).toBe('');
+    expect(feeds[3].lastModified).toBe('last-modified');
   });
 });
 


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #445.  Addresses some of #548.

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR changes how we deal with feed data that is already cached in Redis.  I've added two new optional fields to the `Feed` class: `etag` and `lastModified`.  These correspond to the HTTP headers of the same name.

An `ETag` is a kind if unique identifier for a resource.  If the resource changes, the `ETag` changes.  Likewise, the `Last-Modified` header indicates the date/time that the resource was last updated.  It's not always accurate, and may only represent the last time you requested the resource.  Taken together, the two provide useful clues for a server about whether or not a resource that you have cached is still valid, or whether it needs to send it again.

When requesting data from the server, you can add `If-Non-Match` and `If-Modified-Since` headers, to allow passing the `etag` and `lastModified` values to the server for analysis.

I've altered how our feed parser logic works.  I now do a `HEAD` request to the server, and pass any cache headers we have for a feed.  I take the results I get back, and record any cache info on the feed.  If the resource has been updated, I let the feed parser download and reprocess it.

I've also cleaned up a bunch of the logging and errors we get from the feedparser.  It looks more like this now:

```
[ 2020-01-25 18:25:06.389 ] DEBUG (64525 on brightness.local): [HTTP 200 - OK] Feed has new content: http://asalga.wordpress.com/category/open-source/feed/
[ 2020-01-25 18:25:06.481 ] INFO  (64527 on brightness.local): Skipping resource at http://amkonopko.wordpress.com/feed/, not a valid feed (text/html; charset=UTF-8)
[ 2020-01-25 18:25:06.590 ] DEBUG (64527 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://kyu6.wordpress.com/feed/
[ 2020-01-25 18:25:06.627 ] DEBUG (64525 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://bbarcick.blogspot.com/feeds/posts/default/-/Open%20Source
[ 2020-01-25 18:25:06.706 ] DEBUG (64527 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://isong3.blogspot.com/feeds/posts/default/-/spo600
[ 2020-01-25 18:25:06.706 ] DEBUG (64525 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: https://stevenleopensourceblog.wordpress.com/feed/
[ 2020-01-25 18:25:06.719 ] DEBUG (64526 on brightness.local): [HTTP 200 - OK] Feed has new content: http://shavyg2.wordpress.com/category/open-source/feed/
[ 2020-01-25 18:25:06.779 ] DEBUG (64527 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://vesperrin.blogspot.com/feeds/posts/default/-/open%20source
[ 2020-01-25 18:25:06.803 ] DEBUG (64524 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://marangonim.blogspot.ca/feeds/posts/default/-/SPO600
[ 2020-01-25 18:25:06.911 ] DEBUG (64524 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://xizhangblog.blogspot.com/feeds/posts/default/-/oop344
[ 2020-01-25 18:25:06.948 ] DEBUG (64527 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://pconstantino.wordpress.com/feed
[ 2020-01-25 18:25:06.971 ] DEBUG (64526 on brightness.local): [HTTP 200 - OK] Feed has new content: https://ywpark1.wordpress.com/category/open-source/feed/
[ 2020-01-25 18:25:06.976 ] DEBUG (64525 on brightness.local): [HTTP 200 - OK] Feed has new content: http://danlin007.wordpress.com/category/open_source/feed/
[ 2020-01-25 18:25:07.050 ] DEBUG (64527 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://jmchen11.wordpress.com/feed/
[ 2020-01-25 18:25:07.083 ] DEBUG (64524 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: https://svitlanagalianova.blogspot.ca/feeds/posts/default/
[ 2020-01-25 18:25:07.201 ] DEBUG (64527 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://bzcareermongodb.blogspot.ca/feeds/posts/default
[ 2020-01-25 18:25:07.209 ] DEBUG (64524 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://donna-oberes.blogspot.com/feeds/posts/default?alt=rss
[ 2020-01-25 18:25:07.228 ] INFO  (64525 on brightness.local): Skipping resource at http://danlin007.wordpress.com/category/open_source/feed/, not a valid feed (text/html; charset=utf-8)
[ 2020-01-25 18:25:07.302 ] DEBUG (64526 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://basyager.wordpress.com/feed/
[ 2020-01-25 18:25:07.352 ] DEBUG (64525 on brightness.local): [HTTP 200 - OK] Feed has new content: https://badrmodoukh.wordpress.com/tag/open-source/feed/
[ 2020-01-25 18:25:07.370 ] DEBUG (64524 on brightness.local): [HTTP 200 - OK] Feed has new content: http://dseifried.wordpress.com/category/school/feed/
[ 2020-01-25 18:25:07.383 ] DEBUG (64527 on brightness.local): [HTTP 200 - OK] Feed has new content: https://michaelpierreblog.wordpress.com/category/Open-Source/feed/
[ 2020-01-25 18:25:07.730 ] DEBUG (64526 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://blog.cresencia.ca/category/open-source/osd600/feed/
[ 2020-01-25 18:25:07.819 ] DEBUG (64524 on brightness.local): [HTTP 200 - OK] Feed has new content: http://droxxes.wordpress.com/category/seneca/feed/
[ 2020-01-25 18:25:07.854 ] DEBUG (64525 on brightness.local): [HTTP 200 - OK] Feed has new content: https://lejara.wordpress.com/open-source/feed/
[ 2020-01-25 18:25:07.861 ] DEBUG (64526 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://msmahmood1.blogspot.com/feeds/posts/default/-/opensource
[ 2020-01-25 18:25:07.929 ] INFO  (64525 on brightness.local): Skipping resource at https://lejara.wordpress.com/open-source/feed/, not a valid feed (application/rss+xml; charset=UTF-8)
```

I've updated the tests to get things passing, but I could still use more tests for this.  It would be useful to mock network requests that include and don't-include cache info, and make sure we do the right thing.  I might leave that for a follow-up PR.

It would be interesting later to also explore using a more full-featured cache policy library like https://www.npmjs.com/package/http-cache-semantics.  HTTP caches are tricky to get right, and what I've done, while useful at reducing network traffic, is very basic.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
