### PR TITLE
Fix #746, #760, #946: enhance the My Feeds page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,9 +4,10 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:promise/recommended',
     'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
   ],
 
-  plugins: ['prettier', 'promise', 'react'],
+  plugins: ['prettier', 'promise', 'react', 'react-hooks'],
 
   env: {
     jest: true,
@@ -109,5 +110,7 @@ module.exports = {
      * https://eslint.org/docs/rules/class-methods-use-this
      */
     'class-methods-use-this': 'off',
+
+    'import/no-extraneous-dependencies': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint-plugin-prettier": "3.1.2",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.19.0",
+    "eslint-plugin-react-hooks": "3.0.0",
     "fast-xml-parser": "3.16.0",
     "husky": "4.2.3",
     "jest": "25.2.6",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -9,6 +9,7 @@
     "apollo-boost": "0.4.7",
     "apollo-link-http": "1.5.16",
     "dotenv": "8.2.0",
+    "eslint-plugin-react-hooks": "3.0.0",
     "gatsby": "2.20.10",
     "gatsby-plugin-manifest": "2.3.3",
     "gatsby-plugin-material-ui": "2.1.6",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -19,11 +19,13 @@
     "gatsby-transformer-sharp": "2.4.3",
     "graphql-tag": "2.10.3",
     "highlight.js": "9.18.1",
+    "material-ui-popup-state": "1.5.4",
     "node-fetch": "2.6.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-helmet": "5.2.1"
+    "react-helmet": "5.2.1",
+    "react-material-ui-form-validator": "2.0.10"
   },
   "devDependencies": {
     "json-loader": "0.5.7"

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -88,8 +88,6 @@ function DeleteFeedDialogButton({ feed }) {
 
 DeleteFeedDialogButton.propTypes = {
   feed: PropTypes.object,
-  // 'feed.id': PropTypes.string,
-  // 'feed.url': PropTypes.string,
 };
 
 export default DeleteFeedDialogButton;

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -33,7 +33,6 @@ function DeleteFeedDialogButton({ feed }) {
   const removeFeed = () => {
     console.log(`Removing feed hosted at URL ${feed.url}`);
     // TODO https://github.com/Seneca-CDOT/telescope/issues/946
-    window.location.reload(false);
   };
 
   return (

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -19,7 +19,8 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function DeleteFeedDialogButton({ id, url }) {
+function DeleteFeedDialogButton({ feed }) {
+  const { id, url } = feed;
   const classes = useStyles();
   const { telescopeUrl } = useSiteMetadata();
   const [open, setOpen] = useState(false);
@@ -86,8 +87,9 @@ function DeleteFeedDialogButton({ id, url }) {
 }
 
 DeleteFeedDialogButton.propTypes = {
-  id: PropTypes.string,
-  url: PropTypes.string,
+  feed: PropTypes.object,
+  // 'feed.id': PropTypes.string,
+  // 'feed.url': PropTypes.string,
 };
 
 export default DeleteFeedDialogButton;

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+} from '@material-ui/core';
+import { Delete } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  button: {
+    padding: '3px 0 3px 0',
+  },
+}));
+
+function DeleteFeedDialogButton({ feed }) {
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const removeFeed = () => {
+    console.log(`Removing feed hosted at URL ${feed.url}`);
+    // TODO https://github.com/Seneca-CDOT/telescope/issues/946
+    window.location.reload(false);
+  };
+
+  return (
+    <div>
+      <IconButton classes={{ root: classes.button }} onClick={handleClickOpen}>
+        <Delete color="secondary" />
+      </IconButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{`Remove feed hosted at ${feed.url}?`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Telescope will no longer display blog posts from this feed.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="secondary" variant="outlined" autoFocus>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              handleClose();
+              removeFeed();
+            }}
+            color="primary"
+            variant="contained"
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+DeleteFeedDialogButton.propTypes = {
+  feed: PropTypes.object,
+};
+
+export default DeleteFeedDialogButton;

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function DeleteFeedDialogButton({ feed }) {
+function DeleteFeedDialogButton({ id, url }) {
   const classes = useStyles();
   const { telescopeUrl } = useSiteMetadata();
   const [open, setOpen] = useState(false);
@@ -33,9 +33,9 @@ function DeleteFeedDialogButton({ feed }) {
   };
 
   const removeFeed = async () => {
-    console.log(`Removing feed hosted at URL ${feed.url}...`);
+    console.log(`Removing feed hosted at URL ${url}...`);
     try {
-      const response = await fetch(`${telescopeUrl}/feeds/${feed.id}`, { method: 'DELETE' });
+      const response = await fetch(`${telescopeUrl}/feeds/${id}`, { method: 'DELETE' });
 
       if (!response.ok) {
         throw new Error(response.statusText);
@@ -43,7 +43,7 @@ function DeleteFeedDialogButton({ feed }) {
 
       console.log(`Feed removed successfully`);
     } catch (error) {
-      console.log(`Error removing feed with ID ${feed.id}`, error);
+      console.log(`Error removing feed with ID ${id}`, error);
       throw error;
     }
   };
@@ -59,7 +59,7 @@ function DeleteFeedDialogButton({ feed }) {
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
-        <DialogTitle id="alert-dialog-title">{`Remove feed hosted at ${feed.url}?`}</DialogTitle>
+        <DialogTitle id="alert-dialog-title">{`Remove feed hosted at ${url}?`}</DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
             Telescope will no longer display blog posts from this feed.
@@ -86,7 +86,8 @@ function DeleteFeedDialogButton({ feed }) {
 }
 
 DeleteFeedDialogButton.propTypes = {
-  feed: PropTypes.object,
+  id: PropTypes.string,
+  url: PropTypes.string,
 };
 
 export default DeleteFeedDialogButton;

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -11,6 +11,7 @@ import {
 } from '@material-ui/core';
 import { Delete } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
+import useSiteMetadata from '../../hooks/use-site-metadata';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -20,6 +21,7 @@ const useStyles = makeStyles(() => ({
 
 function DeleteFeedDialogButton({ feed }) {
   const classes = useStyles();
+  const { telescopeUrl } = useSiteMetadata();
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
@@ -30,9 +32,20 @@ function DeleteFeedDialogButton({ feed }) {
     setOpen(false);
   };
 
-  const removeFeed = () => {
-    console.log(`Removing feed hosted at URL ${feed.url}`);
-    // TODO https://github.com/Seneca-CDOT/telescope/issues/946
+  const removeFeed = async () => {
+    console.log(`Removing feed hosted at URL ${feed.url}...`);
+    try {
+      const response = await fetch(`${telescopeUrl}/feeds/${feed.id}`, { method: 'DELETE' });
+
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+
+      console.log(`Feed removed successfully`);
+    } catch (error) {
+      console.log(`Error removing feed with ID ${feed.id}`, error);
+      throw error;
+    }
   };
 
   return (

--- a/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -20,7 +20,7 @@ const useStyles = makeStyles(() => ({
 
 function DeleteFeedDialogButton({ feed }) {
   const classes = useStyles();
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
     setOpen(true);

--- a/src/frontend/src/components/MyFeedsPage/ExistingFeedList.jsx
+++ b/src/frontend/src/components/MyFeedsPage/ExistingFeedList.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TextValidator } from 'react-material-ui-form-validator';
+import { Grid, Typography } from '@material-ui/core';
+import { AccountCircle, RssFeed } from '@material-ui/icons';
+import DeleteFeedDialogButton from './DeleteFeedDialogButton.jsx';
+
+function ExistingFeedList({ feedHash }) {
+  if (Object.keys(feedHash).length) {
+    return Object.keys(feedHash).map((id) => (
+      <Grid container spacing={5} key={id}>
+        <Grid item>
+          <Grid container spacing={1} alignItems="flex-end">
+            <Grid item>
+              <AccountCircle />
+            </Grid>
+            <Grid item>
+              <TextValidator
+                disabled
+                label="Blog feed author"
+                name="author"
+                value={feedHash[id].author}
+                type="string"
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Grid container spacing={1} alignItems="flex-end">
+            <Grid item>
+              <RssFeed />
+            </Grid>
+            <Grid item>
+              <TextValidator
+                disabled
+                label="Blog feed URL"
+                name="url"
+                value={feedHash[id].url}
+                type="url"
+              />
+            </Grid>
+            <Grid item>
+              <DeleteFeedDialogButton feed={feedHash[id]} />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    ));
+  }
+  return (
+    <Typography align="center">
+      <em>(It looks like you have not added any blog feeds yet.)</em>
+    </Typography>
+  );
+}
+
+ExistingFeedList.propTypes = {
+  feedHash: PropTypes.object,
+};
+
+export default ExistingFeedList;

--- a/src/frontend/src/components/MyFeedsPage/ExistingFeedList.jsx
+++ b/src/frontend/src/components/MyFeedsPage/ExistingFeedList.jsx
@@ -40,7 +40,7 @@ function ExistingFeedList({ feedHash }) {
               />
             </Grid>
             <Grid item>
-              <DeleteFeedDialogButton feed={feedHash[id]} />
+              <DeleteFeedDialogButton feed={{ id, ...feedHash[id] }} />
             </Grid>
           </Grid>
         </Grid>

--- a/src/frontend/src/components/MyFeedsPage/HelpPopoverButton.jsx
+++ b/src/frontend/src/components/MyFeedsPage/HelpPopoverButton.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Box, IconButton, Popover, Typography } from '@material-ui/core';
+import { HelpOutline } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+
+const useStyles = makeStyles(() => ({
+  button: {
+    padding: '3px 0 3px 0',
+  },
+}));
+
+function HelpPopoverButton() {
+  const classes = useStyles();
+
+  return (
+    <PopupState variant="popover" popupId="help-popover">
+      {(popupState) => (
+        <div>
+          <IconButton
+            color="secondary"
+            classes={{ root: classes.button }}
+            {...bindTrigger(popupState)}
+          >
+            <HelpOutline />
+          </IconButton>
+          <Popover
+            {...bindPopover(popupState)}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <Box p={2}>
+              <Typography align="center">
+                Please enter the web address of your blog&apos;s RSS or Atom feed.
+              </Typography>
+              <Typography align="center">
+                <em>
+                  (<a href="https://rss.com/blog/find-rss-feed/">Not sure how to find that?</a>)
+                </em>
+              </Typography>
+            </Box>
+          </Popover>
+        </div>
+      )}
+    </PopupState>
+  );
+}
+
+export default HelpPopoverButton;

--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -1,29 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import {
-  Box,
-  Button,
-  Card,
-  Container,
-  Dialog,
-  DialogContent,
-  DialogActions,
-  DialogContentText,
-  DialogTitle,
-  Grid,
-  IconButton,
-  Popover,
-  Typography,
-} from '@material-ui/core';
-import { AccountCircle, AddCircle, Delete, HelpOutline, RssFeed } from '@material-ui/icons';
+import { Box, Card, Container, Grid, IconButton, Typography } from '@material-ui/core';
+import { AccountCircle, AddCircle, RssFeed } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 import { ValidatorForm, TextValidator } from 'react-material-ui-form-validator';
-import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { isWebUri } from 'valid-url';
 
 import PageBase from './PageBase';
 import useSiteMetadata from '../hooks/use-site-metadata';
+import ExistingFeedList from '../components/MyFeedsPage/ExistingFeedList.jsx';
+import HelpPopoverButton from '../components/MyFeedsPage/HelpPopoverButton.jsx';
 
 const useStyles = makeStyles((theme) => ({
   margin: {
@@ -34,152 +19,75 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function HelpPopoverButton() {
-  const classes = useStyles();
-
-  return (
-    <PopupState variant="popover" popupId="help-popover">
-      {(popupState) => (
-        <div>
-          <IconButton
-            color="secondary"
-            classes={{ root: classes.button }}
-            {...bindTrigger(popupState)}
-          >
-            <HelpOutline />
-          </IconButton>
-          <Popover
-            {...bindPopover(popupState)}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-          >
-            <Box p={2}>
-              <Typography align="center">
-                Please enter the web address of your blog&apos;s RSS or Atom feed.
-              </Typography>
-              <Typography align="center">
-                <em>
-                  (<a href="https://rss.com/blog/find-rss-feed/">Not sure how to find that?</a>)
-                </em>
-              </Typography>
-            </Box>
-          </Popover>
-        </div>
-      )}
-    </PopupState>
-  );
-}
-
-function DeleteDialogButton({ feed }) {
-  const classes = useStyles();
-  const [open, setOpen] = React.useState(false);
-
-  const handleClickOpen = () => {
-    setOpen(true);
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
-
-  const removeFeed = () => {
-    console.log(`Removing feed hosted at URL ${feed.url}`);
-    // TODO
-    window.location.reload(false);
-  };
-
-  return (
-    <div>
-      <IconButton classes={{ root: classes.button }} onClick={handleClickOpen}>
-        <Delete color="secondary" />
-      </IconButton>
-      <Dialog
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id="alert-dialog-title">{`Remove feed hosted at ${feed.url}?`}</DialogTitle>
-        <DialogContent>
-          <DialogContentText id="alert-dialog-description">
-            Telescope will no longer display blog posts from this feed.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} color="secondary" variant="outlined" autoFocus>
-            Cancel
-          </Button>
-          <Button
-            onClick={() => {
-              handleClose();
-              removeFeed();
-            }}
-            color="primary"
-            variant="contained"
-          >
-            Confirm
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </div>
-  );
-}
-
-DeleteDialogButton.propTypes = {
-  feed: PropTypes.object,
-};
-
 export default function MyFeeds() {
   const classes = useStyles();
   const [newFeedAuthor, setNewFeedAuthor] = useState('');
   const [newFeedUrl, setNewFeedUrl] = useState('');
   const [submitStatus, setSubmitStatus] = useState({ message: '', isError: false });
   const [userInfo, setUserInfo] = useState({});
-  const [feedHash, updateFeedHash] = useState({}); // { id1: {author: '...', url: '...'} }, ... ]
+  const [feedHash, updateFeedHash] = useState({}); // { id1: {author: '...', url: '...'}, id2: {...}, ... }
 
   const { telescopeUrl } = useSiteMetadata();
 
-  const newFeedAuthorRef = React.createRef();
-  const newFeedUrlRef = React.createRef();
-
-  async function hashUserFeeds() {
-    const [user, feedItems] = await Promise.all([
-      fetch(`${telescopeUrl}/user/info`).then((res) => res.json()),
-      fetch(`${telescopeUrl}/feeds`).then((res) => res.json()),
-    ]);
-    const allFeeds = await Promise.all(
-      feedItems.map((item) => fetch(`${telescopeUrl}${item.url}`))
-    ).then((responses) => Promise.all(responses.map((res) => res.json())));
-
-    if (allFeeds.length && user) {
-      const userFeeds = allFeeds.filter((feed) => {
-        return feed.user === user.id;
-      });
-
-      const userFeedHash = userFeeds.reduce((hash, feed) => {
-        hash[feed.id] = { author: feed.author, url: feed.url };
-        return hash;
-      }, {});
-
-      return Promise.all([updateFeedHash(userFeedHash), setUserInfo(user)]);
-    }
-    return Promise.reject();
-  }
+  const newFeedAuthorRef = React.useRef();
+  const newFeedUrlRef = React.useRef();
 
   useEffect(() => {
-    hashUserFeeds();
+    (async function fetchUserInfo() {
+      try {
+        const response = await fetch(`${telescopeUrl}/user/info`);
+
+        if (!response.ok) {
+          throw new Error(response.statusText);
+        }
+
+        const user = await response.json();
+        setUserInfo(user);
+        setNewFeedAuthor(user.name);
+      } catch (error) {
+        console.log('Error fetching user info, redirecting to login page', error);
+        window.location.href = `${telescopeUrl}/auth/login`;
+      }
+    })();
+
     ValidatorForm.addValidationRule('isUrl', (value) => !!isWebUri(value));
     return ValidatorForm.removeValidationRule.bind('isUrl');
-  }, []);
+  }, [telescopeUrl]);
+
+  useEffect(() => {
+    (async function hashUserFeeds() {
+      try {
+        if (userInfo.id || submitStatus.isError === false) {
+          const response = await fetch(`${telescopeUrl}/feeds`);
+
+          if (!response.ok) {
+            throw new Error(response.statusText);
+          }
+
+          const feedItems = await response.json();
+
+          const allFeedsData = await Promise.all(
+            feedItems.map((item) => fetch(`${telescopeUrl}${item.url}`))
+          );
+          const allFeeds = await Promise.all(allFeedsData.map((res) => res.json()));
+
+          const userFeedHash = allFeeds.reduce((hash, feed) => {
+            if (feed.user === userInfo.id) {
+              hash[feed.id] = { author: feed.author, url: feed.url };
+            }
+            return hash;
+          }, {});
+
+          updateFeedHash(userFeedHash);
+        }
+      } catch (error) {
+        console.log('Error fetching feeds', error);
+        throw error;
+      }
+    })();
+  }, [telescopeUrl, userInfo, submitStatus]);
 
   async function addFeed() {
-    setSubmitStatus({ message: 'Adding new feed, please wait...' });
     try {
       const response = await fetch(`${telescopeUrl}/feeds`, {
         method: 'post',
@@ -192,17 +100,14 @@ export default function MyFeeds() {
           url: newFeedUrl,
         }),
       });
-      await setSubmitStatus(
+      setSubmitStatus(
         response.ok
-          ? { message: 'Feed added successfully' }
+          ? { message: 'Feed added successfully', isError: false }
           : { message: `Error: ${response.status} ${response.statusText}`, isError: true }
       );
-      if (response.ok) {
-        window.location.reload(false);
-      }
     } catch (error) {
       setSubmitStatus({ message: error.message, isError: true });
-      console.log({ error });
+      console.log('Error adding feeds', error);
     }
   }
 
@@ -219,56 +124,6 @@ export default function MyFeeds() {
     ref.current.validate(event.target.value, true);
   }
 
-  function listExistingFeeds() {
-    if (Object.keys(feedHash).length) {
-      return Object.keys(feedHash).map((id) => (
-        <Grid container spacing={5} key={id}>
-          <Grid item>
-            <Grid container spacing={1} alignItems="flex-end">
-              <Grid item>
-                <AccountCircle />
-              </Grid>
-              <Grid item>
-                <TextValidator
-                  disabled
-                  label="Blog feed author"
-                  name="author"
-                  value={feedHash[id].author}
-                  type="string"
-                />
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item>
-            <Grid container spacing={1} alignItems="flex-end">
-              <Grid item>
-                <RssFeed />
-              </Grid>
-              <Grid item>
-                <TextValidator
-                  disabled
-                  label="Blog feed URL"
-                  name="url"
-                  value={feedHash[id].url}
-                  type="url"
-                />
-              </Grid>
-              <Grid item>
-                <DeleteDialogButton feed={feedHash[id]} />
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
-      ));
-    }
-    console.log(`No feeds associated with user ${userInfo.id} found.`);
-    return (
-      <Typography align="center">
-        <em>(It looks like you have not added any blog feeds yet.)</em>
-      </Typography>
-    );
-  }
-
   return (
     <PageBase title="My Feeds">
       <div className={classes.margin}>
@@ -279,7 +134,7 @@ export default function MyFeeds() {
                 <Typography variant="h3" component="h3" align="center">
                   My Feeds
                 </Typography>
-                {listExistingFeeds()}
+                <ExistingFeedList feedHash={feedHash} />
                 <Grid container spacing={5}>
                   <Grid item>
                     <Grid container spacing={1} alignItems="flex-end">
@@ -288,7 +143,6 @@ export default function MyFeeds() {
                       </Grid>
                       <Grid item>
                         <TextValidator
-                          disabled={!userInfo.isAdmin}
                           label="Blog feed author"
                           name="author"
                           ref={newFeedAuthorRef}
@@ -329,7 +183,10 @@ export default function MyFeeds() {
                         <IconButton classes={{ root: classes.button }} type="submit">
                           <AddCircle color="secondary" />
                         </IconButton>
-                        <Typography color={submitStatus.isError ? 'error' : 'textPrimary'}>
+                        <Typography
+                          color={submitStatus.isError ? 'error' : 'textPrimary'}
+                          align="center"
+                        >
                           {submitStatus.message}
                         </Typography>
                       </Grid>

--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -66,6 +66,8 @@ export default function MyFeeds() {
   const [feedAuthor, setFeedAuthor] = useState('');
   const [feedUrl, setFeedUrl] = useState('');
   const [submitStatus, setSubmitStatus] = useState({ message: '', isError: false });
+  const [userInfo, setUserInfo] = useState({});
+  const [userFeeds, setUserFeeds] = useState([]);
 
   const { telescopeUrl } = useSiteMetadata();
 
@@ -73,7 +75,30 @@ export default function MyFeeds() {
   const feedUrlRef = React.createRef();
   const formRef = React.createRef();
 
+  async function fetchUserFeeds() {
+    const [user, feedItems] = await Promise.all([
+      fetch(`${telescopeUrl}/user/info`).then((res) => res.json()),
+      fetch(`${telescopeUrl}/feeds`).then((res) => res.json()),
+    ]);
+    const allFeeds = await Promise.all(
+      feedItems.map((item) => fetch(`${telescopeUrl}${item.url}`))
+    ).then((responses) => Promise.all(responses.map((res) => res.json())));
+
+    console.log(allFeeds.length, user.id);
+
+    if (allFeeds.length && user) {
+      const feeds = allFeeds.filter((feed) => {
+        return feed.user === user.id;
+      });
+      setUserInfo(user);
+      setUserFeeds(feeds);
+    }
+  }
+
   useEffect(() => {
+    (async function () {
+      await fetchUserFeeds();
+    })();
     ValidatorForm.addValidationRule('isUrl', (value) => !!isWebUri(value));
     return ValidatorForm.removeValidationRule.bind('isUrl');
   }, []);
@@ -86,7 +111,7 @@ export default function MyFeeds() {
     setFeedUrl(url);
   }
 
-  async function addFeed() {
+  async function saveFeeds() {
     try {
       setSubmitStatus({ message: 'Saving feeds, please wait...' });
       const response = await fetch(`${telescopeUrl}/feeds`, {
@@ -95,6 +120,7 @@ export default function MyFeeds() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          user: userInfo.id,
           author: feedAuthor,
           url: feedUrl,
         }),
@@ -131,16 +157,76 @@ export default function MyFeeds() {
     }
   }
 
+  function buildFormControls() {
+    if (userFeeds.length > 0) {
+      return userFeeds.map((feed) => (
+        <Grid container spacing={5} key={feed.id}>
+          <Grid item>
+            <Grid container spacing={1} alignItems="flex-end">
+              <Grid item>
+                <AccountCircle />
+              </Grid>
+              <Grid item>
+                <TextValidator
+                  disabled={!userInfo.isAdmin}
+                  label="Blog feed author"
+                  name="author"
+                  // ref={feedAuthorRef}
+                  value={feed.author}
+                  // onBlur={handleBlur}
+                  // onChange={handleChange}
+                  type="string"
+                  validators={['required', 'trim']}
+                  errorMessages={"Please enter the blog's author."}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Grid container spacing={1} alignItems="flex-end">
+              <Grid item>
+                <RssFeed />
+              </Grid>
+              <Grid item>
+                <TextValidator
+                  label="Blog feed URL"
+                  name="url"
+                  // ref={feedUrlRef}
+                  value={feed.url}
+                  // onBlur={handleBlur}
+                  // onChange={handleChange}
+                  type="url"
+                  validators={['required', 'isUrl']}
+                  errorMessages={"Please enter the blog's feed URL."}
+                />
+              </Grid>
+              <Grid item>
+                <HelpPopoverButton />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      ));
+    }
+    console.log(`No feeds associated with user ${userInfo.id} found.`);
+    return (
+      <Typography align="center">
+        <em>(It looks like you have not added any blog feeds yet.)</em>
+      </Typography>
+    );
+  }
+
   return (
     <PageBase title="My Feeds">
       <div className={classes.margin}>
-        <ValidatorForm ref={formRef} onSubmit={addFeed}>
+        <ValidatorForm ref={formRef} onSubmit={saveFeeds}>
           <Container maxWidth="xs" bgcolor="aliceblue">
             <Card>
               <Box px={2} py={1}>
                 <Typography variant="h3" component="h3" align="center">
                   My Feeds
                 </Typography>
+                {buildFormControls()}
                 <Grid container spacing={5}>
                   <Grid item>
                     <Grid container spacing={1} alignItems="flex-end">
@@ -149,6 +235,7 @@ export default function MyFeeds() {
                       </Grid>
                       <Grid item>
                         <TextValidator
+                          disabled={!userInfo.isAdmin}
                           label="Blog feed author"
                           name="author"
                           ref={feedAuthorRef}

--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -1,7 +1,11 @@
-import React, { useState } from 'react';
-import { Container, Box, Typography, TextField, Grid, Card, IconButton } from '@material-ui/core';
+import React, { useState, useEffect } from 'react';
+import { Container, Box, Typography, Grid, Card, IconButton, Popover } from '@material-ui/core';
 import { AccountCircle, RssFeed, HelpOutline, Add } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
+import { ValidatorForm, TextValidator } from 'react-material-ui-form-validator';
+import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { isWebUri } from 'valid-url';
 
 import PageBase from './PageBase';
 import useSiteMetadata from '../hooks/use-site-metadata';
@@ -15,11 +19,64 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+function HelpPopoverButton() {
+  const classes = useStyles();
+
+  return (
+    <PopupState variant="popover" popupId="help-popover">
+      {(popupState) => (
+        <div>
+          <IconButton
+            color="primary"
+            classes={{ root: classes.button }}
+            {...bindTrigger(popupState)}
+          >
+            <HelpOutline />
+          </IconButton>
+          <Popover
+            {...bindPopover(popupState)}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <Box p={2}>
+              <Typography align="center">
+                Please enter the web address of your blog&apos;s RSS or Atom feed.
+              </Typography>
+              <Typography align="center">
+                <em>
+                  (<a href="https://rss.com/blog/find-rss-feed/">Not sure how to find that?</a>)
+                </em>
+              </Typography>
+            </Box>
+          </Popover>
+        </div>
+      )}
+    </PopupState>
+  );
+}
+
 export default function MyFeeds() {
   const classes = useStyles();
   const [feedAuthor, setFeedAuthor] = useState('');
   const [feedUrl, setFeedUrl] = useState('');
+  const [submitStatus, setSubmitStatus] = useState({ message: '', isError: false });
+
   const { telescopeUrl } = useSiteMetadata();
+
+  const feedAuthorRef = React.createRef();
+  const feedUrlRef = React.createRef();
+  const formRef = React.createRef();
+
+  useEffect(() => {
+    ValidatorForm.addValidationRule('isUrl', (value) => !!isWebUri(value));
+    return ValidatorForm.removeValidationRule.bind('isUrl');
+  }, []);
 
   function handleAuthorChange(author) {
     setFeedAuthor(author);
@@ -31,6 +88,7 @@ export default function MyFeeds() {
 
   async function addFeed() {
     try {
+      setSubmitStatus({ message: 'Saving feeds, please wait...' });
       const response = await fetch(`${telescopeUrl}/feeds`, {
         method: 'post',
         headers: {
@@ -42,67 +100,106 @@ export default function MyFeeds() {
         }),
       });
       console.log(response);
+      setSubmitStatus(
+        response.ok
+          ? { message: 'Feeds updated successfully' }
+          : { message: `Error: ${response.status} ${response.statusText}`, isError: true }
+      );
       return response;
     } catch (error) {
+      setSubmitStatus({ message: error.message, isError: true });
       console.log({ error });
       return { error };
+    }
+  }
+
+  function handleChange(event) {
+    const { name, value } = event.target;
+    if (name === 'author') {
+      handleAuthorChange(value);
+    } else {
+      handleUrlChange(value);
+    }
+  }
+
+  function handleBlur(event) {
+    const { name, value } = event.target;
+    if (name === 'author') {
+      feedAuthorRef.current.validate(value, true);
+    } else {
+      feedUrlRef.current.validate(value, true);
     }
   }
 
   return (
     <PageBase title="My Feeds">
       <div className={classes.margin}>
-        <Container maxWidth="xs" bgcolor="aliceblue">
-          <Card>
-            <Box px={2} py={1}>
-              <Typography variant="h3" component="h3" align="center">
-                My Feeds
-              </Typography>
-              <Grid container spacing={5}>
-                <Grid item>
-                  <Grid container spacing={1} alignItems="flex-end">
-                    <Grid item>
-                      <AccountCircle />
+        <ValidatorForm ref={formRef} onSubmit={addFeed}>
+          <Container maxWidth="xs" bgcolor="aliceblue">
+            <Card>
+              <Box px={2} py={1}>
+                <Typography variant="h3" component="h3" align="center">
+                  My Feeds
+                </Typography>
+                <Grid container spacing={5}>
+                  <Grid item>
+                    <Grid container spacing={1} alignItems="flex-end">
+                      <Grid item>
+                        <AccountCircle />
+                      </Grid>
+                      <Grid item>
+                        <TextValidator
+                          label="Blog feed author"
+                          name="author"
+                          ref={feedAuthorRef}
+                          value={feedAuthor}
+                          onBlur={handleBlur}
+                          onChange={handleChange}
+                          type="string"
+                          validators={['required', 'trim']}
+                          errorMessages={"Please enter the blog's author."}
+                        />
+                      </Grid>
                     </Grid>
-                    <Grid item>
-                      <TextField
-                        id="author"
-                        label="John Doe"
-                        onBlur={(event) => handleAuthorChange(event.target.value)}
-                      />
+                  </Grid>
+                  <Grid item>
+                    <Grid container spacing={1} alignItems="flex-end">
+                      <Grid item>
+                        <RssFeed />
+                      </Grid>
+                      <Grid item>
+                        <TextValidator
+                          label="Blog feed URL"
+                          name="url"
+                          ref={feedUrlRef}
+                          value={feedUrl}
+                          onBlur={handleBlur}
+                          onChange={handleChange}
+                          type="url"
+                          validators={['required', 'isUrl']}
+                          errorMessages={"Please enter the blog's feed URL."}
+                        />
+                      </Grid>
+                      <Grid item>
+                        <HelpPopoverButton />
+                      </Grid>
+                    </Grid>
+                    <Grid container spacing={2}>
+                      <Grid item>
+                        <IconButton classes={{ root: classes.button }} type="submit">
+                          <Add />
+                        </IconButton>
+                        <Typography color={submitStatus.isError ? 'error' : 'textPrimary'}>
+                          {submitStatus.message}
+                        </Typography>
+                      </Grid>
                     </Grid>
                   </Grid>
                 </Grid>
-                <Grid item>
-                  <Grid container spacing={1} alignItems="flex-end">
-                    <Grid item>
-                      <RssFeed />
-                    </Grid>
-                    <Grid item>
-                      <TextField
-                        id="url"
-                        label="Blog feed URL"
-                        onBlur={(event) => handleUrlChange(event.target.value)}
-                      />
-                    </Grid>
-                    <Grid item>
-                      <IconButton color="primary" classes={{ root: classes.button }}>
-                        <HelpOutline />
-                      </IconButton>
-                    </Grid>
-                  </Grid>
-                  <Grid container spacing={2}>
-                    <Grid item>
-                      <IconButton classes={{ root: classes.button }} onClick={() => addFeed()}>
-                        <Add />
-                      </IconButton>
-                    </Grid>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Box>
-          </Card>
-        </Container>
+              </Box>
+            </Card>
+          </Container>
+        </ValidatorForm>
       </div>
     </PageBase>
   );

--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -45,8 +45,8 @@ export default function MyFeeds() {
         setUserInfo(user);
         setNewFeedAuthor(user.name);
       } catch (error) {
-        console.log('Error fetching user info, redirecting to login page', error);
-        window.location.href = `${telescopeUrl}/auth/login`;
+        console.log('Failed to fetch user information', error);
+        window.location.href = `${telescopeUrl}/404`;
       }
     })();
 
@@ -124,7 +124,7 @@ export default function MyFeeds() {
     ref.current.validate(event.target.value, true);
   }
 
-  return (
+  return userInfo.id ? (
     <PageBase title="My Feeds">
       <div className={classes.margin}>
         <ValidatorForm onSubmit={addFeed}>
@@ -199,5 +199,7 @@ export default function MyFeeds() {
         </ValidatorForm>
       </div>
     </PageBase>
+  ) : (
+    <></>
   );
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #746
Fixes #760
Fixes #946

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Fixes #746 by finalizing the implementation of buttons on the My Feeds page:
- Clicking on the `?` button of the My Feeds page now opens a [popover](https://material-ui.com/api/popover/) containing a helpful message.
   - Uses [`material-ui-popup-state`](https://www.npmjs.com/package/material-ui-popup-state) (simplifies popover state management)
- Introduces form handling/validation via [`react-material-ui-form-validator`](https://www.npmjs.com/package/react-material-ui-form-validator).
   - (One of the custom-defined validation rules uses the `valid-url` module, which was previously added to Telescope for use in our backend.)
- Calling `addFeed()` now causes a status message to be rendered to the page, indicating whether its fetch request to add a feed succeeded or failed.
- When the page is loaded, each of the current user's owned feeds are fetched and rendered to the page within separate (disabled) text boxes.

Fixes #760 by preventing access to the page by users who are not logged in.
- See: https://github.com/Seneca-CDOT/telescope/issues/760#issuecomment-610695732

Fixes #946 by adding feed deletion buttons alongside each existing feed.
   - **_Update: these now send a `DELETE /feeds/:id` request when clicked._**

_How to review:_
1. Run `docker-compose up` (ensure that `API_URL=http://localhost:3000` in `.env`)
1. Run `npm run clean; npm run build` to build the Gatsby frontend
1. Log into Telescope (http://localhost:3000/auth/login, user1/user1pass)
1. Navigate to the My Feeds page (http://localhost:3000/myfeeds)
1. Fill out the two form controls and click the '+' button to add a new feed. Doing so should cause the new feed to (after a few seconds) appear as a new set of form controls.
1. Clicking on the '?' button should pop up an informative message to assist with the previous step.
1. Wait several seconds after the page refreshes: the new feed should appear within an additional set of (disabled) form controls.
1. Clicking on the 'delete' icon (next to the set of disabled controls) should spawn a dialog window confirming the action. Confirming this dialog will send a `DELETE /feeds/:id` request (which won't result in anything happening until the corresponding backend functionality is merged and this PR is rebased over it).

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
