### PR TITLE
Add automatic syntax highlighting for <pre> post elements

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,6 +13,7 @@
     "gatsby-plugin-sharp": "2.4.5",
     "gatsby-source-filesystem": "2.1.48",
     "gatsby-transformer-sharp": "2.3.16",
+    "highlight.js": "9.18.1",
     "prop-types": "15.7.2",
     "react": "16.13.0",
     "react-dom": "16.13.0",

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { makeStyles } from '@material-ui/core/styles';
 import { Container, Grid } from '@material-ui/core';
 
+import syntaxHighlight from './syntax-highlight';
 import './telescope-post-content.css';
 
 const useStyles = makeStyles({
@@ -42,6 +43,10 @@ function formatPublishedDate(dateString) {
 
 const Post = ({ id, html, author, url, title, date }) => {
   const classes = useStyles();
+  // We need a ref to our post content, which we inject into a <section> below.
+  const sectionEl = useRef(null);
+  // When we initialize, find and highlight all <pre> elements contained within.
+  useEffect(() => syntaxHighlight(sectionEl.current), [sectionEl]);
 
   return (
     <Container className={classes.root}>
@@ -57,7 +62,11 @@ const Post = ({ id, html, author, url, title, date }) => {
 
       <Grid container>
         <Grid item xs={12} className={classes.content}>
-          <section className="telescope-post-content" dangerouslySetInnerHTML={{ __html: html }} />
+          <section
+            ref={sectionEl}
+            className="telescope-post-content"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
         </Grid>
       </Grid>
     </Container>

--- a/src/frontend/src/components/Post/syntax-highlight.js
+++ b/src/frontend/src/components/Post/syntax-highlight.js
@@ -1,0 +1,66 @@
+import hljs from 'highlight.js/lib/highlight';
+
+// Tweak the language list here, see https://highlightjs.org/usage/
+import cpp from 'highlight.js/lib/languages/cpp';
+import sql from 'highlight.js/lib/languages/sql';
+import powershell from 'highlight.js/lib/languages/powershell';
+import cs from 'highlight.js/lib/languages/cs';
+import go from 'highlight.js/lib/languages/go';
+import css from 'highlight.js/lib/languages/css';
+import makefile from 'highlight.js/lib/languages/makefile';
+import markdown from 'highlight.js/lib/languages/markdown';
+import swift from 'highlight.js/lib/languages/swift';
+import armasm from 'highlight.js/lib/languages/armasm';
+import diff from 'highlight.js/lib/languages/diff';
+import python from 'highlight.js/lib/languages/python';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import http from 'highlight.js/lib/languages/http';
+import typescript from 'highlight.js/lib/languages/typescript';
+import ini from 'highlight.js/lib/languages/ini';
+import bash from 'highlight.js/lib/languages/bash';
+import nginx from 'highlight.js/lib/languages/nginx';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import rust from 'highlight.js/lib/languages/rust';
+import json from 'highlight.js/lib/languages/json';
+import x86asm from 'highlight.js/lib/languages/x86asm';
+import kotlin from 'highlight.js/lib/languages/kotlin';
+import xml from 'highlight.js/lib/languages/xml';
+import shell from 'highlight.js/lib/languages/shell';
+import yaml from 'highlight.js/lib/languages/yaml';
+
+import 'highlight.js/styles/github.css';
+
+hljs.registerLanguage('cpp', cpp);
+hljs.registerLanguage('sql', sql);
+hljs.registerLanguage('powershell', powershell);
+hljs.registerLanguage('cs', cs);
+hljs.registerLanguage('go', go);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('makefile', makefile);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('swift', swift);
+hljs.registerLanguage('armasm', armasm);
+hljs.registerLanguage('diff', diff);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('dockerfile', dockerfile);
+hljs.registerLanguage('http', http);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('ini', ini);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('nginx', nginx);
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('rust', rust);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('x86asm', x86asm);
+hljs.registerLanguage('kotlin', kotlin);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('shell', shell);
+hljs.registerLanguage('yaml', yaml);
+
+export default function(node) {
+  if (node) {
+    node.querySelectorAll('pre').forEach(pre => hljs.highlightBlock(pre));
+  }
+}


### PR DESCRIPTION
@Silvyre got me thinking about this during class today, and it turns out to be possible!  This uses [highlight.js](https://highlightjs.org/) to do automatic language detection and syntax highlighting.

<img width="1134" alt="Screen Shot 2020-03-04 at 9 54 02 PM" src="https://user-images.githubusercontent.com/427398/75943350-bc77df80-5e62-11ea-9fd6-425456e5b433.png">

I've enabled all the languages I think we typically see at Seneca, but if you want others added, we can do that too.