### PR TITLE
Fixes #837 add del tag to allowedTags

### DIFF
--- a/src/backend/utils/sanitize-html.js
+++ b/src/backend/utils/sanitize-html.js
@@ -14,6 +14,7 @@ module.exports = function(dirty) {
       'br',
       'caption',
       'code',
+      'del',
       'div',
       'em',
       'figure',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #837 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Thank you @Silvyre for investigating this issue, his fix suggestion was exactly the solution. This PR adds the `<del>` tag to our allowedTags so that 'strikeout' (Wordpress uses `<del>` for some reason) texts are displayed properly

![Capture-Mar25-1](https://user-images.githubusercontent.com/36822198/77568914-c60fc880-6e9f-11ea-923e-4bad7348cc49.PNG)


<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
