### PR TITLE
Reduce width of posts to match other sites

### DIFF
--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -19,10 +19,10 @@ const useStyles = makeStyles({
     padding: '1.5em',
   },
   title: {
-    fontSize: '2.5em',
+    fontSize: '2em',
   },
   author: {
-    fontSize: '1.5em',
+    fontSize: '1.2em',
   },
   published: {
     textDecoration: 'none',

--- a/src/frontend/src/components/Posts/Posts.jsx
+++ b/src/frontend/src/components/Posts/Posts.jsx
@@ -8,6 +8,7 @@ import Post from '../Post/Post.jsx';
 const useStyles = makeStyles({
   root: {
     padding: 0,
+    maxWidth: '785px',
   },
 });
 
@@ -15,7 +16,7 @@ const Posts = ({ posts }) => {
   const classes = useStyles();
 
   return (
-    <Container maxWidth="md" className={classes.root}>
+    <Container className={classes.root}>
       {posts.map(({ id, feed, html, title, url, updated }) => (
         <Post
           key={id}


### PR DESCRIPTION
I've tried reducing the width of the posts, so that we have fewer words per line.  I also reduced some font sizes in the heading to make it work better.

Compare with these:

- https://medium.com/@REAS/collecting-in-the-age-of-digital-reproduction-ab0640a42fe6
- https://www.newyorker.com/sports/sporting-scene/the-blockbuster-video-game-that-wants-to-make-america-whole-again?utm_source=twitter&utm_brand=tny&mbid=social_twitter&utm_social-type=owned&utm_medium=social
- https://www.nytimes.com/2019/11/04/science/voyager-2-interstellar-solar-wind.html
- https://longreads.com/2019/11/07/california-burning/

I think going any wider makes it hard to read, as your head/eye has to travel to take in the whole line.

See my notes in https://github.com/Seneca-CDOT/telescope/issues/339.