### PR TITLE
Remove author, site from Post, add feed id

### DIFF
--- a/src/backend/data/feed.js
+++ b/src/backend/data/feed.js
@@ -45,39 +45,40 @@ class Feed {
   }
 
   /**
-   * Creates a Feed by extracting data from the given feed-like object.
-   * @param {Object} o - an Object containing the necessary fields for a feed
+   * Creates a new Feed object by extracting data from the given feed-like object.
+   * @param {Object} feedData - an Object containing the necessary fields.
+   * Returns the newly created Feed's id.
    */
-  static parse(o) {
-    return new Feed(o.author, o.url, o.etag, o.lastModified);
+  static async create(feedData) {
+    const feed = new Feed(feedData.author, feedData.url, feedData.etag, feedData.lastModified);
+    await feed.save();
+    return feed.id;
   }
 
   /**
    * Returns a Feed from the database using the given id
    * @param {String} id - the id of a feed (hashed, normalized url) to get from Redis.
+   * Returns a Promise<Feed>
    */
   static async byId(id) {
-    const feed = await getFeed(id);
+    const data = await getFeed(id);
     // No feed found using this id
-    if (!(feed && feed.id)) {
+    if (!(data && data.id)) {
       return null;
     }
-    return Feed.parse(feed);
+
+    return new Feed(data.author, data.url, data.etag, data.lastModified);
   }
 
   /**
    * Returns a Feed from the database using the given url
    * @param {String} url - the url of a feed to get from Redis.
+   * Returns a Promise<Feed>
    */
-  static async byUrl(url) {
+  static byUrl(url) {
     // Use the URL to generate an id
     const id = urlToId(url);
-    const feed = await this.byId(id);
-    // No feed found using this url's id
-    if (!(feed && feed.id)) {
-      return null;
-    }
-    return Feed.parse(feed);
+    return this.byId(id);
   }
 }
 

--- a/src/backend/data/feed.js
+++ b/src/backend/data/feed.js
@@ -32,6 +32,7 @@ class Feed {
 
   /**
    * Adds the current Feed to the database with the specified reason
+   * Returns a Promise.
    */
   setInvalid(reason) {
     setInvalidFeed(this.id, reason);
@@ -39,6 +40,7 @@ class Feed {
 
   /**
    * Checks whether the current feed is valid or not
+   * Returns a Promise<Boolean>.
    */
   isInvalid() {
     return isInvalid(this.id);
@@ -47,7 +49,7 @@ class Feed {
   /**
    * Creates a new Feed object by extracting data from the given feed-like object.
    * @param {Object} feedData - an Object containing the necessary fields.
-   * Returns the newly created Feed's id.
+   * Returns the newly created Feed's id as a Promise<String>
    */
   static async create(feedData) {
     const feed = new Feed(feedData.author, feedData.url, feedData.etag, feedData.lastModified);

--- a/src/backend/data/post.js
+++ b/src/backend/data/post.js
@@ -76,8 +76,11 @@ class Post {
     // A valid RSS/Atom feed can have missing fields that we care about.
     // Keep track of any that are missing, and throw if necessary.
     const missing = [];
+    // description is the content of the post
     if (!article.description) missing.push('description');
+    // link is the URL of the post
     if (!article.link) missing.push('link');
+    // guid is the unique identifier of the post
     if (!article.guid) missing.push('guid');
 
     if (missing.length) {

--- a/src/backend/data/post.js
+++ b/src/backend/data/post.js
@@ -13,17 +13,16 @@ function toDate(date) {
 }
 
 class Post {
-  constructor(author, title, html, datePublished, dateUpdated, postUrl, siteUrl, guid) {
+  constructor(title, html, datePublished, dateUpdated, postUrl, guid, feed) {
     // Use the post's guid as our unique identifier
     this.id = hash(guid);
-    this.author = author;
     this.title = title;
     this.html = html;
     this.published = datePublished ? toDate(datePublished) : new Date();
     this.updated = dateUpdated ? toDate(dateUpdated) : new Date();
     this.url = postUrl;
-    this.site = siteUrl;
     this.guid = guid;
+    this.feed = feed;
   }
 
   /**
@@ -48,7 +47,7 @@ class Post {
    *
    * If data is missing, throws an error.
    */
-  static fromArticle(article) {
+  static fromArticle(article, feed) {
     // Validate the properties we get, and if we don't have them all, throw
     if (!article) {
       throw new Error('unable to parse, missing article');
@@ -57,11 +56,9 @@ class Post {
     // A valid RSS/Atom feed can have missing fields that we care about.
     // Keep track of any that are missing, and throw if necessary.
     const missing = [];
-    if (!article.author) missing.push('author');
     if (!article.description) missing.push('description');
     if (!article.link) missing.push('link');
     if (!article.guid) missing.push('guid');
-    if (!(article.meta && article.meta.link)) missing.push('meta.link');
 
     if (missing.length) {
       const message = `invalid article: missing ${missing.join(', ')}`;
@@ -99,7 +96,6 @@ class Post {
     // NOTE: feedparser article properties are documented here:
     // https://www.npmjs.com/package/feedparser#list-of-article-properties
     return new Post(
-      article.author,
       article.title,
       // sanitized HTML version of the post
       sanitizedHTML,
@@ -109,9 +105,8 @@ class Post {
       article.date,
       // link is the url to the post
       article.link,
-      // meta.link is the url to the site
-      article.meta.link,
-      article.guid
+      article.guid,
+      feed
     );
   }
 
@@ -120,7 +115,7 @@ class Post {
    * @param {Object} o - an Object containing the necessary fields
    */
   static parse(o) {
-    return new Post(o.author, o.title, o.html, o.published, o.updated, o.url, o.site, o.guid);
+    return new Post(o.title, o.html, o.published, o.updated, o.url, o.guid, o.feed);
   }
 
   /**

--- a/src/backend/data/stats.js
+++ b/src/backend/data/stats.js
@@ -13,10 +13,10 @@ const Post = require('./post');
 const countWords = posts => posts.reduce((total, post) => total + count(post.text, 'words', {}), 0);
 
 /**
- * Get the total number of unique authors in the posts in the array
+ * Get the total number of unique feeds in the posts in the array
  * @param {Array<Post>} posts the array of post objects
  */
-const countAuthors = posts => new Set(posts.map(post => post.author)).size;
+const countFeeds = posts => new Set(posts.map(post => post.feed)).size;
 
 class Stats {
   constructor(startDate, endDate) {
@@ -36,7 +36,7 @@ class Stats {
 
     return {
       posts: posts.length,
-      authors: countAuthors(posts),
+      authors: countFeeds(posts),
       words: countWords(posts),
     };
   }

--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -120,7 +120,6 @@ function articlesToPosts(articles, feed) {
  * We expect the Feed to already exist in the system at this point.
  */
 module.exports = async function processor(job) {
-  logger.debug('processor', { id: job.data.id });
   const feed = await Feed.byId(job.data.id);
   if (!feed) {
     throw new Error(`unable to get Feed for id=${job.data.id}`);

--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -97,13 +97,13 @@ async function getFeedInfo(feed) {
  * Convert an array of Articles from the feed parser into Post objects.
  * @param {Array<article>} articles to process into posts
  */
-function articlesToPosts(articles) {
+function articlesToPosts(articles, feed) {
   const posts = [];
 
   articles.forEach(article => {
     if (!article) return;
     try {
-      const post = Post.fromArticle(article);
+      const post = Post.fromArticle(article, feed);
       posts.push(post);
     } catch (error) {
       // If this is just some missing data, ignore the post, otherwise throw.
@@ -170,7 +170,7 @@ module.exports = async function processor(job) {
       )
     );
     // Transform the list of articles to a list of Post objects
-    articles = articlesToPosts(articles);
+    articles = articlesToPosts(articles, feed.id);
 
     // Version info for this feed changed, so update the database
     feed.etag = feed.etag || info.etag;

--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -94,36 +94,43 @@ async function getFeedInfo(feed) {
 }
 
 /**
- * Convert an array of Articles from the feed parser into Post objects.
+ * Convert an array of Articles from the feed parser into Post objects
+ * and stores them in Redis.
  * @param {Array<article>} articles to process into posts
  */
 function articlesToPosts(articles, feed) {
-  const posts = [];
-
-  articles.forEach(article => {
-    if (!article) return;
-    try {
-      const post = Post.fromArticle(article, feed);
-      posts.push(post);
-    } catch (error) {
-      // If this is just some missing data, ignore the post, otherwise throw.
-      if (!(error instanceof ArticleError)) {
-        throw error;
+  return Promise.all(
+    articles.map(article => {
+      try {
+        return Post.createFromArticle(article, feed);
+      } catch (error) {
+        // If this is just some missing data, ignore the post, otherwise throw.
+        if (!(error instanceof ArticleError)) {
+          throw error;
+        }
+        return Promise.resolve();
       }
-    }
-  });
-
-  return posts;
+    })
+  );
 }
 
+/**
+ * The processor for the feed queue receives feed jobs, where
+ * the job to process is an Object with the `id` of the feed.
+ * We expect the Feed to already exist in the system at this point.
+ */
 module.exports = async function processor(job) {
-  const feed = Feed.parse(job.data);
-  let articles = [];
+  logger.debug('processor', { id: job.data.id });
+  const feed = await Feed.byId(job.data.id);
+  if (!feed) {
+    throw new Error(`unable to get Feed for id=${job.data.id}`);
+  }
+
   let info;
   const invalid = await feed.isInvalid();
   if (invalid) {
     logger.info(`Skipping resource at ${feed.url}. Feed previously marked invalid`);
-    return [];
+    return;
   }
   try {
     info = await getFeedInfo(feed);
@@ -152,13 +159,13 @@ module.exports = async function processor(job) {
           break;
       }
 
-      // No posts were processed, return an empty list.
-      return articles;
+      // No posts were processed.
+      return;
     }
 
     // Download the updated feed contents
     logger.info(`${info.status} Feed has new content: ${feed.url}`);
-    articles = await parse(
+    const articles = await parse(
       addHeaders(
         {
           url: feed.url,
@@ -170,7 +177,7 @@ module.exports = async function processor(job) {
       )
     );
     // Transform the list of articles to a list of Post objects
-    articles = articlesToPosts(articles, feed.id);
+    articlesToPosts(articles, feed);
 
     // Version info for this feed changed, so update the database
     feed.etag = feed.etag || info.etag;
@@ -189,6 +196,4 @@ module.exports = async function processor(job) {
       throw error;
     }
   }
-
-  return articles;
 };

--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -100,15 +100,15 @@ async function getFeedInfo(feed) {
  */
 function articlesToPosts(articles, feed) {
   return Promise.all(
-    articles.map(article => {
+    articles.map(async article => {
       try {
-        return Post.createFromArticle(article, feed);
+        await Post.createFromArticle(article, feed);
       } catch (error) {
         // If this is just some missing data, ignore the post, otherwise throw.
-        if (!(error instanceof ArticleError)) {
-          throw error;
+        if (error instanceof ArticleError) {
+          return;
         }
-        return Promise.resolve();
+        throw error;
       }
     })
   );
@@ -176,7 +176,7 @@ module.exports = async function processor(job) {
       )
     );
     // Transform the list of articles to a list of Post objects
-    articlesToPosts(articles, feed);
+    await articlesToPosts(articles, feed);
 
     // Version info for this feed changed, so update the database
     feed.etag = feed.etag || info.etag;

--- a/src/backend/feed/queue.js
+++ b/src/backend/feed/queue.js
@@ -12,14 +12,13 @@ setQueues(queue);
 
 /**
  * Provide a helper for adding a feed with our desired default options.
- * The `feedInfo` is an Object with `name` (i.e., name of author) and `url`
- * (i.e., url of feed) properties, matching what we parse from the wiki.
+ * The `job` contains an `id`, which refers to a Feed Object `id` already in Redis.
  */
-queue.addFeed = async function(feed) {
+queue.addFeed = async function(job) {
   const options = {
     // Override the Job ID to use the feed id, so we don't duplicate jobs.
     // Bull will not add a job if there already exists a job with the same id.
-    jobId: feed.id,
+    jobId: job.id,
     attempts: process.env.FEED_QUEUE_ATTEMPTS || 5,
     backoff: {
       type: 'exponential',
@@ -30,9 +29,9 @@ queue.addFeed = async function(feed) {
   };
 
   try {
-    await queue.add(feed, options);
+    await queue.add(job, options);
   } catch (error) {
-    logger.error({ error }, `Unable to add job for ${feed.url} to queue`);
+    logger.error({ error }, `Unable to add job for id=${job.id} to queue`);
   }
 };
 

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -3,7 +3,6 @@ const path = require('path');
 
 const feedQueue = require('./queue');
 const { logger } = require('../utils/logger');
-const Post = require('../data/post');
 
 /**
  * We determine the number of parallel feed processor functions to run
@@ -30,17 +29,5 @@ exports.start = function() {
   const concurrency = getFeedWorkersCount();
   logger.info(`Starting ${concurrency} instance${concurrency > 1 ? 's' : ''} of feed processor.`);
   feedQueue.process(concurrency, path.resolve(__dirname, 'processor.js'));
-
-  // When posts are returned from the queue, save them to the database
-  feedQueue.on('completed', async (job, posts) => {
-    try {
-      // The posts we get back will be Objects, and we need to convert
-      // to a full Post, then save to Redis.
-      await Promise.all(posts.map(post => Post.parse(post).save()));
-    } catch (error) {
-      logger.error({ error }, 'Error inserting posts into database');
-    }
-  });
-
   return feedQueue;
 };

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -69,8 +69,6 @@ module.exports = {
         key,
         'id',
         post.id,
-        'author',
-        post.author,
         'title',
         post.title,
         'html',
@@ -81,10 +79,10 @@ module.exports = {
         post.updated,
         'url',
         post.url,
-        'site',
-        post.site,
         'guid',
-        post.guid
+        post.guid,
+        'feed',
+        post.feed
       )
       // sort set by published date as scores
       .zadd(postsKey, post.published.getTime(), post.id)

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -4,7 +4,6 @@ const { isWebUri } = require('valid-url');
 
 require('../lib/config');
 const { logger } = require('../utils/logger');
-const Feed = require('../data/feed');
 
 const { JSDOM } = jsdom;
 
@@ -82,7 +81,7 @@ module.exports = async function() {
           `Skipping invalid wiki feed url ${currentFeedInfo.url} for author ${currentFeedInfo.author}`
         );
       } else {
-        feeds.push(Feed.parse(currentFeedInfo));
+        feeds.push(currentFeedInfo);
       }
 
       currentFeedInfo = {};

--- a/src/backend/web/graphql/index.js
+++ b/src/backend/web/graphql/index.js
@@ -26,15 +26,14 @@ module.exports.typeDefs = graphql`
   # 'Post' matches our Post type used with redis
   type Post {
     id: String
-    author: String
     title: String
     html: String
     text: String
     published: String
     updated: String
     url: String
-    site: String
     guid: String
+    feed: String
   }
 
   # Queries to fetch data from redis

--- a/src/backend/web/graphql/index.js
+++ b/src/backend/web/graphql/index.js
@@ -33,7 +33,7 @@ module.exports.typeDefs = graphql`
     updated: String
     url: String
     guid: String
-    feed: Feed
+    feed: Feed!
   }
 
   # Queries to fetch data from redis
@@ -147,7 +147,11 @@ module.exports.resolvers = {
       const posts = await Promise.all(postIds.map(Post.byId));
 
       if (filter.author) {
-        const authorResults = posts.filter(post => post.author === filter.author);
+        // Find all post's where the author contains our search term, ignoring case.
+        const authorSearchTerm = filter.author.toLowerCase();
+        const authorResults = posts.filter(post =>
+          post.feed.author.toLowerCase().includes(authorSearchTerm)
+        );
         // check if # of filtered results are less than max results allowed per page.
         if (authorResults.length < prPage) {
           return authorResults;

--- a/src/backend/web/graphql/index.js
+++ b/src/backend/web/graphql/index.js
@@ -33,7 +33,7 @@ module.exports.typeDefs = graphql`
     updated: String
     url: String
     guid: String
-    feed: String
+    feed: Feed
   }
 
   # Queries to fetch data from redis

--- a/src/backend/web/planet/views/planet.handlebars
+++ b/src/backend/web/planet/views/planet.handlebars
@@ -7,7 +7,7 @@
       {{#each .}}
         <div class="channelgroup">
           <br clear="both">
-          <h3 class="planetauthor"><a href="{{post.site}}" title="Stories by {{post.author}}">{{@key}}</a></h3>
+          <h3 class="planetauthor"><a href="{{post.site}}" title="Stories by {{post.feed.author}}">{{@key}}</a></h3>
 
           {{#each this as | post |}}
             <div class="entrygroup" id="{{post.guid}}">
@@ -17,7 +17,7 @@
                   {{{post.html}}}
                 </div>
                 <p class="date">
-                  <a href="{{post.url}}">by {{post.author}} at {{post.updated}}</a>
+                  <a href="{{post.url}}">by {{post.feed.author}} at {{post.updated}}</a>
                 </p>
               </div>
             </div>

--- a/src/backend/web/routes/feed.js
+++ b/src/backend/web/routes/feed.js
@@ -15,7 +15,7 @@ const { logger } = require('../../utils/logger');
 const Feed = require('../../data/feed');
 const Post = require('../../data/post');
 
-const { BASE_URL } = process.env;
+const { API_URL } = process.env;
 
 const router = express.Router();
 
@@ -30,17 +30,17 @@ const feedRoute = type => async (req, res) => {
   const feed = new FeedMeta({
     title: 'Telescope',
     description: "The Seneca College open source community's blog feed",
-    id: BASE_URL,
-    link: `${BASE_URL}/feed/${type}`,
+    id: API_URL,
+    link: `${API_URL}/feed/${type}`,
     language: 'en',
     // TODO: https://github.com/Seneca-CDOT/telescope/issues/637
     // image: 'http://example.com/image.png',
     // favicon: 'http://example.com/favicon.ico',
     copyright: 'Copyright original authors',
     feedLinks: {
-      rss: `${BASE_URL}/feed/rss`,
-      json: `${BASE_URL}/feed/json`,
-      atom: `${BASE_URL}/feed/atom`,
+      rss: `${API_URL}/feed/rss`,
+      json: `${API_URL}/feed/json`,
+      atom: `${API_URL}/feed/atom`,
     },
   });
 
@@ -48,7 +48,7 @@ const feedRoute = type => async (req, res) => {
   let posts;
   try {
     const ids = await getPosts(0, 50);
-    posts = await Promise.all(ids.map(id => Post.byId(id)));
+    posts = await Promise.all(ids.map(Post.byId));
   } catch (err) {
     logger.error({ err }, 'Error processing posts from Redis');
     res.status(503).send({
@@ -67,8 +67,8 @@ const feedRoute = type => async (req, res) => {
       content: post.html,
       author: [
         {
-          name: post.author,
-          link: post.site,
+          name: post.feed.author,
+          // TODO: add site info for this feed https://github.com/Seneca-CDOT/telescope/issues/724
         },
       ],
       date: post.updated,

--- a/src/backend/web/routes/planet.js
+++ b/src/backend/web/routes/planet.js
@@ -19,7 +19,7 @@ function formatDate(date) {
  */
 async function getPostDataGrouped() {
   const ids = await getPosts(0, 50);
-  const posts = await Promise.all(ids.map(id => Post.byId(id)));
+  const posts = await Promise.all(ids.map(Post.byId));
 
   // We group the posts into nested objects: days > authors > posts
   const grouped = { days: {} };
@@ -36,12 +36,12 @@ async function getPostDataGrouped() {
 
     // Days contain Author strings
     const day = grouped.days[formatted];
-    if (!day[post.author]) {
-      day[post.author] = {};
+    if (!day[post.feed.author]) {
+      day[post.feed.author] = {};
     }
 
     // Authors contain guid strings, which are references to post Objects
-    const author = day[post.author];
+    const author = day[post.feed.author];
     if (!author[post.guid]) {
       author[post.guid] = post;
     }

--- a/src/frontend/src/components/Login/Login.jsx
+++ b/src/frontend/src/components/Login/Login.jsx
@@ -39,7 +39,7 @@ function Login() {
     }
 
     getUserInfo();
-  }, []);
+  }, [telescopeUrl]);
 
   return email ? <LoggedIn email={email} /> : <LoggedOut />;
 }

--- a/src/frontend/src/components/TextArea/TextArea.jsx
+++ b/src/frontend/src/components/TextArea/TextArea.jsx
@@ -8,10 +8,10 @@ import './TextArea.css';
 const TextArea = ({ className, posts }) => {
   return (
     <div className={className}>
-      {posts.map(({ author, html, published, title, site, url }, index) => (
+      {posts.map(({ feed, html, title, url }, index) => (
         <Fragment key={index}>
           <Post
-            author={author}
+            author={feed.author}
             url={url}
             html={html}
             title={title}

--- a/test/feed-processor.test.js
+++ b/test/feed-processor.test.js
@@ -1,52 +1,59 @@
 const fixtures = require('./fixtures');
 const processor = require('../src/backend/feed/processor');
+const Feed = require('../src/backend/data/feed');
 
 describe('Feed Processor Tests', () => {
-  beforeAll(async () => {});
+  const createFeed = url =>
+    Feed.create({
+      author: 'author',
+      url,
+    });
 
   test('Passing a valid Atom feed URI should pass', async () => {
-    const feedURL = fixtures.getAtomUri();
+    const url = fixtures.getAtomUri();
+    const id = await createFeed(url);
     fixtures.nockValidAtomResponse();
-    const job = fixtures.createMockJobObjectFromURL(feedURL);
-    await expect(processor(job)).resolves.toBeTruthy();
+    const job = fixtures.createMockJobObjectFromFeedId(id);
+    await expect(processor(job)).resolves.not.toBeDefined();
   });
 
   test('Passing a valid RSS feed URI should pass', async () => {
-    const feedURL = fixtures.getRssUri();
+    const url = fixtures.getRssUri();
+    const id = await createFeed(url);
     fixtures.nockValidRssResponse();
-    const job = fixtures.createMockJobObjectFromURL(feedURL);
-    await expect(processor(job)).resolves.toBeTruthy();
+    const job = fixtures.createMockJobObjectFromFeedId(id);
+    await expect(processor(job)).resolves.not.toBeDefined();
   });
 
-  test('Passing a valid URI with HTML response should return an empty Array', async () => {
+  test('Passing a valid URI with HTML response should work', async () => {
     const url = fixtures.getHtmlUri();
+    const id = await createFeed(url);
     fixtures.nockValidHtmlResponse();
-    const job = fixtures.createMockJobObjectFromURL(url);
-    const result = await processor(job);
-    expect(Array.isArray(result)).toBe(true);
-    expect(result.length).toBe(0);
+    const job = fixtures.createMockJobObjectFromFeedId(id);
+    await expect(processor(job)).resolves.not.toBeDefined();
   });
 
   test('Passing an invalid RSS category feed should pass', async () => {
-    const feedURL = fixtures.getRssUri();
+    const url = fixtures.getRssUri();
+    const id = await createFeed(url);
     fixtures.nockInvalidRssResponse();
-    const job = fixtures.createMockJobObjectFromURL(feedURL);
-    await expect(processor(job)).resolves.toBeTruthy();
+    const job = fixtures.createMockJobObjectFromFeedId(id);
+    await expect(processor(job)).resolves.not.toBeDefined();
   });
 
   test('Passing a valid RSS category feed should pass', async () => {
-    const feedURL = fixtures.getRssUri();
+    const url = fixtures.getRssUri();
+    const id = await createFeed(url);
     fixtures.nockValidRssResponse();
-    const job = fixtures.createMockJobObjectFromURL(feedURL);
-    await expect(processor(job)).resolves.toBeTruthy();
+    const job = fixtures.createMockJobObjectFromFeedId(id);
+    await expect(processor(job)).resolves.not.toBeDefined();
   });
 
-  test('Non existent feed failure case: 404 should return an empty Array', async () => {
+  test('Non existent feed failure case: 404 should work', async () => {
     const url = fixtures.getHtmlUri();
+    const id = await createFeed(url);
     fixtures.nock404Response();
-    const job = fixtures.createMockJobObjectFromURL(url);
-    const result = await processor(job);
-    expect(Array.isArray(result)).toBe(true);
-    expect(result.length).toBe(0);
+    const job = fixtures.createMockJobObjectFromFeedId(id);
+    await expect(processor(job)).resolves.not.toBeDefined();
   });
 });

--- a/test/feed-processor.test.js
+++ b/test/feed-processor.test.js
@@ -1,48 +1,52 @@
 const fixtures = require('./fixtures');
 const processor = require('../src/backend/feed/processor');
 
-test('Passing a valid Atom feed URI should pass', async () => {
-  const feedURL = fixtures.getAtomUri();
-  fixtures.nockValidAtomResponse();
-  const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(processor(job)).resolves.toBeTruthy();
-});
+describe('Feed Processor Tests', () => {
+  beforeAll(async () => {});
 
-test('Passing a valid RSS feed URI should pass', async () => {
-  const feedURL = fixtures.getRssUri();
-  fixtures.nockValidRssResponse();
-  const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(processor(job)).resolves.toBeTruthy();
-});
+  test('Passing a valid Atom feed URI should pass', async () => {
+    const feedURL = fixtures.getAtomUri();
+    fixtures.nockValidAtomResponse();
+    const job = fixtures.createMockJobObjectFromURL(feedURL);
+    await expect(processor(job)).resolves.toBeTruthy();
+  });
 
-test('Passing a valid URI with HTML response should return an empty Array', async () => {
-  const url = fixtures.getHtmlUri();
-  fixtures.nockValidHtmlResponse();
-  const job = fixtures.createMockJobObjectFromURL(url);
-  const result = await processor(job);
-  expect(Array.isArray(result)).toBe(true);
-  expect(result.length).toBe(0);
-});
+  test('Passing a valid RSS feed URI should pass', async () => {
+    const feedURL = fixtures.getRssUri();
+    fixtures.nockValidRssResponse();
+    const job = fixtures.createMockJobObjectFromURL(feedURL);
+    await expect(processor(job)).resolves.toBeTruthy();
+  });
 
-test('Passing an invalid RSS category feed should pass', async () => {
-  const feedURL = fixtures.getRssUri();
-  fixtures.nockInvalidRssResponse();
-  const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(processor(job)).resolves.toBeTruthy();
-});
+  test('Passing a valid URI with HTML response should return an empty Array', async () => {
+    const url = fixtures.getHtmlUri();
+    fixtures.nockValidHtmlResponse();
+    const job = fixtures.createMockJobObjectFromURL(url);
+    const result = await processor(job);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(0);
+  });
 
-test('Passing a valid RSS category feed should pass', async () => {
-  const feedURL = fixtures.getRssUri();
-  fixtures.nockValidRssResponse();
-  const job = fixtures.createMockJobObjectFromURL(feedURL);
-  await expect(processor(job)).resolves.toBeTruthy();
-});
+  test('Passing an invalid RSS category feed should pass', async () => {
+    const feedURL = fixtures.getRssUri();
+    fixtures.nockInvalidRssResponse();
+    const job = fixtures.createMockJobObjectFromURL(feedURL);
+    await expect(processor(job)).resolves.toBeTruthy();
+  });
 
-test('Non existent feed failure case: 404 should return an empty Array', async () => {
-  const url = fixtures.getHtmlUri();
-  fixtures.nock404Response();
-  const job = fixtures.createMockJobObjectFromURL(url);
-  const result = await processor(job);
-  expect(Array.isArray(result)).toBe(true);
-  expect(result.length).toBe(0);
+  test('Passing a valid RSS category feed should pass', async () => {
+    const feedURL = fixtures.getRssUri();
+    fixtures.nockValidRssResponse();
+    const job = fixtures.createMockJobObjectFromURL(feedURL);
+    await expect(processor(job)).resolves.toBeTruthy();
+  });
+
+  test('Non existent feed failure case: 404 should return an empty Array', async () => {
+    const url = fixtures.getHtmlUri();
+    fixtures.nock404Response();
+    const job = fixtures.createMockJobObjectFromURL(url);
+    const result = await processor(job);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(0);
+  });
 });

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -30,10 +30,6 @@ describe('Fost data class tests', () => {
     expect(() => new Feed(undefined, undefined)).toThrow();
   });
 
-  test('Feed.parse() should be able to parse an Object into a Feed', () => {
-    expect(Feed.parse(data)).toEqual(createFeed());
-  });
-
   describe('Get and Set Feed objects from database', () => {
     beforeAll(() => createFeed().save());
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -3,8 +3,6 @@ const url = require('url');
 const fs = require('fs');
 const path = require('path');
 
-const Feed = require('../src/backend/data/feed');
-
 /**
  * This is a fixture module for telescope tests which contains measures to
  * maintain a reproducible environment for system testing
@@ -154,4 +152,4 @@ exports.nockRealWorldRssResponse = function(headers = {}) {
   nockResponse(getRealWorldRssUri(), getRealWorldRssBody(), 200, 'application/rss+xml', headers);
 };
 
-exports.createMockJobObjectFromURL = feedUrl => ({ data: new Feed('author', feedUrl) });
+exports.createMockJobObjectFromFeedId = id => ({ data: { id } });

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -2,10 +2,13 @@ const { parse } = require('feedparser-promised');
 
 const { nockRealWorldRssResponse, getRealWorldRssUri } = require('./fixtures');
 const Post = require('../src/backend/data/post');
+const Feed = require('../src/backend/data/feed');
 const hash = require('../src/backend/data/hash');
 
 describe('Post data class tests', () => {
   const text = 'post text';
+
+  const feed = new Feed('feed-author', 'http://feed-url.com/rss');
 
   const data = {
     title: 'Post Title',
@@ -15,11 +18,11 @@ describe('Post data class tests', () => {
     url: 'https://user.post.com/?post-id=123',
     guid: 'https://user.post.com/?post-id=123&guid',
     id: hash('https://user.post.com/?post-id=123&guid'),
-    feed: 'fake-feed-id',
+    feed,
   };
 
   const createPost = () =>
-    new Post(data.title, data.html, data.published, data.updated, data.url, data.guid, data.feed);
+    new Post(data.title, data.html, data.published, data.updated, data.url, data.guid, feed);
 
   test('Post should be a function', () => {
     expect(typeof Post).toBe('function');
@@ -29,37 +32,85 @@ describe('Post data class tests', () => {
     expect(createPost()).toEqual(data);
   });
 
-  test('Post.parse() should be able to parse an Object into a Post', () => {
-    expect(Post.parse(data)).toEqual(createPost());
+  test('Post constructor should work with with published and updated as Strings', () => {
+    const post1 = createPost();
+    const post2 = new Post(
+      data.title,
+      data.html,
+      'Thu, 20 Nov 2014 18:59:18 UTC',
+      'Thu, 20 Nov 2014 18:59:18 UTC',
+      data.url,
+      data.guid,
+      feed
+    );
+
+    expect(post1).toEqual(post2);
   });
 
-  test('Posts should have a (dynamic) text property', () => {
-    const post1 = Post.parse(data);
-    const post2 = createPost();
+  test('Post constructor should work with with published and updated as Dates', () => {
+    const post1 = createPost();
+    const post2 = new Post(
+      data.title,
+      data.html,
+      new Date('Thu, 20 Nov 2014 18:59:18 UTC'),
+      new Date('Thu, 20 Nov 2014 18:59:18 UTC'),
+      data.url,
+      data.guid,
+      feed
+    );
 
-    expect(post1.text).toEqual(text);
-    expect(post2.text).toEqual(text);
+    expect(post1).toEqual(post2);
   });
 
-  test('Post.parse() should work with missing fields', () => {
+  test('Post constructor should throw if feed is missing or not a Feed instance', () => {
+    const createPostWithFeed = f =>
+      new Post(data.title, data.html, data.published, data.updated, data.url, data.guid, f);
+
+    expect(() => createPostWithFeed(null)).toThrow();
+    expect(() => createPostWithFeed(undefined)).toThrow();
+    expect(() => createPostWithFeed('feedid')).toThrow();
+    expect(() => createPostWithFeed(1234)).toThrow();
+    expect(() => createPostWithFeed({})).toThrow();
+    expect(() => createPostWithFeed(feed)).not.toThrow();
+  });
+
+  test.only('Post.create() should be able to parse an Object into a Post', async () => {
+    const id = await Post.create(data);
+    const expectedId = 'a371654c75';
+    expect(id).toEqual(expectedId);
+    const post = await Post.byId(expectedId);
+    expect(post).toEqual(createPost());
+    expect(post.feed instanceof Feed).toBe(true);
+  });
+
+  test('Posts should have a (dynamic) text property', async () => {
+    const id = await Post.create(data);
+    const post = await Post.byId(id);
+    expect(post.text).toEqual(text);
+  });
+
+  test('Post.create() should work with missing fields', async () => {
     const missingData = { ...data, updated: null };
-    const post = createPost();
-    post.updated = null;
 
     // Make sure that updated was turned into a date
-    const parsed = Post.parse(missingData);
+    const id = await Post.create(missingData);
+    const parsed = await Post.byId(id);
     expect(parsed.updated instanceof Date).toBe(true);
-
-    // Rip it off again and compare to original data
-    parsed.updated = null;
-    expect(parsed).toEqual(post);
   });
 
   test('Post.save() and Post.byId() should both work as expected', async () => {
-    const post = createPost();
+    const id = await Post.create(data);
+    const post = await Post.byId(id);
+    expect(post).toEqual(data);
+
+    // Modify the post and save
+    post.title = 'updated title';
     await post.save();
-    const result = await Post.byId(data.id);
-    expect(result).toEqual(post);
+
+    // Get it back again
+    const post2 = await Post.byId(id);
+    const data2 = { ...data, title: 'updated title' };
+    expect(post2).toEqual(data2);
   });
 
   test('Post.byId() with invalid id should return null', async () => {
@@ -79,13 +130,13 @@ describe('Post data class tests', () => {
     });
 
     test('Post.fromArticle() should throw if passed nothing', () => {
-      expect(() => Post.fromArticle(null)).toThrow();
+      expect(() => Post.fromArticle(null, feed)).toThrow();
       expect(() => Post.fromArticle()).toThrow();
     });
 
     test('Post.fromArticle() should work with real world RSS', () => {
       const article = articles[0];
-      const post = Post.fromArticle(article, 'feed-id');
+      const post = Post.fromArticle(article, feed);
 
       expect(post.title).toEqual('Teaching Open Source, Fall 2019');
       expect(
@@ -97,43 +148,43 @@ describe('Post data class tests', () => {
       expect(post.url).toEqual('https://blog.humphd.org/open-source-fall-2019/');
       expect(post.guid).toEqual('5df7bbd924511e03496b4734');
       expect(post.id).toEqual(hash(post.guid));
-      expect(post.feed).toEqual('feed-id');
+      expect(post.feed).toEqual(feed);
     });
 
     test('Post.fromArticle() with missing description should throw', () => {
       const article = articles[0];
       delete article.description;
-      expect(() => Post.fromArticle(article)).toThrow();
+      expect(() => Post.fromArticle(article, feed)).toThrow();
     });
 
     test('Post.fromArticle() with missing pubdate should not throw', () => {
       const article = articles[0];
       delete article.pubdate;
-      expect(() => Post.fromArticle(article)).not.toThrow();
+      expect(() => Post.fromArticle(article, feed)).not.toThrow();
     });
 
     test('Post.fromArticle() with missing date should not throw', () => {
       const article = articles[0];
       delete article.date;
-      expect(() => Post.fromArticle(article)).not.toThrow();
+      expect(() => Post.fromArticle(article, feed)).not.toThrow();
     });
 
     test('Post.fromArticle() with missing link should throw', () => {
       const article = articles[0];
       delete article.link;
-      expect(() => Post.fromArticle(article)).toThrow();
+      expect(() => Post.fromArticle(article, feed)).toThrow();
     });
 
     test('Post.fromArticle() with missing guid should throw', () => {
       const article = articles[0];
       delete article.guid;
-      expect(() => Post.fromArticle(article)).toThrow();
+      expect(() => Post.fromArticle(article, feed)).toThrow();
     });
 
     test('Post.fromArticle() with missing title should use Untitled', () => {
       const article = articles[0];
       delete article.title;
-      const post = Post.fromArticle(article);
+      const post = Post.fromArticle(article, feed);
       expect(post.title).toEqual('Untitled');
     });
   });

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -8,28 +8,18 @@ describe('Post data class tests', () => {
   const text = 'post text';
 
   const data = {
-    author: 'Post Author',
     title: 'Post Title',
     html: '<p>post text</p>',
     published: new Date('Thu, 20 Nov 2014 18:59:18 UTC'),
     updated: new Date('Thu, 20 Nov 2014 18:59:18 UTC'),
     url: 'https://user.post.com/?post-id=123',
-    site: 'https://user.post.com',
     guid: 'https://user.post.com/?post-id=123&guid',
     id: hash('https://user.post.com/?post-id=123&guid'),
+    feed: 'fake-feed-id',
   };
 
   const createPost = () =>
-    new Post(
-      data.author,
-      data.title,
-      data.html,
-      data.published,
-      data.updated,
-      data.url,
-      data.site,
-      data.guid
-    );
+    new Post(data.title, data.html, data.published, data.updated, data.url, data.guid, data.feed);
 
   test('Post should be a function', () => {
     expect(typeof Post).toBe('function');
@@ -95,9 +85,8 @@ describe('Post data class tests', () => {
 
     test('Post.fromArticle() should work with real world RSS', () => {
       const article = articles[0];
-      const post = Post.fromArticle(article);
+      const post = Post.fromArticle(article, 'feed-id');
 
-      expect(post.author).toEqual('David Humphrey');
       expect(post.title).toEqual('Teaching Open Source, Fall 2019');
       expect(
         post.html.startsWith(`<p>Today I've completed another semester of teaching open source`)
@@ -106,15 +95,9 @@ describe('Post data class tests', () => {
       expect(post.published).toEqual(new Date('Mon, 16 Dec 2019 20:37:14 GMT'));
       expect(post.updated).toEqual(new Date('Mon, 16 Dec 2019 20:37:14 GMT'));
       expect(post.url).toEqual('https://blog.humphd.org/open-source-fall-2019/');
-      expect(post.site).toEqual('https://blog.humphd.org/');
       expect(post.guid).toEqual('5df7bbd924511e03496b4734');
       expect(post.id).toEqual(hash(post.guid));
-    });
-
-    test('Post.fromArticle() with missing author should throw', () => {
-      const article = articles[0];
-      delete article.author;
-      expect(() => Post.fromArticle(article)).toThrow();
+      expect(post.feed).toEqual('feed-id');
     });
 
     test('Post.fromArticle() with missing description should throw', () => {
@@ -144,19 +127,6 @@ describe('Post data class tests', () => {
     test('Post.fromArticle() with missing guid should throw', () => {
       const article = articles[0];
       delete article.guid;
-      expect(() => Post.fromArticle(article)).toThrow();
-    });
-
-    test('Post.fromArticle() with missing meta should throw', () => {
-      const article = articles[0];
-      delete article.meta;
-      expect(() => Post.fromArticle(article)).toThrow();
-    });
-
-    test('Post.fromArticle() with missing meta.link should throw', () => {
-      const article = articles[0];
-      delete article.meta;
-      article.meta = {};
       expect(() => Post.fromArticle(article)).toThrow();
     });
 

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -68,27 +68,25 @@ describe('test /posts/:id responses', () => {
 
   // Post Object
   const addedPost1 = new Post(
-    'author',
     'title',
     'html',
     new Date('2009-09-07T22:20:00.000Z'),
     new Date('2009-09-07T22:23:00.000Z'),
     'url',
-    'site',
-    existingGuid
+    existingGuid,
+    'feed-id'
   );
 
   // Raw JS Object, expected to be returned by a correct query
   const receivedPost1 = {
-    author: 'author',
     title: 'title',
     html: 'html',
     published: '2009-09-07T22:20:00.000Z',
     updated: '2009-09-07T22:23:00.000Z',
     url: 'url',
-    site: 'site',
     guid: 'http://existing-guid',
     id: hash('http://existing-guid'),
+    feed: 'feed-id',
   };
 
   // add the post to the storage

--- a/test/wiki-feed-parser.test.js
+++ b/test/wiki-feed-parser.test.js
@@ -1,7 +1,6 @@
 global.fetch = require('node-fetch');
 
 const getWikiFeeds = require('../src/backend/utils/wiki-feed-parser');
-const Feed = require('../src/backend/data/feed');
 
 const mockFeed = `################# Failing Feeds Commented Out [Start] #################
 
@@ -48,22 +47,16 @@ test('Testing wiki-feed-parser.parseData', async () => {
   fetch.mockResponseOnce(mockBody);
 
   const expectedData = [
-    Feed.parse({
+    {
       author: 'Pirathapan Sivalingam',
       url: 'http://kopay.wordpress.com/category/sbr600-win2011/feed',
-    }),
-    Feed.parse({
-      author: 'Jesse Fulton',
-      url: 'http://jessefulton.wordpress.com/category/SBR600/feed/',
-    }),
-    Feed.parse({
-      author: 'Eric Ferguson',
-      url: 'http://eric-spo600.blogspot.com/feeds/posts/default',
-    }),
-    Feed.parse({
+    },
+    { author: 'Jesse Fulton', url: 'http://jessefulton.wordpress.com/category/SBR600/feed/' },
+    { author: 'Eric Ferguson', url: 'http://eric-spo600.blogspot.com/feeds/posts/default' },
+    {
       author: 'Armen Zambrano G. (armenzg)',
       url: 'http://armenzg.blogspot.com/feeds/posts/default/-/open%20source',
-    }),
+    },
   ];
 
   const response = await getWikiFeeds();

--- a/tools/add-feed.js
+++ b/tools/add-feed.js
@@ -5,8 +5,8 @@ require('../src/backend/lib/config');
 const args = require('minimist')(process.argv.slice(2));
 const isValidUrl = require('valid-url');
 
+const Feed = require('../src/backend/data/feed');
 const { logger } = require('../src/backend/utils/logger');
-const feedQueue = require('../src/backend/feed/queue');
 
 const log = logger.child({ module: 'add-feed' });
 
@@ -24,10 +24,8 @@ async function add() {
     process.exit(1);
   }
 
-  const feedInfo = { name, url };
-
   try {
-    await feedQueue.addFeed(feedInfo);
+    await Feed.create({ author: name, url });
     process.exit(0);
   } catch (err) {
     process.exit(1);


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #716, #665

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This is a WIP to remove duplicated feed info such as `author` and `site` from a Post, and replace it with the id of a `feed`.  For example:

```
# Post
curl -H 'Accepts: application/json' http://localhost:3000/posts/00107ba358
{
  "id": "00107ba358",
  "title": "Part 3: ZFS Setup",
  "html": "<p>...</p>",
  "published": "2019-12-18T04:43:05.000Z",
  "updated": "2019-12-18T04:43:05.000Z",
  "url": "https://ebraublog.wordpress.com/2019/12/18/part-3-zfs-setup/",
  "guid": "http://ebraublog.wordpress.com/?p=58",
  "feed": "4f53e7478d"
}

# Feed
curl -H 'Accepts: application/json' http://localhost:3000/feeds/4f53e7478d
{
  "id": "4f53e7478d",
  "author": "Eric Brauer",
  "url": "https://ebraublog.wordpress.com/category/CDOT/feed/",
  "etag": "W/\"1e7899a6c0d9861dcc15f2434092f4d3\"",
  "lastModified": "Thu, 13 Feb 2020 03:41:58 GMT"
}
```

Since we know the `feed` its `id` when we process each `post`, it's easy to add the `feed`'s `id` right then.

Some questions I have about things I have to solve before we can merge this:

1. What should `Post.byId("00107ba358")` return for the feed info?  Options include: a) raw id "feed": "4f53e7478d"; b) expanded feed data `feed: { id: ..., name, ..., url, ...}`.  The latter would make this easier to use in the frontend, so you don't have to do more queries to get the feed info.
1. How do I fix the GraphQL to use this properly?  If i do b) above, it would mean you already have the data you need; otherwise I have to somehow go and get it in the query.

Based on these, I'll need to fix the frontend to use this data.  I also need to move the site URL info into the feed itself.