### PR TITLE
Connect GraphQL to Telescope

### DIFF
--- a/src/frontend/gatsby-config.js
+++ b/src/frontend/gatsby-config.js
@@ -49,15 +49,6 @@ module.exports = {
       },
     },
     `gatsby-theme-material-ui`,
-    /*{
-      resolve: `gatsby-source-graphql`,
-      options: {
-        typeName: `FEEDS`,
-        fieldName: 'feeds',
-        url: 'http://localhost:3000/graphql',
-        refetchInterval: 60,
-      },
-    },*/
     {
       resolve: `gatsby-source-graphql`,
       options: {

--- a/src/frontend/gatsby-config.js
+++ b/src/frontend/gatsby-config.js
@@ -54,7 +54,7 @@ module.exports = {
       options: {
         typeName: `Telescope`,
         fieldName: 'telescope',
-        url: 'https://dev.telescope.cdot.systems/graphql',
+        url: `${telescopeUrl}/graphql`,
         refetchInterval: 60,
       },
     },

--- a/src/frontend/gatsby-config.js
+++ b/src/frontend/gatsby-config.js
@@ -49,5 +49,23 @@ module.exports = {
       },
     },
     `gatsby-theme-material-ui`,
+    /*{
+      resolve: `gatsby-source-graphql`,
+      options: {
+        typeName: `FEEDS`,
+        fieldName: 'feeds',
+        url: 'http://localhost:3000/graphql',
+        refetchInterval: 60,
+      },
+    },*/
+    {
+      resolve: `gatsby-source-graphql`,
+      options: {
+        typeName: `Telescope`,
+        fieldName: 'telescope',
+        url: 'https://dev.telescope.cdot.systems/graphql',
+        refetchInterval: 60,
+      },
+    },
   ],
 };

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,6 +13,7 @@
     "gatsby-plugin-react-helmet": "^3.1.16",
     "gatsby-plugin-sharp": "^2.3.5",
     "gatsby-source-filesystem": "^2.1.40",
+    "gatsby-source-graphql": "^2.1.33",
     "gatsby-theme-material-ui": "^1.0.8",
     "gatsby-transformer-sharp": "^2.3.7",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #697 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This is actually pretty confusing to use and I've only had success with getting the data as a StaticQuery instead of a Page.  To test changes, use `npm run develop` and navigate to http://localhost:8000/__graphql. 

There should now be a checkbox called `telescope` on the left hand side. Once you click on that you'll find all the other queries we have set up. The `telescope` is like a wrapper. The great thing is, you can build your query in there and then export it using `Code Exporter`. Make sure when you export you change the dropdown from `Page Query` to `StaticQuery`

![image](https://user-images.githubusercontent.com/18711727/75263986-b9268900-57bc-11ea-8b73-32b982d32c71.png)

One thing to watch out for is that when you get the data, its an object, so to get at the data that I want in my above query(title) I have to do something like `JSON.stringify(data.telescope.getPosts)`

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
