### PR TITLE
Refactor Login frontend component to be functional

### DIFF
--- a/src/frontend/src/components/Login/LoggedIn.jsx
+++ b/src/frontend/src/components/Login/LoggedIn.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import useSiteMetadata from '../../hooks/use-site-metadata';
+
+function LoggedIn(props) {
+  const { telescopeUrl } = useSiteMetadata();
+  const logoutUrl = `${telescopeUrl}/auth/logout`;
+
+  return (
+    <div>
+      Welcome {props.email} <a href={logoutUrl}> Logout </a>
+      <img className="avatar" src={`https://unavatar.now.sh/${props.email}`} alt={props.email} />
+    </div>
+  );
+}
+
+LoggedIn.propTypes = {
+  email: PropTypes.string,
+};
+
+export default LoggedIn;

--- a/src/frontend/src/components/Login/LoggedOut.jsx
+++ b/src/frontend/src/components/Login/LoggedOut.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import useSiteMetadata from '../../hooks/use-site-metadata';
+
+function LoggedOut() {
+  const { telescopeUrl } = useSiteMetadata();
+  const loginUrl = `${telescopeUrl}/auth/login`;
+
+  return (
+    <div>
+      <a href={loginUrl}>Login</a>
+    </div>
+  );
+}
+
+export default LoggedOut;

--- a/src/frontend/src/components/Login/Login.jsx
+++ b/src/frontend/src/components/Login/Login.jsx
@@ -1,78 +1,47 @@
-/* eslint-disable class-methods-use-this */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-
+import React, { useState, useEffect } from 'react';
+import LoggedIn from './LoggedIn.jsx';
+import LoggedOut from './LoggedOut.jsx';
 import useSiteMetadata from '../../hooks/use-site-metadata';
 
 import './Login.css';
 
-function LoggedIn(props) {
+/**
+ * Show either a Login button (if user isn't authenticated)
+ * or a welcome message and Logout button.
+ */
+
+function Login() {
   const { telescopeUrl } = useSiteMetadata();
-  const logoutUrl = `${telescopeUrl}/auth/logout`;
+  const [email, setEmail] = useState(null);
 
-  return (
-    <div>
-      Welcome {props.email} <a href={logoutUrl}> Logout </a>
-      <img className="avatar" src={`https://unavatar.now.sh/${props.email}`} alt={props.email} />
-    </div>
-  );
-}
+  useEffect(() => {
+    // Try to get user session info from the server.
+    async function getUserInfo() {
+      try {
+        // See if the server has session info on this user
+        const response = await fetch(`${telescopeUrl}/user/info`);
 
-function LoggedOut() {
-  const { telescopeUrl } = useSiteMetadata();
-  const loginUrl = `${telescopeUrl}/auth/login`;
-
-  return (
-    <div>
-      <a href={loginUrl}>Login</a>
-    </div>
-  );
-}
-
-class Login extends Component {
-  // Initialize the state
-  constructor(props) {
-    super(props);
-    this.state = {
-      email: null,
-    };
-  }
-
-  componentDidMount() {
-    fetch('../user/info', {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    })
-      .then(response => {
-        if (response.ok) {
-          return response;
+        if (!response.ok) {
+          // Not an error, we're just not authenticated
+          if (response.status === 401) {
+            return;
+          }
+          throw new Error(response.statusText);
         }
-        throw new Error('Error danger will robinson');
-      })
-      .then(response => response.json())
-      .then(user => {
-        if (user) {
-          this.setState({ email: user.email });
-        }
-        return true;
-      })
-      .catch(error => {
-        // Handles an error thrown above, as well as network general errors
-        console.log(error);
-      });
-  }
 
-  render() {
-    if (this.state.email) {
-      return <LoggedIn email={this.state.email} />;
+        const user = await response.json();
+        if (user && user.email) {
+          setEmail(user.email);
+        }
+      } catch (error) {
+        console.error('Error getting user info', error);
+      }
     }
-    return <LoggedOut />;
-  }
+
+    getUserInfo();
+  }, []);
+
+  return email ? <LoggedIn email={email} /> : <LoggedOut />;
 }
-LoggedIn.propTypes = {
-  email: PropTypes.string,
-};
 
 export default Login;


### PR DESCRIPTION
@Grommers00, @agarcia-caicedo and I were discussing functional vs. class components in React.  I refactored the recent Login component we were working on at the time to be functional so we would have an example to discuss.

The main changes here:

- split out the `LoggedIn` and `LoggedOut` components to their own files
- switch from using an ES6 class to a function for Login
- use `const [email, setEmail] = useState(null);` to deal with state.  The `useState()` React function returns an array with 2 things: the current value of the state, a function to update it.
- switch from `componentDidMount()` to `useEffect()`.  Notice the use of the `[]` as the last arg, which will mean it only fires once on startup.
- moved away from Promise-based `fetch` code to use async/await
