### PR TITLE
Initial work on /stats route for post statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
+    "@wordpress/wordcount": "2.6.2",
     "accepts": "1.3.7",
     "apollo-server-express": "2.9.16",
     "body-parser": "1.19.0",
@@ -68,6 +69,7 @@
     "bull-board": "0.5.0",
     "cookie-parser": "1.4.4",
     "cors": "2.8.5",
+    "date-fns": "2.9.0",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-handlebars": "3.1.0",

--- a/src/backend/data/stats.js
+++ b/src/backend/data/stats.js
@@ -1,0 +1,77 @@
+const { count } = require('@wordpress/wordcount');
+const startOfWeek = require('date-fns/startOfWeek');
+const startOfMonth = require('date-fns/startOfMonth');
+const startOfYear = require('date-fns/startOfYear');
+
+const { getPostsByDate } = require('../utils/storage');
+const Post = require('./post');
+
+/**
+ * Get the total number of words in the text of all posts in the array
+ * @param {Array<Post>} posts the array of post objects
+ */
+const countWords = posts => posts.reduce((total, post) => total + count(post.text, 'words', {}), 0);
+
+/**
+ * Get the total number of unique authors in the posts in the array
+ * @param {Array<Post>} posts the array of post objects
+ */
+const countAuthors = posts => new Set(posts.map(post => post.author)).size;
+
+class Stats {
+  constructor(startDate, endDate) {
+    if (!(startDate instanceof Date && endDate instanceof Date)) {
+      throw new TypeError('startDate and endDate must be Dates');
+    }
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  /**
+   * Returns a Promise<Array> of post ids
+   */
+  async calculate() {
+    const ids = await getPostsByDate(this.startDate, this.endDate);
+    const posts = await Promise.all(ids.map(Post.byId));
+
+    return {
+      posts: posts.length,
+      authors: countAuthors(posts),
+      words: countWords(posts),
+    };
+  }
+
+  /**
+   * Creates a new Stats object for today
+   */
+  static today() {
+    const today = new Date();
+    return new Stats(today, today);
+  }
+
+  /**
+   * Creates a new Stats object for the first day of this week until today
+   */
+  static thisWeek() {
+    const today = new Date();
+    return new Stats(startOfWeek(today), today);
+  }
+
+  /**
+   * Creates a new Stats object for the first day of this month until today
+   */
+  static thisMonth() {
+    const today = new Date();
+    return new Stats(startOfMonth(today), today);
+  }
+
+  /**
+   * Creates a new Stats object for Jan 1 of this year until today
+   */
+  static thisYear() {
+    const today = new Date();
+    return new Stats(startOfYear(today), today);
+  }
+}
+
+module.exports = Stats;

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -90,6 +90,15 @@ module.exports = {
    */
   getPosts: (from, to) => redis.zrevrange(postsKey, from, to - 1),
 
+  /**
+   * Returns an array of post ids from redis
+   * @param start starting Date in the range
+   * @param end ending Date in the range
+   * @return Array of ids
+   */
+  getPostsByDate: (startDate, endDate) =>
+    redis.zrangebyscore(postsKey, startDate.getTime(), endDate.getTime()),
+
   getPostsCount: () => redis.zcard(postsKey),
 
   getPost: id => redis.hgetall(postNamespace.concat(id)),

--- a/src/backend/web/routes/index.js
+++ b/src/backend/web/routes/index.js
@@ -7,6 +7,7 @@ const opml = require('./opml');
 const planet = require('./planet');
 const posts = require('./posts');
 const login = require('./login');
+const stats = require('./stats');
 
 const router = express.Router();
 
@@ -21,5 +22,6 @@ router.use('/opml', opml);
 router.use('/planet', planet);
 router.use('/posts', posts);
 router.use('/login', login);
+router.use('/stats', stats);
 
 module.exports = router;

--- a/src/backend/web/routes/stats.js
+++ b/src/backend/web/routes/stats.js
@@ -1,0 +1,40 @@
+require('../../lib/config');
+const express = require('express');
+const Stats = require('../../data/stats');
+const { logger } = require('../../utils/logger');
+
+const stats = express.Router();
+
+const statsRoute = statsPeriod => async (req, res) => {
+  try {
+    const data = await statsPeriod.calculate();
+    res.json(data);
+  } catch (err) {
+    logger.error({ err }, 'Unable to get stats from database');
+    res.status(503).json({
+      message: 'Unable to get stats from database',
+    });
+  }
+};
+
+/**
+ * Get stats for today
+ */
+stats.get('/today', statsRoute(Stats.today()));
+
+/**
+ * Get stats for this week so far
+ */
+stats.get('/week', statsRoute(Stats.thisWeek()));
+
+/**
+ * Get stats for this month so far
+ */
+stats.get('/month', statsRoute(Stats.thisMonth()));
+
+/**
+ * Get stats for this year so far
+ */
+stats.get('/year', statsRoute(Stats.thisYear()));
+
+module.exports = stats;


### PR DESCRIPTION
## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This adds some new routes, and backend support for getting some basic statistics about posts.  Here is what the data looks like:

```
$ curl localhost:3000/stats/month
{ "posts": 74, "authors": 17, "words": 15628 }
```

I'm wondering if this might be useful in our UI to show on the front page somehow, to give a sense of what's happened recently.  If we don't use it in the UI, it's interesting to be able to get this data regardless.

Specifically, I've done this:

- ability to get posts from Redis by date range
- ability to calculate stats for number of posts, number of authors, number of words in all posts for a given date range via a new `Stats` object.
- new routes to get this data: `/stats/today`, `/stats/week`, `/stats/month`, `/stats/year`.  Each of these gives stats from the beginning of the period specified until today (e.g., from start of week until today).

I still need tests and graphql types and queries.

Some of this could help with the work @c3ho is doing in #630, maybe the date range part. 