### PR TITLE
Closes #523: Add /feeds route to match what /posts does

### DIFF
--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -1,17 +1,15 @@
 const express = require('express');
 const Feed = require('../../data/feed');
-const { getFeeds, getFeedsCount } = require('../../utils/storage');
+const { getFeeds } = require('../../utils/storage');
 const { logger } = require('../../utils/logger');
 
 const feeds = express.Router();
 
 feeds.get('/', async (req, res) => {
   let ids;
-  let feedsCount;
 
   try {
     ids = await getFeeds();
-    feedsCount = await getFeedsCount();
   } catch (err) {
     logger.error({ err }, 'Unable to get feeds from Redis');
     res.status(503).json({
@@ -20,7 +18,7 @@ feeds.get('/', async (req, res) => {
     return;
   }
 
-  res.set('X-Total-Count', feedsCount);
+  res.set('X-Total-Count', ids.length);
   res.json(
     ids
       // Return id and url for a specific feed
@@ -31,7 +29,6 @@ feeds.get('/', async (req, res) => {
   );
 });
 
-// The guid is likely a URI, and must be encoded by the client
 feeds.get('/:id', async (req, res) => {
   const { id } = req.params;
 

--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const Feed = require('../../data/feed');
+const { getFeeds, getFeedsCount } = require('../../utils/storage');
+const { logger } = require('../../utils/logger');
+
+const feeds = express.Router();
+
+feeds.get('/', async (req, res) => {
+  let ids;
+  let feedsCount;
+
+  try {
+    ids = await getFeeds();
+    feedsCount = await getFeedsCount();
+  } catch (err) {
+    logger.error({ err }, 'Unable to get feeds from Redis');
+    res.status(503).json({
+      message: 'Unable to connect to database',
+    });
+    return;
+  }
+
+  res.set('X-Total-Count', feedsCount);
+  res.json(
+    ids
+      // Return id and url for a specific feed
+      .map(id => ({
+        id,
+        url: `/feeds/${id}`,
+      }))
+  );
+});
+
+// The guid is likely a URI, and must be encoded by the client
+feeds.get('/:id', async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const feed = await Feed.byId(id);
+
+    // If the object we get back is empty, use 404
+    if (!feed) {
+      res.status(404).json({
+        message: `Feed not found for id ${id}`,
+      });
+    } else {
+      res.json(feed);
+    }
+  } catch (err) {
+    logger.error({ err }, 'Unable to get feeds from Redis');
+    res.status(503).json({
+      message: 'Unable to connect to database',
+    });
+  }
+});
+
+module.exports = feeds;

--- a/src/backend/web/routes/index.js
+++ b/src/backend/web/routes/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 
 const admin = require('./admin');
+const feeds = require('./feeds');
 const opml = require('./opml');
 const planet = require('./planet');
 const posts = require('./posts');
@@ -15,6 +16,7 @@ router.use(express.static(path.join(__dirname, '../../../frontend')));
 router.use('/legacy', express.static(path.join(__dirname, '../planet/static')));
 
 router.use('/admin', admin);
+router.use('/feeds', feeds);
 router.use('/opml', opml);
 router.use('/planet', planet);
 router.use('/posts', posts);

--- a/test/feeds.test.js
+++ b/test/feeds.test.js
@@ -1,0 +1,62 @@
+const request = require('supertest');
+
+const app = require('../src/backend/web/app');
+const Feed = require('../src/backend/data/feed');
+const hash = require('../src/backend/data/hash');
+
+describe('test /feeds endpoint', () => {
+  const createdItems = 150;
+
+  // Array of feeds
+  const feeds = [...Array(createdItems).keys()].map(item => {
+    return new Feed('foo', `http://telescope${item}.cdot.systems`);
+  });
+
+  beforeAll(() => Promise.all(feeds.map(feed => feed.save())));
+
+  it('requests feeds', async () => {
+    const res = await request(app).get('/feeds');
+
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.get('X-Total-Count')).toBe(createdItems.toString());
+    expect(res.body.length).toBe(createdItems);
+    expect(res.body instanceof Array).toBe(true);
+  });
+});
+
+describe('test /feeds/:id responses', () => {
+  const existingUrl = 'http://existing-url';
+  const missingUrl = 'http://missing-url';
+
+  // an object to be added for testing purposes
+  const addedFeed = new Feed('foo', existingUrl);
+
+  // an object, expected to be returned by a correct query
+  const receivedFeed = {
+    author: 'foo',
+    url: existingUrl,
+    id: hash(existingUrl),
+  };
+
+  // add the feed to the storage
+  beforeAll(() => addedFeed.save());
+
+  // tests
+  it("pass an id that doesn't exist", async () => {
+    const res = await request(app).get(`/feeds/${hash(missingUrl)}`);
+
+    expect(res.status).toEqual(404);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body instanceof Array).toBe(false);
+  });
+
+  it('pass an id that does exist', async () => {
+    const res = await request(app).get(`/feeds/${hash(existingUrl)}`);
+
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body).toEqual(receivedFeed);
+    expect(res.body instanceof Array).toBe(false);
+  });
+});


### PR DESCRIPTION
## Issue This PR Addresses

Closes #523 


## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds the endpoints `GET /feeds` and `GET /feeds/:id` with tests.
This allows us to requests feeds from the server using:
`http(s)://localhost:3000/feeds`

The expected response should be: 
![feeds](https://user-images.githubusercontent.com/23108901/73139480-62eaec80-403c-11ea-9369-f26f49faa60d.png)

To request a specific feed:
`http(s)://localhost:3000/feeds/{id}`

Expected response:
![rafi](https://user-images.githubusercontent.com/23108901/73139552-15bb4a80-403d-11ea-8990-13d528a41e6d.png)

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
