### PR TITLE
Fixes #702: Unreachable feed list causes the feed queue to error and not recover

### DIFF
--- a/env.example
+++ b/env.example
@@ -24,6 +24,8 @@ LOG_FILE=
 
 # FEED_URL url used to access feed list
 FEED_URL=https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
+# Milliseconds to wait after attempting to fetch the feed list when the server is not available
+FEED_URL_DELAY_MS=30000
 
 # Redis Server info, password may be optional (e.g., leave empty if you don't set one)
 REDIS_URL=redis://127.0.0.1

--- a/env.example
+++ b/env.example
@@ -25,7 +25,7 @@ LOG_FILE=
 # FEED_URL url used to access feed list
 FEED_URL=https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
 # Milliseconds to wait after attempting to fetch the feed list when the server is not available
-FEED_URL_DELAY_MS=30000
+FEED_URL_INTERVAL_MS=30000
 
 # Redis Server info, password may be optional (e.g., leave empty if you don't set one)
 REDIS_URL=redis://127.0.0.1

--- a/env.staging
+++ b/env.staging
@@ -17,7 +17,7 @@ LOG_FILE=telescope.log
 # FEED_URL url used to access feed list
 FEED_URL=https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
 # Milliseconds to wait after attempting to fetch the feed list when the server is not available
-FEED_URL_DELAY_MS=30000
+FEED_URL_INTERVAL_MS=30000
 
 # Redis Server info, password may be optional (e.g., leave empty if you don't set one)
 REDIS_URL=redis://127.0.0.1

--- a/env.staging
+++ b/env.staging
@@ -16,6 +16,8 @@ LOG_FILE=telescope.log
 
 # FEED_URL url used to access feed list
 FEED_URL=https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
+# Milliseconds to wait after attempting to fetch the feed list when the server is not available
+FEED_URL_DELAY_MS=30000
 
 # Redis Server info, password may be optional (e.g., leave empty if you don't set one)
 REDIS_URL=redis://127.0.0.1

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier-check": "prettier --check \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "pretest": "npm run lint",
     "test": "npm run jest",
-    "jest": "cross-env LOG_LEVEL=error MOCK_REDIS=1 jest --",
+    "jest": "cross-env LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest --",
     "coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest --collectCoverage --",
     "jest-watch": "cross-env MOCK_REDIS=1 jest --watch --",
     "start": "node src/backend",

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -38,7 +38,7 @@ async function getWikiText(url) {
  */
 module.exports = async function () {
   let url = process.env.FEED_URL;
-  const interval = process.env.FEED_URL_INTERVAL_MS || 30000;
+  const interval = process.env.FEED_URL_INTERVAL_MS || 2000;
 
   if (!url) {
     url = 'https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List';

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -38,7 +38,7 @@ async function getWikiText(url) {
  */
 module.exports = async function () {
   let url = process.env.FEED_URL;
-  const interval = process.env.FEED_URL_INTERVAL_MS || 2000;
+  const interval = process.env.FEED_URL_INTERVAL_MS || 30000;
 
   if (!url) {
     url = 'https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List';

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -38,7 +38,7 @@ async function getWikiText(url) {
  */
 module.exports = async function () {
   let url = process.env.FEED_URL;
-  const delay = process.env.FEED_URL_DELAY_MS || 30000;
+  const interval = process.env.FEED_URL_INTERVAL_MS || 30000;
 
   if (!url) {
     url = 'https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List';
@@ -48,13 +48,17 @@ module.exports = async function () {
   const nameCheck = /^\s*name/i;
   const commentCheck = /^\s*#/;
 
+  /**
+   * Try to fetch the feed list from 'url'.
+   * If not available, keep trying every 'interval' milliseconds.
+   */
   let intervalId;
   const downloadFeedList = new Promise(resolve => {
     intervalId = setInterval(() => {
       getWikiText(url)
         .then(resolve)
         .catch(error => logger.info({ error }));
-    }, delay);
+    }, interval);
   });
 
   const wikiText = await downloadFeedList;

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -53,11 +53,11 @@ module.exports = async function () {
    * If not available, keep trying every 'interval' milliseconds.
    */
   let intervalId;
-  const downloadFeedList = new Promise(resolve => {
+  const downloadFeedList = new Promise((resolve) => {
     intervalId = setInterval(() => {
       getWikiText(url)
         .then(resolve)
-        .catch(error => logger.info({ error }));
+        .catch((error) => logger.info({ error }));
     }, interval);
   });
 

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -47,13 +47,18 @@ module.exports = async function () {
   const nameCheck = /^\s*name/i;
   const commentCheck = /^\s*#/;
 
-  let wikiText;
-  try {
-    wikiText = await getWikiText(url);
-  } catch (error) {
-    logger.error({ error }, `Unable to download wiki feed data from url ${url}`);
-    throw error;
-  }
+  let intervalId;
+  const downloadFeedList = new Promise(resolve => {
+    intervalId = setInterval(() => {
+      getWikiText(url)
+        .then(resolve)
+        .catch(error => logger.info({ error }));
+    }, 5000);
+  });
+
+  const wikiText = await downloadFeedList;
+
+  clearInterval(intervalId);
 
   const lines = wikiText.split(/\r\n|\r|\n/);
   const feeds = [];

--- a/src/backend/utils/wiki-feed-parser.js
+++ b/src/backend/utils/wiki-feed-parser.js
@@ -38,6 +38,7 @@ async function getWikiText(url) {
  */
 module.exports = async function () {
   let url = process.env.FEED_URL;
+  const delay = process.env.FEED_URL_DELAY_MS || 30000;
 
   if (!url) {
     url = 'https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List';
@@ -53,7 +54,7 @@ module.exports = async function () {
       getWikiText(url)
         .then(resolve)
         .catch(error => logger.info({ error }));
-    }, 5000);
+    }, delay);
   });
 
   const wikiText = await downloadFeedList;

--- a/test/wiki-feed-parser.test.js
+++ b/test/wiki-feed-parser.test.js
@@ -62,12 +62,3 @@ test('Testing wiki-feed-parser.parseData', async () => {
   const response = await getWikiFeeds();
   expect(response).toStrictEqual(expectedData);
 });
-
-test('Testing wiki-feed-parser.parseData when getData fails with no pre tag', async () => {
-  const mockBody = `<html>${mockFeed}</html>`;
-  fetch.mockResponseOnce(mockBody);
-
-  await getWikiFeeds().catch((err) => {
-    expect(err).toStrictEqual(noPreErr);
-  });
-});

--- a/test/wiki-feed-parser.test.js
+++ b/test/wiki-feed-parser.test.js
@@ -36,8 +36,6 @@ name=Eric Ferguson
 [http://armenzg.blogspot.com/feeds/posts/default/-/open%20source]
 name=Armen Zambrano G. (armenzg)`;
 
-const noPreErr = TypeError("Cannot read property 'textContent' of null");
-
 beforeEach(() => {
   fetch.resetMocks();
 });


### PR DESCRIPTION
# Issue This PR Addresses

Fixes #702 

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds a functionality that prevents Telescope from crashing when the feed list is not available. If CDOT wiki is down, Telescope will keep trying to fetch the list in intervals of a number of milliseconds that can be set in our `.env` (default value is 30 seconds).

Testing:
Testing this functionality is tricky since we can't control when the feed list is available. Because of that, we will start a little server locally and make telescope fetch the feed list from it.

Steps
- Once you're in the PR's branch, set `env.example` as your `.env`.
- In `.env`, set
  - `FEED_URL_INTERVAL_MS=5000`
  - `FEED_URL=http://localhost:4000/Planet_CDOT_Feed_List`
- Download the feed list from CDOT wiki:
  - e.g. `wget https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List`
- Remove the file inside of the `redis-data` directory for a clean deployment.
- Start redis and elasticsearch locally or using docker.
- Start Telescope with `npm start`. You should get an error every 5 seconds (5000 ms) saying that Telescope can't get the feed list:
```sh
[ 2020-04-01 20:41:23.239 ] ERROR (12820 on lanar4-pc): Unable to download wiki feed data from url http://localhost:4000/Planet_CDOT_Feed_List
    error: {
      "message": "request to http://localhost:4000/Planet_CDOT_Feed_List failed, reason: connect ECONNREFUSED 127.0.0.1:4000",
      "type": "system",
      "errno": "ECONNREFUSED",
      "code": "ECONNREFUSED"
    }
[ 2020-04-01 20:41:23.240 ] INFO  (12820 on lanar4-pc):
    error: {
      "message": "request to http://localhost:4000/Planet_CDOT_Feed_List failed, reason: connect ECONNREFUSED 127.0.0.1:4000",
      "type": "system",
      "errno": "ECONNREFUSED",
      "code": "ECONNREFUSED"
    }
```

- Telescope is trying to get the list from `http://localhost:4000/Planet_CDOT_Feed_List`, but it's not available. To make it available, open a terminal and go to the directory where the feed list was downloaded using `wget` (or your favourite tool to download feed lists). Once there, start a small server in port 4000 (same port defined in `FEED_URL`) using python 2 or 3:
  - Python 2: `python -m SimpleHTTPServer 4000`
  - Python 3: `python3 -m http.server 4000`
- Telescope should start processing feeds. If you stop the python server, you should see how Telescope processes all the fetched feeds (and their posts), and once it's done, the same error about not being able to get the feed list should appear again.

__Important__:
Don't forget to set your `.env` back to default values and stop the python server once you're done testing this PR.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
