### PR TITLE
Fix post padding for mobile

### DIFF
--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
   header: {
     backgroundColor: '#335A7E',
     color: '#002944',
-    padding: '1.5em',
+    padding: '2em',
   },
   title: {
     fontSize: '2em',
@@ -29,7 +29,7 @@ const useStyles = makeStyles({
     color: '#A4D4FF',
   },
   content: {
-    padding: '2em 4em',
+    padding: '2em',
   },
 });
 


### PR DESCRIPTION
This increases the amount of text we can see on mobile, reducing padding around the post.  I think the reduced space is also nice for larger sizes, too, but let me know if you disagree.