### PR TITLE
adds: fade-in transition for stats once loaded

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles(theme => ({
     left: theme.spacing(8),
     lineHeight: 'inherit',
     letterSpacing: 'inherit',
-    transition: 'all linear 350ms',
+    transition: 'all linear 1s',
     [theme.breakpoints.between('xs', 'sm')]: {
       textAlign: 'left',
       fontSize: '2rem',
@@ -112,9 +112,13 @@ function ScrollDown(props) {
   );
 }
 
-function RetrieveBackgroundImage() {
+function RetrieveBannerDynamicAssets() {
   const [backgroundImgSrc, setBackgroundImgSrc] = useState('');
   const [transitionBackground, setTransitionBackground] = useState(true);
+  const [stats, setStats] = useState({ stats: { posts: 0, authors: 0, words: 0 } });
+
+  const classes = useStyles();
+  const { telescopeUrl } = useSiteMetadata();
 
   useEffect(() => {
     async function getBackgroundImgSrc() {
@@ -138,7 +142,6 @@ function RetrieveBackgroundImage() {
 
         // Ease in Background
         setBackgroundImgSrc(src);
-        setTransitionBackground(false);
       } catch (error) {
         console.error('Error getting user info', error);
         // Fallback to default image
@@ -146,29 +149,6 @@ function RetrieveBackgroundImage() {
       }
     }
 
-    getBackgroundImgSrc();
-  }, []);
-
-  return (
-    <div
-      className="bannerImg"
-      style={{
-        backgroundImage:
-          backgroundImgSrc === '../../images/hero-banner.png'
-            ? backgroundImgSrc
-            : `url(${backgroundImgSrc})`,
-        opacity: transitionBackground ? 0 : 0.4,
-      }}
-    ></div>
-  );
-}
-
-function RetrieveStats() {
-  const { telescopeUrl } = useSiteMetadata();
-  const [stats, setStats] = useState({ stats: { posts: 0, authors: 0, words: 0 } });
-  const [transitionBackground, setTransitionBackground] = useState(true);
-
-  useEffect(() => {
     async function getStats() {
       try {
         const response = await fetch(`${telescopeUrl}/stats/year`);
@@ -189,17 +169,30 @@ function RetrieveStats() {
       }
     }
 
-    getStats();
+    getBackgroundImgSrc().then(getStats());
   }, [telescopeUrl]);
 
   return (
-    <div
-      className="stats"
-      style={{
-        opacity: transitionBackground ? 0 : 0.85,
-      }}
-    >
-      This year {stats.authors} of us have written {stats.words} words and counting. Add yours!
+    <div>
+      <div
+        className="bannerImg"
+        style={{
+          backgroundImage:
+            backgroundImgSrc === '../../images/hero-banner.png'
+              ? backgroundImgSrc
+              : `url(${backgroundImgSrc})`,
+          opacity: transitionBackground ? 0 : 0.4,
+        }}
+      ></div>
+      <Typography
+        variant="caption"
+        className={classes.stats}
+        style={{
+          opacity: transitionBackground ? 0 : 0.85,
+        }}
+      >
+        This year {stats.authors} of us have written {stats.words} words and counting. Add yours!
+      </Typography>
     </div>
   );
 }
@@ -216,17 +209,14 @@ export default function Banner() {
     <React.Fragment>
       <CssBaseline />
       <div className="heroBanner">
-        <RetrieveBackgroundImage />
+        <RetrieveBannerDynamicAssets />
 
         <ThemeProvider>
           <Typography variant="h1" className={classes.h1}>
             {'Telescope'}
           </Typography>
-
-          <Typography variant="caption" className={classes.stats}>
-            <RetrieveStats />
-          </Typography>
         </ThemeProvider>
+
         <div className={classes.version}>v {Version.version}</div>
 
         <div className={classes.icon}>

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -112,7 +112,7 @@ function ScrollDown(props) {
   );
 }
 
-async function getDynamicAsset(url, callback, errorCB) {
+async function getDynamicAsset(url, success, failure) {
   try {
     const response = await fetch(url);
 
@@ -121,15 +121,16 @@ async function getDynamicAsset(url, callback, errorCB) {
     }
 
     if (response.headers.get('content-type').includes('application/json')) {
-      callback(await response.json());
+      success(await response.json());
+      return;
     }
 
-    callback(response);
+    success(response);
   } catch (error) {
     console.error('Error getting dynamic asset', error);
 
-    if (errorCB) {
-      errorCB();
+    if (failure) {
+      failure();
     }
   }
 }
@@ -157,8 +158,8 @@ function RetrieveBannerDynamicAssets() {
       await getDynamicAsset(
         `https://source.unsplash.com/collection/894/${dimensions}/`,
         response => {
-          // Ease in Background
           setBackgroundImgSrc(response.url);
+          getStats();
         },
         () => {
           // Fallback to default image
@@ -175,13 +176,13 @@ function RetrieveBannerDynamicAssets() {
           words: response.words.toLocaleString(),
         };
         setStats(localeStats);
-      });
 
-      setTransitionBackground(false);
+        // Ease in Background
+        setTransitionBackground(false);
+      });
     }
 
     getBackgroundImgSrc();
-    getStats();
   }, [telescopeUrl]);
 
   return (

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -40,13 +40,13 @@ const useStyles = makeStyles(theme => ({
     position: 'absolute',
     color: 'white',
     fontFamily: 'Roboto',
-    opacity: 0.85,
     fontSize: '2rem',
     display: 'block',
     bottom: theme.spacing(12),
     left: theme.spacing(8),
     lineHeight: 'inherit',
     letterSpacing: 'inherit',
+    transition: 'all linear 350ms',
     [theme.breakpoints.between('xs', 'sm')]: {
       textAlign: 'left',
       fontSize: '2rem',
@@ -166,6 +166,7 @@ function RetrieveBackgroundImage() {
 function RetrieveStats() {
   const { telescopeUrl } = useSiteMetadata();
   const [stats, setStats] = useState({ stats: { posts: 0, authors: 0, words: 0 } });
+  const [transitionBackground, setTransitionBackground] = useState(true);
 
   useEffect(() => {
     async function getStats() {
@@ -182,6 +183,7 @@ function RetrieveStats() {
           words: stat.words.toLocaleString(),
         };
         setStats(localeStats);
+        setTransitionBackground(false);
       } catch (error) {
         console.error('Error getting user info', error);
       }
@@ -191,7 +193,12 @@ function RetrieveStats() {
   }, [telescopeUrl]);
 
   return (
-    <div className="stats">
+    <div
+      className="stats"
+      style={{
+        opacity: transitionBackground ? 0 : 0.85,
+      }}
+    >
       This year {stats.authors} of us have written {stats.words} words and counting. Add yours!
     </div>
   );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #892 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

This adds the same opacity transition trick used by the Banner background  to the Banner stats component. Makes the loading and API call less jarring to the user since text would simply appear and update the previously blank numeric values. 

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
