### PR TITLE
Use feed.id as jobId to de-dupe job queue

### DIFF
--- a/env.example
+++ b/env.example
@@ -45,16 +45,15 @@ BLOG_INACTIVE_TIME=360
 GITHUB_TOKEN=
 
 # Feed job queue attempts
-FEED_QUEUE_ATTEMPTS=2
+FEED_QUEUE_ATTEMPTS=5
 
 # Feed job queue delay(ms)
-FEED_QUEUE_DELAY_MS=30000
+FEED_QUEUE_DELAY_MS=60000
 
 # Number of concurrent worker processors to run. Use * if you want to run
 # one per CPU. Use a number if you want to set it manually, up to a max
 # of the CPU count.  If not set, we'll assume 1.
 FEED_QUEUE_PARALLEL_WORKERS=1
-FEED_QUEUE_DELAY_MS=60000
 
 # Max number of posts per page
 MAX_POSTS_PER_PAGE=30

--- a/src/backend/feed/queue.js
+++ b/src/backend/feed/queue.js
@@ -15,24 +15,24 @@ setQueues(queue);
  * The `feedInfo` is an Object with `name` (i.e., name of author) and `url`
  * (i.e., url of feed) properties, matching what we parse from the wiki.
  */
-queue.addFeed = async function(feedInfo) {
+queue.addFeed = async function(feed) {
   const options = {
-    // Use the feed URL as the job key, so we don't double add it.
-    // Bull will not add a job there already exists a job with the same id.
-    id: feedInfo.url,
-    attempts: process.env.FEED_QUEUE_ATTEMPTS || 2,
+    // Override the Job ID to use the feed id, so we don't duplicate jobs.
+    // Bull will not add a job if there already exists a job with the same id.
+    jobId: feed.id,
+    attempts: process.env.FEED_QUEUE_ATTEMPTS || 5,
     backoff: {
       type: 'exponential',
-      delay: process.env.FEED_QUEUE_DELAY_MS || 30 * 1000,
+      delay: process.env.FEED_QUEUE_DELAY_MS || 60 * 1000,
     },
     removeOnComplete: true,
     removeOnFail: true,
   };
 
   try {
-    await queue.add(feedInfo, options);
+    await queue.add(feed, options);
   } catch (error) {
-    logger.error({ error, feedInfo }, 'Unable to add job to queue');
+    logger.error({ error }, `Unable to add job for ${feed.url} to queue`);
   }
 };
 


### PR DESCRIPTION
## Issue This PR Addresses

1. Fixes #611 
1. Fixes #608

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

I was trying to understand why our staging box had 68K+ delayed jobs in the queue, and discovered that we are using the wrong id name for our jobs.

When adding a job to a Bull queue, you can either use the default job number, an auto-incrementing integer, or [you can specify your own](https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queueadd).  The problem with the latter is that it means that you can easily add multiple jobs for the same task, since each one is keyed on a number that has nothing to do with the data in the job.  If you instead provide a key that is unique to the job itself, you can have Bull ignore duplicates.

We actually tried to do this before, and instead of using `jobId` we used `id`, so Bull is ignoring it.  This change switches to use the correct version.

Because of this change, our backoff strategy now makes sense.  If a job doesn't work, we need to try it over and over again, at longer and longer intervals.  When the job finally fails for real, we can put it in the blacklist (cc @c3ho).

When we land this, we should update the `.env` on the staging box to reflect this changes here to our retry strategy (cc @manekenpix).
