### PR TITLE
Add graphql-passport to Telescope

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "feedparser-promised": "2.0.1",
     "get-urls": "9.2.0",
     "graphql-iso-date": "3.6.1",
+    "graphql-passport": "0.6.1",
     "helmet": "3.21.2",
     "ioredis": "4.16.0",
     "ioredis-mock": "4.19.0",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #701 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

- Installs the [`graphql-passport`](https://www.npmjs.com/package/graphql-passport) module, which enables us to apply our `passport.js` authentication functionalities to our GraphQL queries.
- **My testing method of choice:**
  1. Check out this PR locally
  1. Run `npm install`, installing the added `graphql-passport` module
  1. Within `src/backend/web/graphql/index.js`, add `context` as the third parameter of a GraphQL resolver of your choice.
     - e.g. The parameters of [`getPosts`](https://github.com/Seneca-CDOT/telescope/blob/master/src/backend/web/graphql/index.js#L126) would be updated as such: `(parent, { filter, page, perPage })` -> `(parent, { filter, page, perPage }, context)`
     - (It is not necessary to make any changes to `typeDefs`)
  1. Within the function body of your chosen resolver, add a statement to log `context.isAuthenticated()` and/or `context.getUser()` to your console.
     - e.g. `console.log(context.isAuthenticated(), '\n', context.getUser());`
  1. Run `docker-compose up redis login elasticsearch` (Telescope's SAML server needs to be running)
  1. Run `npm start` (the backend must be run locally)
     - (Ensure that `API_URL` is set to `http://localhost:3000` within your `.env` file)
  1. Navigate to `http://localhost:3000/auth/login` and log in with the credentials `user1`/`user1pass` (as per [our login documentation](https://github.com/Seneca-CDOT/telescope/blob/master/docs/login.md))
     - (You can confirm logged-in status by visiting `http://localhost:3000/user/profile`)
  1. Navigate to `http://localhost:3000/graphql` and write a query of choice corresponding to the updated resolver.
     - e.g. a query for `getPosts`:
     ```graphql
     {
       getPosts(page: 0, perPage: 1) {
         id
       }
     }
     ```
  1. Execute the query
  1. Observe the statement logged to Telescope's console, which should look something like this:
  ```js
  true 
  {
    ...
    email: 'user1@example.com'
  }
  ```
  
_(I can't thank @manekenpix enough for his close collaboration and patient assistance on this issue. Thank you!)_

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
