### PR TITLE
Fix #603: make web server stoppable

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "sanitize-html": "1.20.1",
     "sentiment": "5.0.2",
     "spam-filter": "1.1.1",
+    "stoppable": "1.1.0",
     "valid-url": "1.0.9",
     "wordcount": "1.1.1"
   },

--- a/src/backend/lib/shutdown.js
+++ b/src/backend/lib/shutdown.js
@@ -16,7 +16,10 @@ async function stopQueue() {
 }
 
 async function stopWebServer() {
-  const serverClose = promisify(server.close.bind(server));
+  // Use stopppable's server.stop() instead of httpServer.close()
+  // to force connections to close as well.  See:
+  // https://github.com/hunterloftis/stoppable
+  const serverClose = promisify(server.stop.bind(server));
   try {
     await serverClose();
     logger.info('Web server shut down.');

--- a/src/backend/web/server.js
+++ b/src/backend/web/server.js
@@ -1,11 +1,16 @@
 require('../lib/config');
+const stoppable = require('stoppable');
+
 const app = require('./app.js');
 
 const { logger } = app.get('logger');
 const HTTP_PORT = process.env.PORT || 3000;
 
-const server = app.listen(HTTP_PORT, () => {
-  logger.info(`Telescope listening on port ${HTTP_PORT}`);
-});
+// Make our server not block when we want it to close.
+const server = stoppable(
+  app.listen(HTTP_PORT, () => {
+    logger.info(`Telescope listening on port ${HTTP_PORT}`);
+  })
+);
 
 module.exports = server;


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #603

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR wraps our web server with the [stoppable](https://github.com/hunterloftis/stoppable), to keep track of open/long-lived web connections and close them when shutting down.  Currently, these are keeping our process from exiting cleanly.

To test this:

1. Start the server: `npm start`
1. Open some web connections (e.g., `http://localhost:3000/planet`, ``http://localhost:3000/admin/queues`, ``http://localhost:3000/graphql`, etc)
1. Kill the server in your terminal with `Ctrl+C`

You should get a clean shutdown:

```
[ 2020-01-26 08:55:49.150 ] INFO  (66737 on brightness.local): Received SIGINT, starting shut down
[ 2020-01-26 08:55:49.150 ] ERROR (66737 on brightness.local):
    error: "SIGINT"
[ 2020-01-26 08:55:49.153 ] INFO  (66737 on brightness.local): Web server shut down.
[ 2020-01-26 08:55:49.169 ] ERROR (66737 on brightness.local): Job 5444 failed.
    error: {}
[ 2020-01-26 08:55:49.170 ] ERROR (66737 on brightness.local): Job 5442 failed.
    error: {}
[ 2020-01-26 08:55:49.170 ] ERROR (66737 on brightness.local): Job 5448 failed.
    error: {}
[ 2020-01-26 08:55:49.172 ] INFO  (66737 on brightness.local): Feed queue shut down.
[ 2020-01-26 08:55:49.172 ] INFO  (66737 on brightness.local): Completing shut down.
```