### PR TITLE
fixes: utilizes telescope-blue as primary color, makes FAB larger

### DIFF
--- a/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
@@ -61,7 +61,7 @@ export default function BackToTop(props) {
       <Toolbar id="back-to-top-anchor" />
       <ScrollTop {...props}>
         <Fab color="primary" aria-label="scroll back to top">
-          <KeyboardArrowUpIcon />
+          <KeyboardArrowUpIcon fontSize="large" />
         </Fab>
       </ScrollTop>
     </React.Fragment>

--- a/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
@@ -60,7 +60,7 @@ export default function BackToTop(props) {
       <CssBaseline />
       <Toolbar id="back-to-top-anchor" />
       <ScrollTop {...props}>
-        <Fab color="primary" size="small" aria-label="scroll back to top">
+        <Fab color="primary" aria-label="scroll back to top">
           <KeyboardArrowUpIcon />
         </Fab>
       </ScrollTop>

--- a/src/frontend/src/theme.js
+++ b/src/frontend/src/theme.js
@@ -5,7 +5,7 @@ import { createMuiTheme } from '@material-ui/core/styles';
 const theme = createMuiTheme({
   palette: {
     primary: {
-      main: '#2e2e2e',
+      main: '#a4d4ff',
     },
     secondary: {
       main: '#3670a5',

--- a/src/frontend/src/theme.js
+++ b/src/frontend/src/theme.js
@@ -5,7 +5,7 @@ import { createMuiTheme } from '@material-ui/core/styles';
 const theme = createMuiTheme({
   palette: {
     primary: {
-      main: '#a4d4ff',
+      main: '#335A7E',
     },
     secondary: {
       main: '#3670a5',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #793 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Changes primary color used in `theme.js` to `telescope-blue` as I call it, which is `#a4d4ff`. Can be changed to whichever is preferred.

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)

MDDPI-Screen
![image](https://user-images.githubusercontent.com/14265337/75942574-bbde4980-5e60-11ea-8d78-be284d737e47.png)

HD Phone Screen
![image](https://user-images.githubusercontent.com/14265337/75942593-d31d3700-5e60-11ea-88a4-b3b4ba9a90f3.png)

- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
