### PR TITLE
fix: Change settings to restrict access to redis container

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -24,8 +24,6 @@ services:
 
   redis:
     image: redis:latest
-    ports:
-      - '$REDIS_PORT:$REDIS_PORT'
     restart: always
 
   # SSO Identity Provider test service, https://simplesamlphp.org
@@ -34,6 +32,7 @@ services:
     environment:
       - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID:-saml-poc}
       - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SAML2_REDIRECT_URI}
+      - SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE=${SLO_LOGOUT_CALLBACK_URL}
     # image owner's blog post https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9
     image: kristophjunge/test-saml-idp
     ports:
@@ -54,7 +53,8 @@ services:
       - 80:80
       - 443:443
     restart: always
-    depends_on: telescope
+    depends_on:
+      - telescope
     # This makes nginx reload its configuration (and certificates) every six hours in the background and
     # launches nginx in the foreground
     command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -31,7 +31,7 @@ services:
   login:
     environment:
       - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID:-saml-poc}
-      - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SAML2_REDIRECT_URI}
+      - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SSO_LOGIN_CALLBACK_URL}
       - SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE=${SLO_LOGOUT_CALLBACK_URL}
     # image owner's blog post https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9
     image: kristophjunge/test-saml-idp

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -18,8 +18,6 @@ services:
     depends_on:
       - redis
       - login
-    ports:
-      - '$PORT:$PORT'
     restart: always
 
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     depends_on:
       - redis
       - login
-    ports:
-      - '$PORT:$PORT'
 
   redis:
     image: redis:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@
 version: '3'
 
 services:
-  # First service
   telescope:
     build:
       context: .
@@ -17,19 +16,16 @@ services:
       - REDIS_URL=redis://redis:${REDIS_PORT}
     depends_on:
       - redis
+      - login
     ports:
       - '$PORT:$PORT'
 
-  # Second service
   redis:
     image: redis:latest
-    ports:
-      - '$REDIS_PORT:$REDIS_PORT'
 
-  # Third service
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml
-  ssoipd:
+  login:
     environment:
       - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID:-saml-poc}
       - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SSO_LOGIN_CALLBACK_URL}

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,7 +30,7 @@ http {
     listen 80;
     server_name login.telescope.cdot.systems;
     location / {
-      proxy_pass http://telescope/login;
+      proxy_pass http://telescope_staging/login;
     }
   }
 }

--- a/src/frontend/src/components/Layout/Layout.js
+++ b/src/frontend/src/components/Layout/Layout.js
@@ -49,11 +49,11 @@ class Layout extends Component {
   async getPosts(pageNum = 1) {
     let postsData = [];
     try {
-      const res = await fetch(`http://dev.telescope.cdot.systems/posts?page=${pageNum}`);
+      const res = await fetch(`https://dev.telescope.cdot.systems/posts?page=${pageNum}`);
       const postsUrls = await res.json();
       postsData = await Promise.all(
         postsUrls.map(async ({ url }) => {
-          const tmp = await fetch(`http://dev.telescope.cdot.systems${url}`);
+          const tmp = await fetch(`https://dev.telescope.cdot.systems${url}`);
           const post = await tmp.json();
           return post;
         })


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR changes settings in our docker-compose files to restrict access to our redis container from outside of the docker network. Port `6379` should be unreachable now.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
