### PR TITLE
adds: docker multistage builds for reduce container sizes

### DIFF
--- a/developer.Dockerfile
+++ b/developer.Dockerfile
@@ -1,0 +1,46 @@
+# This Docker file tends to be used only
+# for `development` and `test` stage
+#
+# CLI command to run this file: script="some-name" docker-compose up --build
+# `some-name` is one of the names provided under `scripts` tag in `package.json` file
+# example: $ script="test" docker-compose up --build    --> will run telescope with `test` script
+# default: $ docker-compose up --build                  --> will run telescope with `start` script
+
+
+# Dockerfile
+
+# Context: Build Container
+# Use `node` long term stable image as the parent to build this image
+FROM node:lts-alpine as build
+
+# Use Redis image via compose-file
+
+# Change working directory on the image
+WORKDIR "/telescope"
+
+# Copy package.json and .npmrc from local to the image
+# Copy before bundle app source to make sure package-lock.json never gets involved
+COPY package.json ./
+COPY .npmrc ./
+# Bundle app source
+COPY . .
+
+# Install all Node.js modules on the image
+RUN npm install --no-package-lock
+
+# Build Frontend before deployment
+RUN npm run build
+
+
+# ADD . src/frontend/public
+
+# User is root by default (only for development)
+
+# Expose the server port from compose file
+
+# Environment variable with default value
+ENV script=start
+
+# Running telescope when the image gets built using a script
+# `script` is one of the scripts from `packege.json`, passed to the image
+CMD ["sh", "-c", "npm run ${script}"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Fixes https://github.com/Seneca-CDOT/telescope/issues/682

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

![image](https://user-images.githubusercontent.com/14265337/74092237-23d28780-4a8f-11ea-9183-94d789c81677.png)


Generates docker containers using a the native multistage build process, specifically for the staging environment. This reduces the current container size from ~1.91GB (640MB with @humphd's experiment) to  ~251MB!

```
telescope_telescope           latest              95b308226ca8        4 minutes ago       251MB
<none>                        <none>              5957bf2d5b55        4 minutes ago       940MB
<none>                        <none>              986285b4fdda        8 minutes ago       773MB
node                          12.15.0-alpine3.9   72805eb6a2b6        46 hours ago        84.9MB
redis                         latest              44d36d2c2374        7 days ago          98.2MB
kristophjunge/test-saml-idp   latest              a85d01fab7df        2 years ago         457MB
```

<!-- Please add a detailed description of what this PR does and why it is needed -->
**IMPORTANT**
To test locally, use the staging.Dockerfile  instead of developer.Dockerfile  in the docker-compose.yml file.


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally _Tested locally on W10, unable to verify npm test due to the reduced node packages on final container_
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [X] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
