### PR TITLE
Add a way to receive updates when new posts are available

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "3.1.3",
-    "@material-ui/core": "4.9.8",
+    "@material-ui/core": "4.9.9",
     "@material-ui/icons": "4.9.1",
     "@material-ui/styles": "4.9.6",
     "apollo-boost": "0.4.7",

--- a/src/frontend/src/components/SnackBar/SnackBar.jsx
+++ b/src/frontend/src/components/SnackBar/SnackBar.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import Snackbar from '@material-ui/core/Snackbar';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+
+export default function SimpleSnackbar() {
+  const [open, setOpen] = useState(true);
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        open={open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        message="There is new content available!"
+        action={
+          <React.Fragment>
+            <IconButton size="small" aria-label="close" color="inherit" onClick={handleClose}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </React.Fragment>
+        }
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/SnackBar/index.js
+++ b/src/frontend/src/components/SnackBar/index.js
@@ -1,0 +1,3 @@
+import CustomizedSnackBar from './SnackBar.jsx';
+
+export default CustomizedSnackBar;

--- a/src/frontend/src/pages/index.js
+++ b/src/frontend/src/pages/index.js
@@ -1,20 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PageBase from './PageBase';
 import Banner from '../components/Banner';
 import Posts from '../components/Posts';
 import ScrollToTop from '../components/ScrollToTop';
 import useSiteMetaData from '../hooks/use-site-metadata';
+import CustomizedSnackBar from '../components/SnackBar';
 
 export default function IndexPage() {
   const [numPages, setNumPages] = useState(1);
   const [posts, setPosts] = useState([]);
+  const [initNumPosts, setInitNumPosts] = useState(0);
+  const [currentNumPosts, setCurrentNumPosts] = useState(0);
   const { telescopeUrl } = useSiteMetaData();
+  const savedCallback = useRef();
 
   useEffect(() => {
     async function getPosts(pageNum = 1) {
       try {
         const res = await fetch(`${telescopeUrl}/posts?page=${pageNum}`);
-
         if (!res.ok) {
           throw new Error(res.statusText);
         }
@@ -22,7 +25,6 @@ export default function IndexPage() {
         const postsData = await Promise.all(
           postsUrls.map(async ({ url }) => {
             const tmp = await fetch(`${telescopeUrl}${url}`);
-
             if (!tmp.ok) {
               throw new Error(tmp.statusText);
             }
@@ -40,12 +42,66 @@ export default function IndexPage() {
     getPosts(numPages);
   }, [telescopeUrl]);
 
+  async function getPostsCount() {
+    try {
+      const res = await fetch(`${telescopeUrl}/posts`, { method: 'HEAD' });
+      if (!res.ok) {
+        throw new Error(res.statusText);
+      }
+      return res.headers.get('x-total-count');
+    } catch (error) {
+      console.log(error);
+    }
+    return null;
+  }
+
+  function callback() {
+    getPostsCount()
+      .then(setCurrentNumPosts)
+      .catch((error) => console.log(error));
+  }
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  });
+
+  // Get the current + initial posts count when page loads
+  useEffect(() => {
+    async function setPostsInfo() {
+      try {
+        await Promise.all([
+          setInitNumPosts(await getPostsCount()),
+          setCurrentNumPosts(await getPostsCount()),
+        ]);
+      } catch (error) {
+        console.log({ error });
+      }
+    }
+    setPostsInfo();
+  }, []);
+
+  useEffect(() => {
+    function getCurrentNumPosts() {
+      savedCallback.current();
+    }
+
+    savedCallback.current = callback;
+    // Polls every 5 minutes
+    const interval = setInterval(getCurrentNumPosts, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [currentNumPosts]);
+
   return (
-    <PageBase title="Home">
-      <Banner className="banner" />
-      <ScrollToTop />
-      <main className="main">{posts.length > 0 ? <Posts posts={posts} /> : null}</main>
-      <footer>© {new Date().getFullYear()}</footer>
+    <PageBase>
+      <>
+        <Banner className="banner" />
+        <ScrollToTop />
+        <main className="main">
+          {posts.length > 0 ? <Posts posts={posts} /> : null}
+          {currentNumPosts !== initNumPosts ? <CustomizedSnackBar posts={currentNumPosts} /> : null}
+        </main>
+        <footer>© {new Date().getFullYear()}</footer>
+      </>
     </PageBase>
   );
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #791 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Adding a `setInterval` to the front end that will query telescope to see if the # of posts has changed.

It is currently set at 5 seconds as I'm still working on it. How it should ideally work:
1. The page is loaded: we get posts, total posts count AND start a timer. When we fetched for the total posts count, we assign it to two states `initNumPosts` and `currentNumPosts`.
2. Every 5s the attached timer will fetch for total posts count and assign that value to currentNumPosts.
3. At the return statement portion of `index.js` I have a conditional that will render the component `CustomizedSnackBar`. I set it so that as soon as the `CustomizedSnackBar` component is rendered it will trigger an alert `There are new post(s) available`.

I also updated the package `@material-ui/core` so I can add+use the experimental package `@material-ui/lab` for Alerts

Testing instructions:
You'll need your local backend for this to work.
1. Make sure redis is empty, this includes `redis-flushall` and deleting the redis-data file.
2. Use `npm run develop` make sure the front-end is built
3. Use `npm start`, you can open up the developer tools as I added console.log messages that'll be removed when this goes in.
4. If there's a difference between the initial and the current # of posts an alert should appear at the bottom center of the screen. Keep in mind this alert only appears once and for about 6s.
5. The fun only goes on until all the posts are stored in redis, if this happens start from step1 all over again. To keep track of how many posts are in redis, use the command `redis-cli zcard t:posts`


<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
