### PR TITLE
Fix #734: add mock authentication for testing

### DIFF
--- a/src/backend/web/__mocks__/authentication.js
+++ b/src/backend/web/__mocks__/authentication.js
@@ -1,0 +1,86 @@
+/**
+ * Mock SAML2 SSO Passport.js authentication strategy.
+ */
+const hash = require('../../data/hash');
+
+let loggedInUser;
+
+/**
+ * Override init() to provide login for tests
+ */
+function init(name, email, isAdmin = false) {
+  if (arguments.length >= 2) {
+    // Log in
+    loggedInUser = {
+      id: hash(email),
+      name,
+      email,
+      isAdmin,
+    };
+  } else {
+    // Log out
+    loggedInUser = null;
+  }
+}
+
+function samlMetadata() {
+  return 'metadata';
+}
+
+// If user is not authenticated, return an appropriate 400 error type
+function forbidden(req, res) {
+  if (req.accepts('json')) {
+    res.status(403).json({
+      message: 'Forbidden',
+    });
+  } else {
+    res.status(403).send('Forbidden');
+  }
+}
+
+function checkUser(requireAdmin, redirect, req, res, next) {
+  // First, see if the user is authenticated
+  if (loggedInUser) {
+    // Next, check to see if we need admin rights to pass
+    if (requireAdmin) {
+      // See if this user is an admin
+      if (loggedInUser.isAdmin) {
+        next();
+      }
+      // Not an admin, so fail this now using best response type
+      else {
+        forbidden(req, res);
+      }
+    } else {
+      // We don't need an admin, and this is a regular authenticated user, let it pass
+      next();
+    }
+  } else {
+    forbidden(req, res);
+  }
+}
+
+// We'll deal with admin via init(), just let this pass
+function administration() {
+  return function(req, res, next) {
+    next();
+  };
+}
+
+function protect(redirect) {
+  return function(req, res, next) {
+    checkUser(false, redirect, req, res, next);
+  };
+}
+
+function protectAdmin(redirect) {
+  return function(req, res, next) {
+    checkUser(true, redirect, req, res, next);
+  };
+}
+
+module.exports.init = init;
+module.exports.protect = protect;
+module.exports.protectAdmin = protectAdmin;
+module.exports.administration = administration;
+module.exports.samlMetadata = samlMetadata;

--- a/src/backend/web/__mocks__/authentication.js
+++ b/src/backend/web/__mocks__/authentication.js
@@ -62,19 +62,19 @@ function checkUser(requireAdmin, redirect, req, res, next) {
 
 // We'll deal with admin via init(), just let this pass
 function administration() {
-  return function(req, res, next) {
+  return function (req, res, next) {
     next();
   };
 }
 
 function protect(redirect) {
-  return function(req, res, next) {
+  return function (req, res, next) {
     checkUser(false, redirect, req, res, next);
   };
 }
 
 function protectAdmin(redirect) {
-  return function(req, res, next) {
+  return function (req, res, next) {
     checkUser(true, redirect, req, res, next);
   };
 }

--- a/src/backend/web/authentication.js
+++ b/src/backend/web/authentication.js
@@ -246,5 +246,4 @@ module.exports.init = init;
 module.exports.protect = protect;
 module.exports.protectAdmin = protectAdmin;
 module.exports.administration = administration;
-module.exports.strategy = strategy;
 module.exports.samlMetadata = samlMetadata;

--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -2,7 +2,7 @@ const express = require('express');
 const Feed = require('../../data/feed');
 const { getFeeds } = require('../../utils/storage');
 const { logger } = require('../../utils/logger');
-// const { protect } = require('../authentication'); https://github.com/Seneca-CDOT/telescope/issues/734
+const { protect } = require('../authentication');
 
 const feeds = express.Router();
 
@@ -51,9 +51,7 @@ feeds.get('/:id', async (req, res) => {
   }
 });
 
-// add protect here for development. https://github.com/Seneca-CDOT/telescope/issues/734
-
-feeds.post('/', async (req, res) => {
+feeds.post('/', protect(), async (req, res) => {
   const feedData = req.body;
   try {
     if (!(feedData.url && feedData.author)) {

--- a/test/feeds.test.js
+++ b/test/feeds.test.js
@@ -83,10 +83,7 @@ describe('test POST /feeds endpoint', () => {
       user: 'user',
     };
     logout();
-    const res = await request(app)
-      .post('/feeds')
-      .send(feedData)
-      .set('Accept', 'application/json');
+    const res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
     expect(res.status).toEqual(403);
   });
 

--- a/test/lib/authentication.js
+++ b/test/lib/authentication.js
@@ -1,0 +1,22 @@
+// NOTE: you must mock the authentication provider where you require this:
+// jest.mock('../src/backend/web/authentication');
+
+const { init } = require('../../src/backend/web/authentication');
+
+const defaultName = 'user1';
+const defaultEmail = 'user1@example.com';
+
+// Login as a regular user
+module.exports.login = function(name, email, isAdmin = false) {
+  init(name || defaultName, email || defaultEmail, isAdmin);
+};
+
+// Login as an Admin
+module.exports.loginAdmin = function(name, email) {
+  module.exports.login(name, email, true);
+};
+
+// Logout
+module.exports.logout = function() {
+  init();
+};

--- a/test/lib/authentication.js
+++ b/test/lib/authentication.js
@@ -7,16 +7,16 @@ const defaultName = 'user1';
 const defaultEmail = 'user1@example.com';
 
 // Login as a regular user
-module.exports.login = function(name, email, isAdmin = false) {
+module.exports.login = function (name, email, isAdmin = false) {
   init(name || defaultName, email || defaultEmail, isAdmin);
 };
 
 // Login as an Admin
-module.exports.loginAdmin = function(name, email) {
+module.exports.loginAdmin = function (name, email) {
   module.exports.login(name, email, true);
 };
 
 // Logout
-module.exports.logout = function() {
+module.exports.logout = function () {
   init();
 };


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #734 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This adds a Jest mock for our SAML authentication strategy, allowing test code to login, login as an admin, or logout.

I've also added `protect` to our `POST /feeds` route, and updated the tests.

Any code for authenticated routes can use this.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
