### PR TITLE
Fixes #765 add toolbar mixin underneath Header bar

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -5,7 +5,6 @@ import Typography from '@material-ui/core/Typography';
 import Fab from '@material-ui/core/Fab';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Toolbar from '@material-ui/core/Toolbar';
 
 import useSiteMetadata from '../../hooks/use-site-metadata';
 
@@ -141,7 +140,6 @@ export default function Banner() {
   return (
     <React.Fragment>
       <CssBaseline />
-      <Toolbar id="scroll-down-anchor" />
       <div className="heroBanner">
         <div className="bannerImg"></div>
         <ThemeProvider>

--- a/src/frontend/src/components/Header/Header.jsx
+++ b/src/frontend/src/components/Header/Header.jsx
@@ -19,11 +19,12 @@ import useSiteMetadata from '../../hooks/use-site-metadata';
 
 import Login from '../Login';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
     backgroundColor: '#242424',
   },
+  toolbar: theme.mixins.toolbar,
   menuIcon: {
     fontSize: '2.5rem',
   },
@@ -59,7 +60,7 @@ const useStyles = makeStyles({
   item: {
     textAlign: 'center',
   },
-});
+}));
 
 const Header = () => {
   const { title } = useSiteMetadata();
@@ -136,6 +137,7 @@ const Header = () => {
           </Drawer>
         </Toolbar>
       </AppBar>
+      <Toolbar className={classes.toolbar}></Toolbar>
     </div>
   );
 };

--- a/src/frontend/src/pages/search.js
+++ b/src/frontend/src/pages/search.js
@@ -6,11 +6,6 @@ const Search = () => {
   return (
     <div>
       <Header />
-      <div
-        style={{
-          height: '12vh',
-        }}
-      ></div>
       <SearchBar />
     </div>
   );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
Fixes #765 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This fix stops the Header from overlapping on top of the SearchBar in the Search Page and any future pages that will have the Header. The Hero Banner had an anchor that added extra space at the top so I removed it. 

Search Page:
![Annotation 2020-03-23 091906](https://user-images.githubusercontent.com/36822198/77320749-82725e80-6ce7-11ea-9146-f5eb79718f00.png)

Home Page:
![Annotation 2020-03-23 091906_](https://user-images.githubusercontent.com/36822198/77320771-8aca9980-6ce7-11ea-90b2-e9d23856e6eb.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
