### PR TITLE
Closes #665: Nested Queries in GraphQL

### DIFF
--- a/src/backend/web/graphql/index.js
+++ b/src/backend/web/graphql/index.js
@@ -21,6 +21,7 @@ module.exports.typeDefs = graphql`
     id: String
     author: String
     url: String
+    posts: [Post]
   }
 
   # 'Post' matches our Post type used with redis
@@ -69,6 +70,13 @@ module.exports.resolvers = {
   // Custom Date scalar from package
   Date: GraphQLDate,
 
+  Feed: {
+    posts: async ({ id }) => {
+      const postIds = await getPosts(0, 0);
+      const processed = await Promise.all(postIds.map(Post.byId));
+      return processed.filter(post => post.feed.id === id);
+    },
+  },
   Query: {
     /**
      * @description Takes an id and returns a Feed object

--- a/src/backend/web/graphql/index.js
+++ b/src/backend/web/graphql/index.js
@@ -70,11 +70,15 @@ module.exports.resolvers = {
   // Custom Date scalar from package
   Date: GraphQLDate,
 
+  /**
+   * This resolver defines how to return the 'posts' field
+   * in the Feed type.
+   */
   Feed: {
     posts: async ({ id }) => {
       const postIds = await getPosts(0, 0);
-      const processed = await Promise.all(postIds.map(Post.byId));
-      return processed.filter(post => post.feed.id === id);
+      const posts = await Promise.all(postIds.map(Post.byId));
+      return posts.filter(post => post.feed.id === id);
     },
   },
   Query: {


### PR DESCRIPTION
## Issue This PR Addresses

Closes #665 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Small PR that adds a new resolver to define how to deal with `posts`, a new added field to the `Feed` type definition in our `GraphQL` module. 

With this, it'll be possible to fetch all the posts related to a feed when using `getFeedById` or `getFeedByUrl` by simply adding `posts` (and subfields) to a query:

![Screenshot_20200318_221148](https://user-images.githubusercontent.com/23108901/77024911-21a0fa00-6966-11ea-869c-e760b941e875.png)

For testing, use one of the available methods to get feeds from telescope (`REST` or `GraphQL`), and select one id or url to be used with `getFeedById` or `gefFeedByUrl`, adding `posts` and subfields to the query as shown in the image above.

 **Important**: It's better to let telescope run until all the feeds are processed before trying the new resolver. Querying Telescope too soon might result in an empty `posts` array since it'd mean that Telescope hasn't processed the posts for that specific feed yet.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
