### PR TITLE
adds: post stats component to banner

### DIFF
--- a/src/frontend/src/components/Banner/Banner.css
+++ b/src/frontend/src/components/Banner/Banner.css
@@ -20,12 +20,3 @@
   top: 92.5%;
   left: 50%;
 }
-
-.version {
-  position: absolute;
-  opacity: 0.85;
-  top: 95%;
-  left: 2.5%;
-  font-size: 1.75rem;
-  color: white;
-}

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(theme => ({
     opacity: 0.85,
     fontSize: '12vw',
     display: 'block',
-    top: theme.spacing(35),
+    top: theme.spacing(20),
     left: theme.spacing(8),
   },
   stats: {
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: '6vw',
     width: '75%',
     display: 'block',
-    bottom: theme.spacing(24),
+    bottom: theme.spacing(20),
     left: theme.spacing(8),
     transition: 'linear 250ms all',
     lineHeight: 'inherit',
@@ -43,7 +43,7 @@ const useStyles = makeStyles(theme => ({
   version: {
     position: 'absolute',
     opacity: 0.85,
-    bottom: theme.spacing(14),
+    bottom: theme.spacing(10),
     left: theme.spacing(8),
     fontSize: '1.75rem',
     color: 'white',
@@ -81,12 +81,12 @@ function RetrieveStats() {
         }
 
         const stat = await response.json();
-        const locale_stats = {
+        const localeStats = {
           posts: stat.posts.toLocaleString(),
           authors: stat.authors.toLocaleString(),
           words: stat.words.toLocaleString(),
         };
-        setStats(locale_stats);
+        setStats(localeStats);
       } catch (error) {
         console.error('Error getting user info', error);
       }
@@ -125,14 +125,12 @@ export default function Banner() {
             <RetrieveStats />
           </Typography>
         </ThemeProvider>
-        <div className="version" className={classes.version}>
-          v {Version.version}
-        </div>
+        <div className={classes.version}>v {Version.version}</div>
 
         <div className="icon">
           <ScrollDown>
             <Fab color="primary" aria-label="scroll-down">
-              <KeyboardArrowDownIcon />
+              <KeyboardArrowDownIcon fontSize="large" />
             </Fab>
           </ScrollDown>
         </div>

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -19,18 +19,36 @@ const useStyles = makeStyles(theme => ({
     fontFamily: 'Roboto',
     fontWeight: 'bold',
     opacity: 0.85,
-    fontSize: '12vw',
+    fontSize: '12rem',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      fontSize: '4rem',
+    },
+    [theme.breakpoints.between('md', 'lg')]: {
+      fontSize: '8rem',
+    },
+    [theme.breakpoints.up('xl')]: {
+      fontSize: '12rem',
+    },
     display: 'block',
     top: theme.spacing(20),
     left: theme.spacing(8),
+    transition: 'linear 250ms all',
   },
   stats: {
     position: 'absolute',
     color: 'white',
     fontFamily: 'Roboto',
-    fontWeight: '400',
     opacity: 0.85,
-    fontSize: '6vw',
+    fontSize: '2rem',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      fontSize: '2rem',
+    },
+    [theme.breakpoints.between('md', 'lg')]: {
+      fontSize: '4rem',
+    },
+    [theme.breakpoints.up('xl')]: {
+      fontSize: '8rem',
+    },
     width: '75%',
     display: 'block',
     bottom: theme.spacing(20),
@@ -46,6 +64,16 @@ const useStyles = makeStyles(theme => ({
     bottom: theme.spacing(10),
     left: theme.spacing(8),
     fontSize: '1.75rem',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      fontSize: '1.75rem',
+    },
+    [theme.breakpoints.between('md', 'lg')]: {
+      fontSize: '2rem',
+    },
+    [theme.breakpoints.up('xl')]: {
+      fontSize: '4rem',
+    },
+
     color: 'white',
   },
 }));
@@ -97,7 +125,7 @@ function RetrieveStats() {
 
   return (
     <div className="stats">
-      This year, {stats.authors} of us wrote {stats.words} words and counting!
+      This year {stats.authors} of us have written {stats.words} words and counting. Add yours!
     </div>
   );
 }

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -6,6 +6,8 @@ import Fab from '@material-ui/core/Fab';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Toolbar from '@material-ui/core/Toolbar';
+
+import useSiteMetadata from '../../hooks/use-site-metadata';
 
 import Version from '../../../../../package.json';
 import './Banner.css';
@@ -18,8 +20,33 @@ const useStyles = makeStyles(theme => ({
     fontWeight: 'bold',
     opacity: 0.85,
     fontSize: '12vw',
+    display: 'block',
     top: theme.spacing(35),
     left: theme.spacing(8),
+  },
+  stats: {
+    position: 'absolute',
+    color: 'white',
+    fontFamily: 'Roboto',
+    fontWeight: '400',
+    opacity: 0.85,
+    fontSize: '6vw',
+    width: '75%',
+    display: 'block',
+    bottom: theme.spacing(24),
+    left: theme.spacing(8),
+    transition: 'linear 250ms all',
+    lineHeight: 'inherit',
+    letterSpacing: 'inherit',
+  },
+
+  version: {
+    position: 'absolute',
+    opacity: 0.85,
+    bottom: theme.spacing(14),
+    left: theme.spacing(8),
+    fontSize: '1.75rem',
+    color: 'white',
   },
 }));
 
@@ -37,6 +64,40 @@ function ScrollDown(props) {
   return (
     <div onClick={handleClick} role="presentation">
       {children}
+    </div>
+  );
+}
+
+function RetrieveStats() {
+  const { telescopeUrl } = useSiteMetadata();
+  const [stats, setStats] = useState({ stats: { posts: 0, authors: 0, words: 0 } });
+
+  useEffect(() => {
+    async function getStats() {
+      try {
+        const response = await fetch(`${telescopeUrl}/stats/year`);
+        if (response.status !== 200) {
+          throw new Error(response.statusText);
+        }
+
+        const stat = await response.json();
+        const locale_stats = {
+          posts: stat.posts.toLocaleString(),
+          authors: stat.authors.toLocaleString(),
+          words: stat.words.toLocaleString(),
+        };
+        setStats(locale_stats);
+      } catch (error) {
+        console.error('Error getting user info', error);
+      }
+    }
+
+    getStats();
+  }, [telescopeUrl]);
+
+  return (
+    <div className="stats">
+      This year, {stats.authors} of us wrote {stats.words} words and counting!
     </div>
   );
 }
@@ -59,11 +120,18 @@ export default function Banner() {
           <Typography variant="h1" className={classes.h1}>
             {'Telescope'}
           </Typography>
+
+          <Typography variant="caption" className={classes.stats}>
+            <RetrieveStats />
+          </Typography>
         </ThemeProvider>
-        <div className="version">v {Version.version}</div>
+        <div className="version" className={classes.version}>
+          v {Version.version}
+        </div>
+
         <div className="icon">
           <ScrollDown>
-            <Fab color="primary" size="medium" aria-label="scroll-down">
+            <Fab color="primary" aria-label="scroll-down">
               <KeyboardArrowDownIcon />
             </Fab>
           </ScrollDown>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #789, with a hint of Fixes #830 dashed in.
Further improves on font responsive sizing with @cindyledev help.

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

This references the `/stats/year` to display the total amount of words written in the current year. This is the first step in the stats component, with GitHub contributions stats being added next. Likewise, aware that on LowDPI screens it overlaps with main title. That will be corrected. Open to suggestions on that fix.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)

![image](https://user-images.githubusercontent.com/14265337/76586256-c464fe80-64b6-11ea-850c-0f32f4ef2584.png)

![image](https://user-images.githubusercontent.com/14265337/76586288-d646a180-64b6-11ea-909b-60f9e85d8979.png)

![image](https://user-images.githubusercontent.com/14265337/76586313-e1013680-64b6-11ea-9221-858ea6e3c434.png)



- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
