### PR TITLE
Follow-up to PR #726: complete feed processing delay implementation

### DIFF
--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -126,8 +126,7 @@ module.exports = async function processor(job) {
   }
 
   let info;
-  const invalid = await feed.isInvalid();
-  const delayed = await feed.isDelayed();
+  const [invalid, delayed] = await Promise.all([feed.isInvalid(), feed.isDelayed()]);
   if (invalid) {
     logger.info(`Skipping resource at ${feed.url}. Feed previously marked invalid`);
     return;

--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -127,8 +127,13 @@ module.exports = async function processor(job) {
 
   let info;
   const invalid = await feed.isInvalid();
+  const delayed = await feed.isDelayed();
   if (invalid) {
     logger.info(`Skipping resource at ${feed.url}. Feed previously marked invalid`);
+    return;
+  }
+  if (delayed) {
+    logger.info(`Skipping resource at ${feed.url}. Feed previously marked for delayed processing`);
     return;
   }
   try {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

#624, which was closed by #726

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Implements the functionality to make the feed processor 'back off' from delayed feeds, which somehow ended up disappearing from PR #724.

_A big thank-you to @c3ho, who discovering that this functionality was missing from the original PR!_

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
