### PR TITLE
adds: responsive adjustements for banner component

### DIFF
--- a/src/frontend/src/components/Banner/Banner.css
+++ b/src/frontend/src/components/Banner/Banner.css
@@ -12,11 +12,3 @@
   height: 100vh;
   opacity: 0.4;
 }
-
-.icon {
-  height: 7rem;
-  width: 7rem;
-  position: absolute;
-  top: 92.5%;
-  left: 50%;
-}

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -87,9 +87,13 @@ const useStyles = makeStyles(theme => ({
     width: '5.6rem',
     position: 'relative',
     left: '49.5%',
-    bottom: theme.spacing(18),
+    transition: 'linear 500ms all',
+    bottom: theme.spacing(20),
     [theme.breakpoints.between('xs', 'sm')]: {
-      left: '45%',
+      right: theme.spacing(4),
+      transition: 'linear 500ms all',
+      left: '80%',
+      bottom: theme.spacing(18),
     },
   },
 }));

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -19,8 +19,15 @@ const useStyles = makeStyles(theme => ({
     fontWeight: 'bold',
     opacity: 0.85,
     fontSize: '12rem',
+    display: 'block',
+    top: theme.spacing(20),
+    left: theme.spacing(8),
+    transition: 'linear 250ms all',
     [theme.breakpoints.between('xs', 'sm')]: {
       fontSize: '4rem',
+      textAlign: 'left',
+      left: theme.spacing(4),
+      right: theme.spacing(4),
     },
     [theme.breakpoints.between('md', 'lg')]: {
       fontSize: '8rem',
@@ -28,10 +35,6 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('xl')]: {
       fontSize: '12rem',
     },
-    display: 'block',
-    top: theme.spacing(20),
-    left: theme.spacing(8),
-    transition: 'linear 250ms all',
   },
   stats: {
     position: 'absolute',
@@ -39,8 +42,17 @@ const useStyles = makeStyles(theme => ({
     fontFamily: 'Roboto',
     opacity: 0.85,
     fontSize: '2rem',
+    display: 'block',
+    bottom: theme.spacing(20),
+    left: theme.spacing(8),
+    transition: 'linear 250ms all',
+    lineHeight: 'inherit',
+    letterSpacing: 'inherit',
     [theme.breakpoints.between('xs', 'sm')]: {
+      textAlign: 'left',
       fontSize: '2rem',
+      left: theme.spacing(4),
+      right: theme.spacing(4),
     },
     [theme.breakpoints.between('md', 'lg')]: {
       fontSize: '4rem',
@@ -48,13 +60,6 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('xl')]: {
       fontSize: '8rem',
     },
-    width: '75%',
-    display: 'block',
-    bottom: theme.spacing(20),
-    left: theme.spacing(8),
-    transition: 'linear 250ms all',
-    lineHeight: 'inherit',
-    letterSpacing: 'inherit',
   },
 
   version: {
@@ -63,7 +68,10 @@ const useStyles = makeStyles(theme => ({
     bottom: theme.spacing(10),
     left: theme.spacing(8),
     fontSize: '1.75rem',
+    color: 'white',
     [theme.breakpoints.between('xs', 'sm')]: {
+      left: theme.spacing(4),
+      right: theme.spacing(4),
       fontSize: '1.75rem',
     },
     [theme.breakpoints.between('md', 'lg')]: {
@@ -72,8 +80,14 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('xl')]: {
       fontSize: '4rem',
     },
-
-    color: 'white',
+  },
+  icon: {
+    height: '7rem',
+    width: '7rem',
+    position: 'relative',
+    left: '45%',
+    right: '45%',
+    bottom: theme.spacing(18),
   },
 }));
 
@@ -153,7 +167,7 @@ export default function Banner() {
         </ThemeProvider>
         <div className={classes.version}>v {Version.version}</div>
 
-        <div className="icon">
+        <div className={classes.icon}>
           <ScrollDown>
             <Fab color="primary" aria-label="scroll-down">
               <KeyboardArrowDownIcon fontSize="large" />

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles(theme => ({
     display: 'block',
     top: theme.spacing(20),
     left: theme.spacing(8),
-    transition: 'linear 250ms all',
     [theme.breakpoints.between('xs', 'sm')]: {
       fontSize: '4rem',
       textAlign: 'left',
@@ -46,7 +45,6 @@ const useStyles = makeStyles(theme => ({
     display: 'block',
     bottom: theme.spacing(12),
     left: theme.spacing(8),
-    transition: 'linear 250ms all',
     lineHeight: 'inherit',
     letterSpacing: 'inherit',
     [theme.breakpoints.between('xs', 'sm')]: {
@@ -87,11 +85,9 @@ const useStyles = makeStyles(theme => ({
     width: '5.6rem',
     position: 'relative',
     left: '49.5%',
-    transition: 'linear 500ms all',
     bottom: theme.spacing(20),
     [theme.breakpoints.between('xs', 'sm')]: {
       right: theme.spacing(4),
-      transition: 'linear 500ms all',
       left: '80%',
       bottom: theme.spacing(18),
     },

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles(theme => ({
       textAlign: 'left',
       left: theme.spacing(4),
       right: theme.spacing(4),
+      top: theme.spacing(14),
     },
     [theme.breakpoints.between('md', 'lg')]: {
       fontSize: '8rem',
@@ -43,7 +44,7 @@ const useStyles = makeStyles(theme => ({
     opacity: 0.85,
     fontSize: '2rem',
     display: 'block',
-    bottom: theme.spacing(20),
+    bottom: theme.spacing(12),
     left: theme.spacing(8),
     transition: 'linear 250ms all',
     lineHeight: 'inherit',
@@ -65,7 +66,7 @@ const useStyles = makeStyles(theme => ({
   version: {
     position: 'absolute',
     opacity: 0.85,
-    bottom: theme.spacing(10),
+    bottom: theme.spacing(6),
     left: theme.spacing(8),
     fontSize: '1.75rem',
     color: 'white',
@@ -82,12 +83,14 @@ const useStyles = makeStyles(theme => ({
     },
   },
   icon: {
-    height: '7rem',
-    width: '7rem',
+    height: '5.6rem',
+    width: '5.6rem',
     position: 'relative',
-    left: '45%',
-    right: '45%',
+    left: '49.5%',
     bottom: theme.spacing(18),
+    [theme.breakpoints.between('xs', 'sm')]: {
+      left: '45%',
+    },
   },
 }));
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #872 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

Makes `Banner.jsx` and `Header.jsx` responsive for various mediums. Tested using Firefox Responsive tool for:
- 720p
- iPhone SE
- Samsung Galaxy S9 
- 1080p

Styling / spacing etc all up for debate. Simply getting the discussion going in this PR.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)

Banner Improvements (WIP)
![image](https://user-images.githubusercontent.com/14265337/77491515-5b657b00-6e14-11ea-9591-9d7f58f02678.png)

![image](https://user-images.githubusercontent.com/14265337/77491501-50124f80-6e14-11ea-8fbd-7e53a56288f3.png)

- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

