### PR TITLE
Access logging information using GET /admin/log

### DIFF
--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -1,8 +1,35 @@
+require('../../lib/config');
 const express = require('express');
 const { UI } = require('bull-board');
+const fs = require('fs');
+const { logger } = require('../../utils/logger');
 
 const router = express.Router();
 
 router.use('/queues', UI);
+
+router.get('/log', (req, res) => {
+  let readStream;
+  if (!process.env.LOG_FILE) {
+    res.send('LOG_FILE undefined in .env file');
+    return;
+  }
+  try {
+    readStream = fs.createReadStream(process.env.LOG_FILE);
+
+    res.append('Content-type', 'text/plain');
+    readStream.pipe(res).on('error', error => {
+      logger.error({ error });
+      readStream.destroy();
+    });
+
+    res.on('error', error => {
+      logger.error({ error });
+      readStream.destroy();
+    });
+  } catch (error) {
+    res.send(error.message);
+  }
+});
 
 module.exports = router;


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Currently, there's not way to have access to `dev.telescope`'s logging information. This adds an endpoint that will return the information that would normally be shown on our terminal when we run telescope locally.
Provide a name for a log file either using `LOG_FILE=` in our `.env` file, or at launch with `LOG_FILE=myfilehere npm start`

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
