### PR TITLE
Fixes #914: link logged-in user's name to MyFeeds page

### DIFF
--- a/src/frontend/src/components/Login/LoggedIn.jsx
+++ b/src/frontend/src/components/Login/LoggedIn.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { Button, Typography } from '@material-ui/core';
+import { Link } from 'gatsby';
 
 import useSiteMetadata from '../../hooks/use-site-metadata';
 
@@ -32,7 +33,9 @@ function LoggedIn(props) {
           Logout
         </a>
       </Button>
-      <Typography variant="h4">| Welcome {props.name}</Typography>
+      <Link to="/myfeeds" className={classes.links}>
+        <Typography variant="h4">| {props.name}</Typography>
+      </Link>
       <img
         className={classes.avatar}
         src={`https://unavatar.now.sh/${props.name}`}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #914

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

This PR adds a means to navigate to the My Feeds component via a Header link. 

When a user is logged in, clicking on their username (within the Header) will now redirect them to the My Feeds page.

This change does not involve adding any additional elements to the (already-full) Header, which was a point a concern.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
