### PR TITLE
Fix #775: include RelayState with referrer info in SAML response

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ FROM build AS dependencies
 
 # Get Entire Codebase
 COPY . .
+# Copy certs into container
+COPY ./certs ./certs
 
 # Install Production Modules, Build!
 RUN npm install --only=production --no-package-lock
@@ -43,6 +45,8 @@ FROM build AS release
 COPY --from=dependencies /telescope/node_modules /telescope/node_modules
 COPY --from=dependencies /telescope/src/frontend/public /telescope/src/frontend/public
 COPY ./src/backend ./src/backend
+# Copy certs into container
+COPY ./certs ./certs
 
 # Environment variable with default value
 ENV script=start

--- a/developer.Dockerfile
+++ b/developer.Dockerfile
@@ -24,6 +24,8 @@ COPY package.json ./
 COPY .npmrc ./
 # Bundle app source
 COPY . .
+# Copy the certs/ directory
+COPY ./certs ./certs
 
 # Install all Node.js modules on the image
 RUN npm install --no-package-lock

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -28,7 +28,7 @@ services:
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml
   login:
     environment:
-      - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID:-saml-poc}
+      - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID}
       - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SSO_LOGIN_CALLBACK_URL}
       - SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE=${SLO_LOGOUT_CALLBACK_URL}
     # image owner's blog post https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml
   login:
     environment:
-      - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID:-saml-poc}
+      - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML2_CLIENT_ID}
       - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SSO_LOGIN_CALLBACK_URL}
       - SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE=${SLO_LOGOUT_CALLBACK_URL}
     # image owner's blog post https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9

--- a/docs/login.md
+++ b/docs/login.md
@@ -45,39 +45,68 @@ from `src/backend/web/authentication.js`.
 We use a test SAML SSO provider via a [docker image](kristophjunge/test-saml-idp).
 You can [read more about how it works here](https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9).
 
-To get this to run locally, you need to follow these steps.
+### Setup
 
-1. From your project root directory, run the shell script in `tools/generate_ssl_certs.sh` to generate SSL certificates.
+To get this to run locally, you need to create three `.pem` files:
 
-2. You will also need to create a `idp_key.pem` file in the `certs/` folder that gets created with the following key:
+1. a private key for localhost
+1. a public certificate for localhost
+1. a public key for the test SAML provider
 
-`MIIDXTCCAkWgAwIBAgIJALmVVuDWu4NYMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMjMxMTQzNDQ3WhcNNDgwNjI1MTQzNDQ3WjBFMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUCFozgNb1h1M0jzNRSCjhOBnR`
+For good background on what each of these are, see [this explanation](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs).
 
-3. Update your `.env` file (copy `env.example` if you don't have one) to ensure all related SAML2 SSO variables are defined. You need the following to be set:
+From the root of the project, follow these steps:
 
-   ```ini
-   # The Single Sign On (SSO) login service URL
-   SSO_LOGIN_URL=http://localhost:8080/simplesaml/saml2/idp/SSOService.php
+```bash
+$ mkdir certs
+$ cd certs
+$ ../tools/generate-ssl-certs.sh
+Generating a 4096 bit RSA private key
+..................................................................................................................................................................................................++
+......................................................................................................................................................................................................++
+writing new private key to 'privkey.pem'
+-----
+```
 
-   # The callback URL endpoint to be used by the SSO login service (see the /auth route)
-   SSO_LOGIN_CALLBACK_URL=http://localhost:3000/auth/login/callback
+You will now have the following three files:
 
-   # The Single Logout (SLO) service URL
-   SLO_LOGOUT_URL=http://localhost:8080/simplesaml/saml2/idp/SingleLogoutService.php
+1. `certs/cert.pem` your public certificate
+1. `certs/privkey.pem` your private key
+1. `certs/idp_pubkey.pem` the public key for the Dockerized SSO Identify Provider
 
-   # The callback URL endpoint to be used by the SLO logout service (see the /auth route)
-   SLO_LOGOUT_CALLBACK_URL=http://localhost:3000/auth/logout/callback
+### Environment Variables
 
-   # SAML2_CLIENT_ID = CLIENT ID obtained from SAML Strategy default: saml-poc
-   SAML2_CLIENT_ID=saml-poc
+With the necessary `.pem` files created, update your `.env` file (copy `env.example`
+if you don't have one) to ensure all related SAML2 SSO variables are defined.
+You need the following to be set:
 
-   # SAML2_CLIENT_SECRET = CLIENT SECRET obtained from SAML Strategy, default : secret;
-   SAML2_CLIENT_SECRET=secret
-   ```
+```ini
+# The Single Sign On (SSO) login service URL
+SSO_LOGIN_URL=http://localhost:8080/simplesaml/saml2/idp/SSOService.php
 
-4. Start the backend apps using `docker-compose up –build`. This will build the SAML2 server that is being used as a local service for testing purposes, and Telescope (express). From there, you should be able to click on the login button at `http://localhost:3000/` that will redirect you to the proper login page.
+# The callback URL endpoint to be used by the SSO login service (see the /auth route)
+SSO_LOGIN_CALLBACK_URL=http://localhost:3000/auth/login/callback
 
-5. The test SSO server uses the following fake user accounts:
+# The Single Logout (SLO) service URL
+SLO_LOGOUT_URL=http://localhost:8080/simplesaml/saml2/idp/SingleLogoutService.php
+
+# The callback URL endpoint to be used by the SLO logout service (see the /auth route)
+SLO_LOGOUT_CALLBACK_URL=http://localhost:3000/auth/logout/callback
+
+# SAML2_CLIENT_ID = CLIENT ID obtained from SAML Strategy default
+SAML2_CLIENT_ID=telescope
+
+# SAML2_CLIENT_SECRET = CLIENT SECRET obtained from SAML Strategy, default : secret;
+SAML2_CLIENT_SECRET=secret
+```
+
+### Running the SSO Identify Provider
+
+Start the backend apps using `docker-compose up –build`. This will build the SAML2 server that is being used as a local service for testing purposes, and Telescope (express). From there, you should be able to click on the login button at `http://localhost:3000/` that will redirect you to the proper login page.
+
+## SSO Fake user Accounts
+
+The test SSO server uses the following fake user accounts:
 
 | Username | Password  |
 | -------- | --------- |

--- a/env.example
+++ b/env.example
@@ -41,6 +41,15 @@ SSO_LOGIN_URL=http://localhost:8080/simplesaml/saml2/idp/SSOService.php
 # The callback URL endpoint to be used by the SSO login service (see the /auth route)
 SSO_LOGIN_CALLBACK_URL=http://localhost:3000/auth/login/callback
 
+# The SSO Identity Provider's certificate .pem file
+SSO_IDP_CERT_PEM_FILE=certs/idp_cert.pem
+
+# Our app's certificate .pem file
+SSO_PRIVATE_CERT_PEM_FILE=certs/cert.pem
+
+# Our app's private key .pem file
+SSO_PRIVATE_KEY_PEM_FILE=certs/privkey.pem
+
 # The Single Logout (SLO) service URL
 SLO_LOGOUT_URL=http://localhost:8080/simplesaml/saml2/idp/SingleLogoutService.php
 

--- a/env.staging
+++ b/env.staging
@@ -33,6 +33,15 @@ SSO_LOGIN_URL=http://dev.telescope.cdot.systems:8080/simplesaml/saml2/idp/SSOSer
 # The callback URL endpoint to be used by the SSO login service (see the /auth route)
 SSO_LOGIN_CALLBACK_URL=http://dev.telescope.cdot.systems/auth/login/callback
 
+# The SSO Identity Provider's certificate .pem file
+SSO_IDP_CERT_PEM_FILE=certs/idp_cert.pem
+
+# Our app's certificate .pem file
+SSO_PRIVATE_CERT_PEM_FILE=certs/cert.pem
+
+# Our app's private key .pem file
+SSO_PRIVATE_KEY_PEM_FILE=certs/privkey.pem
+
 # The Single Logout (SLO) service URL
 SLO_LOGOUT_URL=http://dev.telescope.cdot.systems:8080/simplesaml/saml2/idp/SingleLogoutService.php
 

--- a/src/backend/web/app.js
+++ b/src/backend/web/app.js
@@ -13,7 +13,6 @@ const logger = require('../utils/logger');
 const authentication = require('./authentication');
 const router = require('./routes');
 
-const secret = authentication.init(passport);
 const app = express();
 
 // Enable CORS and preflight checks on all routes
@@ -37,9 +36,11 @@ app.set('view engine', 'handlebars');
 app.set('logger', logger);
 app.use(logger);
 
-// Setup Passport SAML based Authentication
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+
+// Setup Passport SAML based Authentication
+const secret = authentication.init(passport);
 // TODO: decide if we should do resave=false, https://www.npmjs.com/package/express-session#resave
 app.use(session({ secret, resave: false, saveUninitialized: true }));
 app.use(passport.initialize());

--- a/src/backend/web/authentication/index.js
+++ b/src/backend/web/authentication/index.js
@@ -6,8 +6,8 @@ const SamlStrategy = require('passport-saml').Strategy;
 const fs = require('fs');
 const path = require('path');
 
-const { logger } = require('../utils/logger');
-const hash = require('../data/hash');
+const { logger } = require('../../utils/logger');
+const hash = require('../../data/hash');
 
 /**
  * Get our SSO/SLO/SAML/Auth env variables, and warn if any are missing
@@ -134,28 +134,6 @@ function samlMetadata() {
   return strategy.generateServiceProviderMetadata(getCert(), getCert());
 }
 
-/**
- * Middleware to make sure that a route is authenticated. If the user is
- * already authenticated, your route will be called. If the user is already
- * authenticated, the next() route will be be called, otherwise an HTTP 401
- * Unauthorized will be returned on the response. This is probably what you
- * want for a REST API endpoint.
- *
- * To use:
- *
- * router.get('/your/route', protect, function(res, res) { ... }))
- */
-function protect(req, res, next) {
-  // If the user is already authenticated, let this pass to next route
-  if (req.isAuthenticated()) {
-    next();
-  } else {
-    // TODO: should probably send appropriate response type (HTML, JSON, etc.)
-    res.status(401).send('Unauthorized');
-  }
-}
-
 module.exports.init = init;
-module.exports.protect = protect;
 module.exports.strategy = strategy;
 module.exports.samlMetadata = samlMetadata;

--- a/src/backend/web/authentication/index.js
+++ b/src/backend/web/authentication/index.js
@@ -4,7 +4,6 @@
 
 const SamlStrategy = require('passport-saml').Strategy;
 const fs = require('fs');
-const path = require('path');
 
 const { logger } = require('../../utils/logger');
 const hash = require('../../data/hash');
@@ -18,6 +17,9 @@ function getAuthEnv() {
     SAML2_CLIENT_SECRET,
     SSO_LOGIN_URL,
     SSO_LOGIN_CALLBACK_URL,
+    SSO_IDP_CERT_PEM_FILE,
+    SSO_PRIVATE_CERT_PEM_FILE,
+    SSO_PRIVATE_KEY_PEM_FILE,
     SLO_LOGOUT_URL,
     SLO_LOGOUT_CALLBACK_URL,
   } = process.env;
@@ -28,6 +30,9 @@ function getAuthEnv() {
       SAML2_CLIENT_SECRET &&
       SSO_LOGIN_URL &&
       SSO_LOGIN_CALLBACK_URL &&
+      SSO_IDP_CERT_PEM_FILE &&
+      SSO_PRIVATE_CERT_PEM_FILE &&
+      SSO_PRIVATE_KEY_PEM_FILE &&
       SLO_LOGOUT_URL &&
       SLO_LOGOUT_CALLBACK_URL
     )
@@ -40,28 +45,49 @@ function getAuthEnv() {
   }
 
   return {
-    SAML2_CLIENT_ID,
-    SAML2_CLIENT_SECRET,
+    SAML2_CLIENT_ID: SAML2_CLIENT_ID || 'telescope',
+    SAML2_CLIENT_SECRET: SAML2_CLIENT_SECRET || hash(`secret-${Date.now()}!`),
     SSO_LOGIN_URL,
     SSO_LOGIN_CALLBACK_URL,
+    SSO_IDP_CERT_PEM_FILE,
+    SSO_PRIVATE_CERT_PEM_FILE,
+    SSO_PRIVATE_KEY_PEM_FILE,
     SLO_LOGOUT_URL,
     SLO_LOGOUT_CALLBACK_URL,
   };
 }
 
-// TODO: figure out our cert/key loading
-let cert;
+/**
+ * Read and process a PEM-encoded X.509 signing certificate, extracting
+ * the portion between "BEGIN CERTIFICATE" and "END CERTIFICATE".
+ * If the certificate is already a single line, we'll use it as is.
+ */
+function readCert(filename) {
+  let cert = fs.readFileSync(filename, 'utf8');
+  // Strip containing CERTIFICATE wrapper
+  cert = cert.replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '');
+  // Join into a single line if split
+  cert = cert.replace(/\r?\n/, '');
 
-function getCert() {
-  if (cert) {
-    return cert;
-  }
+  return cert;
+}
 
-  try {
-    cert = fs.readFileSync(path.resolve(process.cwd(), './certs/key.pem'), 'utf8');
-  } catch (error) {
-    logger.error({ error }, 'Unable to load certs/key.pem');
-  }
+/**
+ * Our public certificate so that we can get a private key to sign SAML Requests.
+ * We need our public PEM-encoded X.509 signing certificate, and we use the portion
+ * between "PRIVATE KEY" and "END PRIVATE KEY". This is then used to obtain the
+ * private cert. In the end we want a String in the following form:
+ *
+ * privateCert: 'MIICizCCAfQCCQCY8tKaMc0BMjANBgkqh ... W=='
+ *
+ * If the certificate is already a single line, we'll use it as is.
+ */
+function getPrivateKey(filename) {
+  let cert = fs.readFileSync(filename, 'utf8');
+  // Strip containing CERTIFICATE wrapper
+  cert = cert.replace('-----BEGIN PRIVATE KEY-----', '').replace('-----END PRIVATE KEY-----', '');
+  // Join into a single line if split
+  cert = cert.replace(/\r?\n/, '');
 
   return cert;
 }
@@ -76,6 +102,8 @@ function init(passport) {
     SAML2_CLIENT_SECRET,
     SSO_LOGIN_URL,
     SSO_LOGIN_CALLBACK_URL,
+    SSO_IDP_CERT_PEM_FILE,
+    SSO_PRIVATE_KEY_PEM_FILE,
     SLO_LOGOUT_URL,
     SLO_LOGOUT_CALLBACK_URL,
   } = getAuthEnv();
@@ -98,40 +126,46 @@ function init(passport) {
   });
 
   // Setup SAML authentication strategy
-  strategy = new SamlStrategy(
-    {
-      // See param details at https://github.com/bergie/passport-saml#config-parameter-details
-      logoutUrl: SLO_LOGOUT_URL,
-      logoutCallbackUrl: SLO_LOGOUT_CALLBACK_URL,
-      entryPoint: SSO_LOGIN_URL,
-      callbackUrl: SSO_LOGIN_CALLBACK_URL,
-      issuer: SAML2_CLIENT_ID,
-      // TODO: this isn't right yet.  See https://github.com/bergie/passport-saml#security-and-signatures
-      decryptionPvk: getCert(),
-      privateCert: getCert(),
-    },
-    function(profile, done) {
-      // TODO: we can probably pick off the user data we actually need here...
-      if (!profile) {
-        const error = new Error('SAML Strategy verify callback missing profile');
-        logger.error({ error });
-        done(error);
-      } else {
-        done(null, profile);
+  try {
+    strategy = new SamlStrategy(
+      {
+        // See param details at https://github.com/bergie/passport-saml#config-parameter-details
+        logoutUrl: SLO_LOGOUT_URL,
+        logoutCallbackUrl: SLO_LOGOUT_CALLBACK_URL,
+        entryPoint: SSO_LOGIN_URL,
+        callbackUrl: SSO_LOGIN_CALLBACK_URL,
+        issuer: SAML2_CLIENT_ID,
+        cert: readCert(SSO_IDP_CERT_PEM_FILE),
+        decryptionPvk: getPrivateKey(SSO_PRIVATE_KEY_PEM_FILE),
+      },
+      function(profile, done) {
+        // TODO: we can probably pick off the user data we actually need here...
+        if (!profile) {
+          const error = new Error('SAML Strategy verify callback missing profile');
+          logger.error({ error });
+          done(error);
+        } else {
+          done(null, profile);
+        }
       }
-    }
-  );
+    );
+  } catch (error) {
+    logger.error({ error }, 'Unable to initialize SAML Strategy');
+    throw error;
+  }
 
   passport.use(strategy);
 
   // Give back the session secret to use
-  return SAML2_CLIENT_SECRET || hash(`secret-${Date.now()}!`);
+  return SAML2_CLIENT_SECRET;
 }
 
 function samlMetadata() {
+  const { SSO_PRIVATE_CERT_PEM_FILE } = getAuthEnv();
+
   // I need to get the decryptionCert vs signingCert sorted out here...
   // https://github.com/bergie/passport-saml#generateserviceprovidermetadata-decryptioncert-signingcert-
-  return strategy.generateServiceProviderMetadata(getCert(), getCert());
+  return strategy.generateServiceProviderMetadata(readCert(SSO_PRIVATE_CERT_PEM_FILE));
 }
 
 module.exports.init = init;

--- a/src/backend/web/authentication/middleware.js
+++ b/src/backend/web/authentication/middleware.js
@@ -1,0 +1,43 @@
+const passport = require('passport');
+
+/**
+ * Middleware to make sure that a route is protected, and the user
+ * has already authenticated. If the user is already authenticated, the next
+ * route will be called. If not, an HTTP 401 Unauthorized response will be
+ * returned. This is probably what you want for a REST API endpoint.
+ *
+ * To use:
+ *
+ * router.get('/your/route', protect(), function(res, res) { ... }))
+ */
+function protect() {
+  return function(req, res, next) {
+    // If the user is already authenticated, let this pass to next route
+    if (req.isAuthenticated()) {
+      next();
+    } else {
+      // TODO: should probably send appropriate response type (HTML, JSON, etc.)
+      res.status(401).send('Unauthorized');
+    }
+  };
+}
+
+/**
+ * Authentication middleware, but remember where this login request came from.
+ * Stash the original referrer in the SAML RelayState. When we get a response
+ * in our callback, we'll pick it out of the POST data and redirect there vs /.
+ * This is probably what you want for a user-accessible URL route vs. REST API.
+ *
+ * To use:
+ *
+ * router.get('/your/route', authenticate(), function(res, res) { ... }))
+ */
+function authenticate() {
+  return function(req, res, next) {
+    req.query.RelayState = req.get('Referrer');
+    passport.authenticate('saml')(req, res, next);
+  };
+}
+
+module.exports.protect = protect;
+module.exports.authenticate = authenticate;

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -1,16 +1,18 @@
 require('../../lib/config');
 const express = require('express');
-const passport = require('passport');
 const { UI } = require('bull-board');
 const fs = require('fs');
+
+const { authenticate } = require('../authentication/middleware');
 const { logger } = require('../../utils/logger');
 
 const router = express.Router();
 
-// Only authenticated users can use this route
-router.use('/queues', passport.authenticate('saml'), UI);
+// Only authenticated users can use these routes
 
-router.get('/log', (req, res) => {
+router.use('/queues', authenticate(), UI);
+
+router.get('/log', authenticate(), (req, res) => {
   let readStream;
   if (!process.env.LOG_FILE) {
     res.send('LOG_FILE undefined in .env file');

--- a/src/backend/web/routes/user.js
+++ b/src/backend/web/routes/user.js
@@ -1,12 +1,12 @@
 const express = require('express');
 
-const { protect } = require('../authentication');
+const { protect } = require('../authentication/middleware');
 const { logger } = require('../../utils/logger');
 
 const router = express.Router();
 
 // Only authenticated users can use this route
-router.get('/info', protect, (req, res) => {
+router.get('/info', protect(), (req, res) => {
   if (!req.user) {
     logger.error('missing req.user!');
     return res.status(503).json({

--- a/tools/generate-ssl-certs.sh
+++ b/tools/generate-ssl-certs.sh
@@ -1,12 +1,31 @@
 #!/usr/bin/env bash
 
+
 set -e
 
-mkdir certs
-openssl req -x509       \
-  -newkey rsa:4096      \
-  -keyout certs/key.pem \
-  -out certs/cert.pem   \
-  -nodes                \
-  -subj '/CN=localhost' \
-  -days 365
+# Step 1) Generates local SSL pem files:
+#
+#   1. a new 4096-bit private key (privkey.pem)
+#   2. a self-signed public cert (cert.pem) for localhost good for 1024 days.
+#      The Distinguished Name (DN) fields are pre-set as follows:
+#
+#      Country Name (2 letter code) [CA]:CA
+#      State or Province Name (full name) [Some-State]:Ontario
+#      Locality Name (eg, city) []:Toronto
+#      Organization Name (eg, company) [Internet Widgits Pty Ltd]:CDOT
+#      Common Name (e.g. server FQDN or YOUR name) []:localhost
+#
+# NOTE: these are not suitable for use in
+# production. For good docs on what is happening here, see:
+# https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs
+openssl req                                              \
+  -x509                                                  \
+  -newkey rsa:4096                                       \
+  -nodes                                                 \
+  -subj "/C=CA/ST=Ontario/L=Toronto/O=CDOT/CN=localhost" \
+  -days 1024                                             \
+  -keyout privkey.pem                                    \
+  -out cert.pem
+
+# Step 2) IDP Public Cert - https://github.com/bergie/passport-saml/blob/master/test/static/acme_tools_com.cert
+echo -e '-----BEGIN CERTIFICATE-----\nMIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5h\nY21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkx\nFzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A\nMIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqw\nO1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L\n1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyY\nwngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv\n2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxj\no+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IB\nAQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg\n8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/\n+YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDir\nKJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp\n0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+p\nlHpOX1rt1R+UiTEIhTSXPNt/\n-----END CERTIFICATE-----' > idp_cert.pem


### PR DESCRIPTION
## Issue This PR Addresses

1. Fixes #775
2. Fixes #674

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This makes use of referrer info in our login flow, and gets it back via `RelayState` on the SAML response.  I've also cleaned up a few related things.  However, I'm not sure that this is working yet.  It seems like authentication is broken beyond just the redirect issue.

I probably need to do more work on this, but it looks like it should work.  Maybe others could help me look at this and test?