### PR TITLE
Fix #858: Use feed.author when counting post authors in stats

### DIFF
--- a/src/backend/data/stats.js
+++ b/src/backend/data/stats.js
@@ -16,7 +16,7 @@ const countWords = posts => posts.reduce((total, post) => total + count(post.tex
  * Get the total number of unique feeds in the posts in the array
  * @param {Array<Post>} posts the array of post objects
  */
-const countFeeds = posts => new Set(posts.map(post => post.feed)).size;
+const countFeeds = posts => new Set(posts.map(post => post.feed.author)).size;
 
 class Stats {
   constructor(startDate, endDate) {
@@ -28,7 +28,7 @@ class Stats {
   }
 
   /**
-   * Returns a Promise<Array> of post ids
+   * Returns a Promise<Object> with counts for posts, authors, and words.
    */
   async calculate() {
     const ids = await getPostsByDate(this.startDate, this.endDate);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses


1. Fixes #858 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

When we altered the way that feeds get stored on posts, we didn't update how the counting works in our stats.  This changes it so that instead of using the feed object itself, we use the feed author's name.

<img width="430" alt="Screen Shot 2020-03-23 at 11 51 43 AM" src="https://user-images.githubusercontent.com/427398/77336441-e869e080-6cfd-11ea-8285-7770ba73c577.png">

