### PR TITLE
Fix: Change response from 301 to 307 and redirect request to the right route

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ http {
   server {
     listen 80 default_server;
     server_name _;
-    return 301 https://$host$request_uri;
+    return 307 https://$host$request_uri;
   }
 
   server {
@@ -30,7 +30,7 @@ http {
     listen 80;
     server_name login.telescope.cdot.systems;
     location / {
-      proxy_pass http://telescope_staging/login;
+      proxy_pass http://telescope_staging:3000/auth/login;
     }
   }
 }


### PR DESCRIPTION
## Issue This PR Addresses

Progress towards #691 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This is initial work to be able to use `SSO` with `HTTPS`.
This PR makes sure that `POST` requests sent from a client don't turn into `GET` requests due to a [301](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) response in our `nginx.conf`. For that, [307](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) will be used instead.

> The only difference between 307 and 302 is that 307 guarantees that the method and the body will not be changed when the redirected request is made. With 302, some old clients were incorrectly changing the method to GET: the behavior with non-GET methods and 302 is then unpredictable on the Web, whereas the behavior with 307 is predictable.

Also, `login.telescope.cdot.systems` now redirects to the correct route.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
