### PR TITLE
Closes #666: Add data volume to redis container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ certs/
 
 # gatsby public folder
 public/
+
+# Redis data storage
+redis-data/

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -25,6 +25,9 @@ services:
 
   redis:
     image: redis:latest
+    command: ['redis-server', '--appendonly', 'yes']
+    volumes:
+      - ../redis-data:/data
     restart: always
 
   elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
     image: redis:latest
     ports:
       - ${REDIS_PORT}:${REDIS_PORT}
+    command: ['redis-server', '--appendonly', 'yes']
+    volumes:
+      - ./redis-data:/data
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.5.0


### PR DESCRIPTION
## Issue This PR Addresses

Closes #666 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds persistent storage for local and staging.
Right after deployment, redis will create a directory (if it's not there yet) and will store Telescope's data in a file (`appendonly.aof`). At launch, redis will load Telescope's data and will log a message:

![image](https://user-images.githubusercontent.com/23108901/77604462-f0d23f00-6ee8-11ea-8eb5-11832e2f0f41.png)

For local, the directory created by redis will be in the Telescope directory, and it's been added to `.gitignore`.
For staging, the directory will be outside of `./telescope` so it won't get deleted when auto-deployment gets triggered by a merge to master.


**Testing**
- Launch Telescope and let it run for while.
- Once a good number of feeds have been processed, navigate to `localhost:3000` and take a look at the state of `index.html` (posts, number of contributors and words) .
- Stop Telescope and redis.
- Relaunch Telescope and redis.
- Navigate to `localhost:3000` and check if the same posts and information about words and contributors are shown. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
