### PR TITLE
Improve colours for links, text in heading on post

### DIFF
--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -16,8 +16,9 @@ const useStyles = makeStyles({
   },
   header: {
     backgroundColor: '#335A7E',
-    color: '#002944',
+    color: '#97d5ff',
     padding: '2em',
+    lineHeight: '1.3',
   },
   title: {
     fontSize: '2em',
@@ -27,7 +28,7 @@ const useStyles = makeStyles({
   },
   published: {
     textDecoration: 'none',
-    color: '#A4D4FF',
+    color: '#002944',
   },
   content: {
     padding: '2em',

--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -47,8 +47,8 @@
 .telescope-post-content code,
 .telescope-post-content pre {
   font-family: Menlo, Consolas, Monaco, 'Liberation Mono', 'Lucida Console', monospace;
-  background: rgb(239, 240, 241);
-  color: rgb(57, 51, 24);
+  background: #eff0f1;
+  color: #242424;
 }
 
 .telescope-post-content code {
@@ -56,7 +56,7 @@
 }
 
 .telescope-post-content pre {
-  border: 1px solid rgb(57, 51, 24);
+  border: 1px solid #242424;
   page-break-inside: avoid;
   font-size: 1.5rem;
   line-height: 1.5;
@@ -64,4 +64,16 @@
   overflow: auto;
   padding: 0.5em 1.5em;
   word-wrap: break-word;
+}
+
+/**
+ * hyperlinks
+ */
+.telescope-post-content a {
+  color: #335a7e;
+}
+
+.telescope-post-content a:active,
+.telescope-post-content a:visited {
+  color: #35001d;
 }


### PR DESCRIPTION
This plays with the colours in the heading and text of links in posts, which I want to connect more closely to our colour theme:

<img width="1018" alt="Screen Shot 2020-03-07 at 6 59 35 PM" src="https://user-images.githubusercontent.com/427398/76154173-d81ef800-60a5-11ea-9d5a-fe30c592eb28.png">
