### PR TITLE
Fix #880: add pushRepo to github release step in release-it, update version

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,7 +6,8 @@
     "pushRepo": "upstream"
   },
   "github": {
-    "release": true
+    "release": true,
+    "pushRepo": "upstream"
   },
   "npm": {
     "publish": false

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "1.19.1",
     "pretty-quick": "2.0.1",
-    "release-it": "12.6.3",
+    "release-it": "13.4.0",
     "run.env": "1.1.0",
     "stylelint": "13.2.0",
     "stylelint-config-prettier": "8.0.1",


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #880

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

We filed an upstream bug after @Silvyre tried to run our release, and it put the assets in the wrong repo.  The [bug was fixed](https://github.com/release-it/release-it/commit/2ab8aaf060b7dc9d5e783e47cdfa415ee0e85320), so I've updated our version of release it and added a `pushRepo` for our GitHub Release section in the config.

After we land this, I'll get @Silvyre to do a 0.8.3 release to test it.
