### PR TITLE
Tweak Zeit Now config

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,5 +5,9 @@
       "use": "@now/static-build",
       "config": { "distDir": "src/frontend/public" }
     }
-  ]
+  ],
+  "public": true,
+  "github": {
+    "silent": true
+  }
 }


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

I'm trying to a couple of tweaks to the Zeit Now `now.json` config:

- [disabling issue/PR comment spam](https://zeit.co/docs/configuration#git-integrations/github-silent).  This might be too much, and we might want to re-enable this, I'm not sure.
- [try to make it possible for people other than me to see build/deploy logs](https://zeit.co/docs/configuration#project/public).  I'm not sure if this will work without trying it.