### PR TITLE
Fix reusing volumes in staging deployment

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -146,6 +146,9 @@ docker-compose up --build redis elasticsearch
 
 _Note: You may need to add your user to the docker group in Linux to use `docker-compose` without `sudo`. To do this, try `groups $USER` in a terminal and check if docker is in the list of groups. If not, add it with `usermod -aG docker $USER` and reboot._
 
+**Important:** Docker builds Telescope's dependencies at launch and keeps them on disk. In some cases, Docker might try to reuse already-built dependencies or cached data, causing misleading results when testing Telescope. To avoid this, it is recommended to use the command `docker system prune -af --volumes` to remove all already-built Telescope dependencies and ensure fresh deployments.
+More information about docker: [images vs containers](https://www.baeldung.com/docker-images-vs-containers) and [volumes](https://docs.docker.com/storage/volumes/).
+
 #### Option 2: Natively installed:
 
 #### Redis:

--- a/tools/autodeployment/deploy_stage.sh
+++ b/tools/autodeployment/deploy_stage.sh
@@ -5,7 +5,7 @@ cd ../telescope
 
 docker-compose -f docker-compose-staging.yml down
 
-docker system prune -af
+docker system prune -af --volumes
 
 
 # Delete and clone


### PR DESCRIPTION
## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

After landing #871, Telescope kept serving a version of the front end that was 2 commits behind #871. The problem turned out to be the command used in autodeployment for deleting all the docker elements related to Telescope (`docker system prune -af`). This command doesn't get rid of volumes, which is what we're using to share data between containers. As a result, Telescope was serving an old frontend stored in a persistent volume on `dev.telescope.cdot.systems`.

To fix this, adding `--volumes` (as suggested [here](https://linuxize.com/post/how-to-remove-docker-images-containers-volumes-and-networks/)) to the command used in autodeployment will also remove all volumes and new ones will be created for every new deployment.

@raygervais helped me debug this and found out that the problem was persistent volumes.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
