### PR TITLE
Fix: Add ports for telescope and redis local deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,13 @@ services:
     depends_on:
       - redis
       - login
+    ports:
+      - ${PORT}:${PORT}
 
   redis:
     image: redis:latest
+    ports:
+      - ${REDIS_PORT}:${REDIS_PORT}
 
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR addresses 2 issues:
- Telescope still needs access to `redis` from outside of the docker network when `redis` runs using docker-compose and telescope is launched using the command line. For that, it's necessary to specify `redis'` port in the `docker-compose` file used for development.
- Also, to be able to access telescope when it's launched using docker, the port used in our `.env` must be added to our `docker-compose` file used for development.


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
