### PR TITLE
fix-556: updated sinitize-html.js and test for iframe tag added

### DIFF
--- a/src/backend/utils/sanitize-html.js
+++ b/src/backend/utils/sanitize-html.js
@@ -7,12 +7,14 @@ module.exports = function(dirty) {
   return sanitizeHtml(dirty, {
     // Add <img> to the list of allowed tags, see:
     // https://github.com/apostrophecms/sanitize-html#what-are-the-default-options
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+    allowedTags: [
       'img',
       'figure',
       'br',
       'p',
       'a',
+      'ol',
+      'nl',
       'div',
       'li',
       'td',
@@ -24,8 +26,10 @@ module.exports = function(dirty) {
       'ul',
       'tr',
       'h3',
+      'td',
       'i',
       'h4',
+      'pre',
       'blockquote',
       'hr',
       'table',
@@ -36,7 +40,6 @@ module.exports = function(dirty) {
       'h6',
       'thread',
       'caption',
-    ]),
-    disallowedTagsMode: 'discard',
+    ],
   });
 };

--- a/src/backend/utils/sanitize-html.js
+++ b/src/backend/utils/sanitize-html.js
@@ -7,6 +7,36 @@ module.exports = function(dirty) {
   return sanitizeHtml(dirty, {
     // Add <img> to the list of allowed tags, see:
     // https://github.com/apostrophecms/sanitize-html#what-are-the-default-options
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'figure']),
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+      'img',
+      'figure',
+      'br',
+      'p',
+      'a',
+      'div',
+      'li',
+      'td',
+      'strong',
+      'pre',
+      'code',
+      'b',
+      'em',
+      'ul',
+      'tr',
+      'h3',
+      'i',
+      'h4',
+      'blockquote',
+      'hr',
+      'table',
+      'tbody',
+      'th',
+      'h5',
+      'strike',
+      'h6',
+      'thread',
+      'caption',
+    ]),
+    disallowedTagsMode: 'discard',
   });
 };

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -34,6 +34,13 @@ describe('Sanitize HTML', () => {
     );
   });
 
+  test('<iframe> gets removed after run through sanitizeHTML', () => {
+    const data = sanitizeHTML(
+      '<iframe src="https://www.telescope.com" style="border:none;">Telescope</iframe>'
+    );
+    expect(data).toBe('<iframe>Telescope</iframe>');
+  });
+
   test('<pre> with inline style, sanitize strips inline style', () => {
     const data = sanitizeHTML('<pre class="brush: plain; title: ; notranslate">Hello World</pre>');
     expect(data).toBe('<pre>Hello World</pre>');

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -38,7 +38,7 @@ describe('Sanitize HTML', () => {
     const data = sanitizeHTML(
       '<iframe src="https://www.telescope.com" style="border:none;">Telescope</iframe>'
     );
-    expect(data).toBe('<iframe>Telescope</iframe>');
+    expect(data).toBe('Telescope');
   });
 
   test('<pre> with inline style, sanitize strips inline style', () => {


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Updated sanitize-html.js, so all needed tags are allowed, the rest are disallowed. Needed tags are taken from the list provided by @humphd in [issue-487](https://github.com/Seneca-CDOT/telescope/issues/487). Also, test for <iframe> tag added. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
