### PR TITLE
Add /planet/compare route

### DIFF
--- a/src/backend/web/planet/views/compare-planets.handlebars
+++ b/src/backend/web/planet/views/compare-planets.handlebars
@@ -1,0 +1,24 @@
+<style>
+  html, body {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+  main {
+    display: flex;
+    height: 100%;
+    width: 100%;
+  }
+  iframe {
+    flex: 1;
+    border: 0;
+  }
+  #telescope {
+    border-left: solid 2px black;
+  }
+</style>
+<main>
+  <iframe id="original" src="http://zenit.senecac.on.ca/~chris.tyler/planet/"></iframe>
+  <iframe id="telescope" src="/planet"></iframe>
+</main>

--- a/src/backend/web/planet/views/planet.handlebars
+++ b/src/backend/web/planet/views/planet.handlebars
@@ -1,4 +1,4 @@
-<h1>Planet CDOT</h1>
+<h1>Planet CDOT (Telescope)</h1>
 
 {{#each days}}
   <div class="daygroup">

--- a/src/backend/web/routes/planet.js
+++ b/src/backend/web/routes/planet.js
@@ -72,4 +72,8 @@ router.get('/', async (req, res) => {
   }
 });
 
+router.get('/compare', (req, res) => {
+  res.render('compare-planets');
+});
+
 module.exports = router;


### PR DESCRIPTION
## Description

This adds a new route for debugging `/planet/compare` which lets you load our old and new planets side by side in the same window to easily compare.  I got the idea from @cindyledev, who has been doing this in some issues, and it gives us a quick way to see differences.

NOTE: the two planets aren't currently pixel perfect with one another (#621 for example).

Here is what it looks like:

<img width="1229" alt="Screen Shot 2020-01-30 at 10 14 45 AM" src="https://user-images.githubusercontent.com/427398/73462332-a2ba1880-4349-11ea-88bf-1e0e5e43ed84.png">

