### PR TITLE
More SSO cleanup

### DIFF
--- a/src/backend/web/app.js
+++ b/src/backend/web/app.js
@@ -28,7 +28,6 @@ app.options('*', cors());
 // Setup session and passport for authentication
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
-authentication.init(passport);
 app.use(
   session({
     store: new RedisStore({ client: redis }),
@@ -37,6 +36,7 @@ app.use(
     saveUninitialized: false,
   })
 );
+authentication.init();
 app.use(passport.initialize());
 app.use(passport.session());
 

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -9,9 +9,9 @@ const { logger } = require('../../utils/logger');
 const router = express.Router();
 
 // Only authenticated users can use these routes
-router.use('/queues', protect, UI);
+router.use('/queues', protect(true), UI);
 
-router.get('/log', protect, (req, res) => {
+router.get('/log', protect(true), (req, res) => {
   let readStream;
   if (!process.env.LOG_FILE) {
     res.send('LOG_FILE undefined in .env file');

--- a/src/backend/web/routes/auth.js
+++ b/src/backend/web/routes/auth.js
@@ -32,12 +32,14 @@ router.get('/login', passport.authenticate('saml'));
  * users upon successful logout.
  */
 router.get('/logout/callback', (req, res) => {
+  // Clear session passport.js user info
   req.logout();
-  res.redirect('/');
+  res.redirect(telescopeHomeUrl);
 });
 
 /**
- * /auth/logout allows users to clear login tokens from their session
+ * /auth/logout allows users to use Single Logout and clear login tokens
+ * from their passport.js session.
  */
 router.get('/logout', (req, res) => {
   try {
@@ -45,14 +47,14 @@ router.get('/logout', (req, res) => {
     passport._strategy('saml').logout(req, (error, requestUrl) => {
       if (error) {
         logger.error({ error }, 'logout error - unable to generate logout URL');
-        res.redirect('/');
+        res.redirect(telescopeHomeUrl);
+      } else {
+        res.redirect(requestUrl);
       }
-      req.logout();
-      res.redirect(requestUrl);
     });
   } catch (error) {
     logger.error({ error }, 'logout error');
-    res.redirect('/');
+    res.redirect(telescopeHomeUrl);
   }
 });
 

--- a/src/backend/web/routes/user.js
+++ b/src/backend/web/routes/user.js
@@ -6,7 +6,7 @@ const { logger } = require('../../utils/logger');
 const router = express.Router();
 
 // Only authenticated users can use this route
-router.get('/info', protect, (req, res) => {
+router.get('/info', protect(), (req, res) => {
   if (!req.user) {
     logger.error('missing req.user!');
     return res.status(503).json({


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #775

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [] **UI**: Change which improves UI

## Description

While I was writing https://blog.humphd.org/not-so-simple-saml/ I re-read all of our SSO/SAML code and noticed a few things that still needed attention.  This cleans those up, and I *think* I'm not down playing with this.

To test this:

- start the `login` container, and any others you need to run the app locally
- build the front-end `npm run build`
- start the back end `npm start`

Now try testing the various ways that we do authentication and route protection.  There are at least 3 things worth mentioning.

1. Make sure you can still log in and log out as before.
2. Log out and try going to `/admin/queues`.  You should be redirected to a login page.  Log in and then it should immediately take you to the Bull Queue UI.  Hitting the Back button should back to `/`.
3. Try the above while logged in.  You should go directly to the page without a login redirect.
4. Log out and try going to `/user/info`.  You should get a 403 and some JSON saying this is forbidden.  You should *NOT* get redirected to a login page.  Hitting the Back button should back to `/`.
5.  Try logging in and do 4. again.  It should return your user info as JSON.