### PR TITLE
Fix #767: Adjust styles for <pre> and <code> in posts

### DIFF
--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -23,22 +23,6 @@
   vertical-align: text-top;
 }
 
-.telescope-post-content code,
-.telescope-post-content pre {
-  background: rgb(239, 240, 241);
-  border-bottom-color: rgb(57, 51, 24);
-  color: rgb(57, 51, 24);
-  page-break-inside: avoid;
-  font-family: Consolas, Menlo, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono';
-  font-size: 1.5rem;
-  line-height: 1.6;
-  max-width: 100%;
-  overflow: auto;
-  padding: 1em 1.5em;
-  display: block;
-  word-wrap: break-word;
-}
-
 .telescope-post-content h1 {
   font-size: 2.5em;
   max-width: 670px;
@@ -55,4 +39,35 @@
   line-height: 25px;
   font-family: Palatino, Georgia, Cambrai, 'Times New Roman', Times, 'Helvetica Neue', Helvetica,
     Arial;
+}
+
+/**
+ * Styling for <code> (inline), <pre> (block), and <pre><code>...</code></pre>
+ */
+.telescope-post-content code,
+.telescope-post-content pre {
+  font-family: Consolas, Menlo, Monaco, 'Lucida Console', 'Liberation Mono', monospace;
+}
+
+.telescope-post-content code {
+  background: #8a8a8a;
+  color: #242424;
+  padding: 2px 4px;
+}
+
+.telescope-post-content pre {
+  color: rgb(57, 51, 24);
+  background: rgb(239, 240, 241);
+  border: 1px solid rgb(57, 51, 24);
+  page-break-inside: avoid;
+  font-size: 1.5rem;
+  line-height: 1.5;
+  max-width: 100%;
+  overflow: auto;
+  padding: 0.5em 1.5em;
+  word-wrap: break-word;
+}
+
+.telescope-post-content pre > code {
+  background: rgb(239, 240, 241);
 }

--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -46,18 +46,16 @@
  */
 .telescope-post-content code,
 .telescope-post-content pre {
-  font-family: Consolas, Menlo, Monaco, 'Lucida Console', 'Liberation Mono', monospace;
+  font-family: Menlo, Consolas, Monaco, 'Liberation Mono', 'Lucida Console', monospace;
+  background: rgb(239, 240, 241);
+  color: rgb(57, 51, 24);
 }
 
 .telescope-post-content code {
-  background: #8a8a8a;
-  color: #242424;
   padding: 2px 4px;
 }
 
 .telescope-post-content pre {
-  color: rgb(57, 51, 24);
-  background: rgb(239, 240, 241);
   border: 1px solid rgb(57, 51, 24);
   page-break-inside: avoid;
   font-size: 1.5rem;
@@ -66,8 +64,4 @@
   overflow: auto;
   padding: 0.5em 1.5em;
   word-wrap: break-word;
-}
-
-.telescope-post-content pre > code {
-  background: rgb(239, 240, 241);
 }


### PR DESCRIPTION

## Issue This PR Addresses

1. Fixes #767

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

I've adjusted our styles for `<pre>`, `<code>`, and combos of the two.  I tried two approaches to inline code, and don't know which I like better (currently I left it dark):

<img width="1215" alt="Screen Shot 2020-03-03 at 3 19 25 PM" src="https://user-images.githubusercontent.com/427398/75816304-f2359f00-5d62-11ea-961b-e8931882f120.png">
<img width="1215" alt="Screen Shot 2020-03-03 at 3 19 00 PM" src="https://user-images.githubusercontent.com/427398/75816306-f2ce3580-5d62-11ea-954d-70f290ab839a.png">

Which one do you like better?