### PR TITLE
fixes: ensures docker cache dependencies when package.js is not modified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,32 @@ ENTRYPOINT [ "/sbin/tini", "--"]
 # Set Working Directory Context
 WORKDIR "/telescope"
 
-# Copy shared context
+# Copy package.jsons for each service
 COPY package.json .
+COPY ./tools/autodeployment/package.json ./tools/autodeployment/package.json
+COPY ./src/frontend/package.json ./src/frontend/package.json
 
 # -------------------------------------
 # Context: Dependencies
 FROM build AS dependencies
 
-# Get Entire Codebase
-COPY . .
+# Install Production Modules! 
+# Disable postinstall hook in this case since we are being explict with installs
+RUN npm install --only=production --no-package-lock --ignore-scripts
 
-# Install Production Modules, Build!
-RUN npm install --only=production --no-package-lock
+# Install Frontend Modules!
+RUN cd ./src/frontend && npm install --no-package-lock
+
+# Install Deployment Microservice Modules!
+RUN cd /telescope/tools/autodeployment && npm install --no-package-lock
+
+# -------------------------------------
+# Context: Front-end Builder
+FROM dependencies as builder
+
+COPY ./src/frontend ./src/frontend
+
 RUN npm run build
-
 
 # -------------------------------------
 # Context: Release
@@ -41,7 +53,8 @@ FROM build AS release
 
 # GET deployment code from previous containers
 COPY --from=dependencies /telescope/node_modules /telescope/node_modules
-COPY --from=dependencies /telescope/src/frontend/public /telescope/src/frontend/public
+COPY --from=dependencies /telescope/tools/autodeployment /telescope/tools/autodeployment
+COPY --from=builder /telescope/src/frontend/public /telescope/src/frontend/public
 COPY ./src/backend ./src/backend
 
 # Environment variable with default value
@@ -50,3 +63,4 @@ ENV script=start
 # Running telescope when the image gets built using a script
 # `script` is one of the scripts from `package.json`, passed to the image
 CMD ["sh", "-c", "npm run ${script}"]
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #825 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

On my system with changes, the build time for a local docker instance after doing the first successful build (and thus caching dependencies) and modifying a line in the backend code as a test comes out to:
```
real	0m6.243s
user	0m0.375s
sys     0m0.064s
```

**Limitations  for  Docker caching**: any change to package.json and it's related dependencies will force a new container build. Source code changes otherwise should not trigger rebuild of cached containers.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)

![image](https://user-images.githubusercontent.com/14265337/76272135-ea896500-6250-11ea-8d94-741aaf3b22e0.png)


- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
