### PR TITLE
Don't log errors when articles are missing fields

### DIFF
--- a/src/backend/data/article-error.js
+++ b/src/backend/data/article-error.js
@@ -1,0 +1,13 @@
+class ArticleError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = new Error(message).stack;
+    }
+  }
+}
+
+module.exports = ArticleError;

--- a/src/backend/data/post.js
+++ b/src/backend/data/post.js
@@ -3,6 +3,7 @@ const { logger } = require('../utils/logger');
 const sanitizeHTML = require('../utils/sanitize-html');
 const textParser = require('../utils/text-parser');
 const hash = require('./hash');
+const ArticleError = require('./article-error');
 
 function toDate(date) {
   if (date instanceof Date) {
@@ -59,7 +60,7 @@ class Post {
     if (missing.length) {
       const message = `invalid article: missing ${missing.join(', ')}`;
       logger.debug(message);
-      throw new Error(message);
+      throw new ArticleError(message);
     }
 
     // Allow for missing title, but give it one


### PR DESCRIPTION
## Issue This PR Addresses

Part of #548

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This adds a new error type, `ArticleError`, which allows us to filter out a bunch of errors we get when an article is missing data that we need to create a post.

By fixing this, I've now dealt with 2/3rds of the errors we get when running normally.  I just have to deal with fatal network errors, which I'll do in a follow-up.

To test this, run the server like this:

```
LOG_LEVEL=info npm start
```

It will look like this, showing what happens as it processes each feed, downloading content (200) or using our cached version (304), etc:

```
[ 2020-01-28 20:57:56.162 ] INFO  (80339 on brightness.local): [HTTP 200 - OK] Feed has new content: http://haxbyte.wordpress.com/category/Open%20Source/feed/
[ 2020-01-28 20:57:56.258 ] INFO  (80337 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://galewis.blogspot.com/feeds/posts/default
[ 2020-01-28 20:57:56.343 ] INFO  (80338 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://jmpiltz.blogspot.com/feeds/posts/default
[ 2020-01-28 20:57:56.360 ] INFO  (80340 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://joeysoddthoughts.blogspot.ca/feeds/posts/default/
[ 2020-01-28 20:57:56.418 ] INFO  (80338 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://spo600ninawip.blogspot.com/feeds/posts/default/
[ 2020-01-28 20:57:56.487 ] INFO  (80340 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://mercedes-oop344.blogspot.com/feeds/posts/default
[ 2020-01-28 20:57:56.501 ] INFO  (80339 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: http://codingblub.blogspot.com/feeds/posts/default/
[ 2020-01-28 20:57:56.576 ] INFO  (80339 on brightness.local): [HTTP 304 - Not Modified] Feed not downloaded: https://marvinrsanchez.wordpress.com/feed/
[ 2020-01-28 20:57:56.612 ] INFO  (80337 on brightness.local): [HTTP 200 - OK] Feed has new content: http://odjahanpour.wordpress.com/category/spo600/feed
```