### PR TITLE
Fix #704 - update docs, settings for release

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -7,5 +7,8 @@
   },
   "github": {
     "release": true
+  },
+  "npm": {
+    "publish": false
   }
 }

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,11 +29,11 @@ To help automate this process, we use the [release-it](https://www.npmjs.com/pac
 To create a new release, follow these steps:
 
 1. Make sure you've done everything in the Setup section above, including your `GITHUB_TOKEN`.
+1. Make sure your `master` branch is up-to-date, and you have the most recent git tags in your repo: `git pull upstream master --tags`.
 1. Run `npm outdated` to see a report of [outdated npm packages](https://docs.npmjs.com/cli-commands/outdated.html). Examine this list and decide whether we need to update
    anything now, or before the next release. _Please file a new Issue to update
    anything that is outdated_.
 1. Determine what the new version number should be based on [semantic versioning](https://docs.npmjs.com/about-semantic-versioning).
-1. Use `npm run release --dry-run` to see what would happen if you did a release
 1. Use `npm run release` to actually do the full release
 
 As part of the process, [release-it](https://www.npmjs.com/package/release-it) will


### PR DESCRIPTION
## Issue This PR Addresses

1. Fixes #704

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This updates our release-it config to not try and publish to `npm`, and removes the `--dry-run` instructions, since they don't work.  I've also updated the docs to have the person running this pull the latest tags so the changelog will work (it's looking for changes since the last tag, and if you don't have it, you don't get a changelog).

If we want to test this, we could do a 0.7.1 release.  It might be good to get #781 merged first, though.