### PR TITLE
Fixes #813: Whitelist YouTube/Vimeo iframe elements in post content

### DIFF
--- a/src/backend/utils/sanitize-html.js
+++ b/src/backend/utils/sanitize-html.js
@@ -25,6 +25,7 @@ module.exports = function(dirty) {
       'h6',
       'hr',
       'i',
+      'iframe',
       'img',
       'li',
       'ol',
@@ -40,5 +41,11 @@ module.exports = function(dirty) {
       'tr',
       'ul',
     ],
+    allowedAttributes: {
+      iframe: ['src'],
+      img: ['src'],
+      a: ['href'],
+    },
+    allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com'],
   });
 };

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -34,11 +34,21 @@ describe('Sanitize HTML', () => {
     );
   });
 
-  test('<iframe> gets removed after run through sanitizeHTML', () => {
+  test('<iframe> to Telescope returns an empty iframe tag', () => {
     const data = sanitizeHTML(
       '<iframe src="https://www.telescope.com" style="border:none;">Telescope</iframe>'
     );
-    expect(data).toBe('Telescope');
+    expect(data).toBe('<iframe>Telescope</iframe>');
+  });
+
+  test('<iframe> tag to a youtube embed should not get removed', () => {
+    const data = sanitizeHTML('<iframe src="https://www.youtube.com/embed/nGeKSiCQkPw"></iframe>');
+    expect(data).toBe('<iframe src="https://www.youtube.com/embed/nGeKSiCQkPw"></iframe>');
+  });
+
+  test('<iframe> tag to a vimeo player should not get removed', () => {
+    const data = sanitizeHTML('<iframe src="https://player.vimeo.com/video/395927811"></iframe>');
+    expect(data).toBe('<iframe src="https://player.vimeo.com/video/395927811"></iframe>');
   });
 
   test('<pre> with inline style, sanitize strips inline style', () => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #813

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Youtube / Vimeo videos now show up in the feed.
![image](https://user-images.githubusercontent.com/35276477/77376799-99e13400-6d47-11ea-833b-28b281e99bb2.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
