### PR TITLE
adds: Docker for WSL 2 / Windows 10 Pro and Front-end Caching Optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN cd /telescope/tools/autodeployment && npm install --no-package-lock --ignore
 # Context: Front-end Builder
 FROM dependencies as builder
 
-COPY . .
+COPY ./src/frontend ./src/frontend
+COPY ./.git ./.git
 
 RUN npm run build
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -112,14 +112,14 @@ _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.
 
-#### Windows 10 Home,Pro, Enterprise, or Education (Insiders / WSL 2 / Docker)
+#### Windows 10 Home, Pro, Enterprise, or Education (Insiders / WSL 2 / Docker)
 
 1. If your [Windows build number](https://www.windowscentral.com/how-check-your-windows-10-build) is below [18917](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install/), join the [insiders program](https://insider.windows.com/en-us/). Then, update your machine to a newer build through Automatic Updates.
 2. Once installed successfully, install [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install).
 3. Open a Windows PowerShell window for the next few commands.
 4. Leverage the command `wsl --set-default-version 2`, and install Ubuntu from the Windows Store.
 5. Use `wsl -l -v` to see your Ubuntu instance version, if it's still using WSL version 1, convert it to WSL 2 using `wsl --set-version Ubuntu 2`.
-6. Install any other Prerequisties listed on [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
+6. Install any other prerequisites listed on [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
 7. Download and install [Docker Desktop Edge Latest](https://download.docker.com/win/edge/Docker%20Desktop%20Installer.exe)
 8. Follow the instructions on the [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/) to configure the WSL based engine. Docker-compose is installed with the Docker desktop application.
 9. Follow the Docker commands `docker-compose up --build` listed below in greater detail to start hacking.

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -112,31 +112,17 @@ _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.
 
-#### Windows 10 Pro, Enterprise, or Education (Insiders / WSL 2 / Docker)
+#### Windows 10 Home,Pro, Enterprise, or Education (Insiders / WSL 2 / Docker)
 
-1. If your Windows build is below 1941, join the [insiders program](https://insider.windows.com/en-us/). Then, update your machine to a newer build through Automatic Updates.
+1. If your [Windows build number](https://www.windowscentral.com/how-check-your-windows-10-build) is below [18917](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install/), join the [insiders program](https://insider.windows.com/en-us/). Then, update your machine to a newer build through Automatic Updates.
 2. Once installed successfully, install [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install).
-3. Leverage the command `wsl --set-default-version 2`, and install Ubuntu from the Windows Store.
-4. Use `wsl -l -v` to see your Ubuntu instance version, if it's still using WSL version 1, convert it to WSL 2 using `wsl --set-version Ubuntu 2`.
-5. Install The Prerequisties listed on [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
-6. Download and install [Docker Desktop Edge Latest](https://download.docker.com/win/edge/Docker%20Desktop%20Installer.exe)
-7. Follow the instructions on the Docker Desktop WSL Preview to configure the WSL based engine. Docker-compose is installed with the Docker desktop application.
-8. Follow the Docker commands `docker-compose up --build` listed below in greater detail to start hacking.
-
-#### Windows 10 Home Edition and Windows Subsystem for Linux (WSL)
-
-Docker Desktop for Windows is not available on Home Edition, and you cannot run docker in WSL (Windows Subsystem for Linux). You can get the environment set up using **one** of these three methods:
-
-- Get [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) instead of Docker Desktop for Windows. Make sure that your system can do virtualization and enable virtualization.
-- Set up a virtual machine to run Linux Ubuntu
-  1. Make sure your system can do virtualization and enable it.
-  1. [Download VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-  1. [Follow this helpful youtube tutorial to create a virtual machine with Ubuntu](https://www.youtube.com/watch?v=ThsxqznrgCw&t=401s)
-  1. Use the Linux installation instructions [below](#linux-Ubuntu).
-- Update your home edition to Windows 10 Education Edition
-  1. Download Windows 10 Education Edition from the [Seneca Software Center](https://senecacollege.onthehub.com/WebStore/OfferingDetails.aspx?o=c0bd2c36-a530-e511-940e-b8ca3a5db7a1)
-  1. Update your OS using the installation instructions.
-  1. Use [Windows 10 Education Edition](#Windows-10-Pro,-Enterprise,-or-Education) set up instructions.
+3. Open a Windows PowerShell window for the next few commands.
+4. Leverage the command `wsl --set-default-version 2`, and install Ubuntu from the Windows Store.
+5. Use `wsl -l -v` to see your Ubuntu instance version, if it's still using WSL version 1, convert it to WSL 2 using `wsl --set-version Ubuntu 2`.
+6. Install any other Prerequisties listed on [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
+7. Download and install [Docker Desktop Edge Latest](https://download.docker.com/win/edge/Docker%20Desktop%20Installer.exe)
+8. Follow the instructions on the [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/) to configure the WSL based engine. Docker-compose is installed with the Docker desktop application.
+9. Follow the Docker commands `docker-compose up --build` listed below in greater detail to start hacking.
 
 ## After installing the prerequisites:
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -107,10 +107,21 @@ _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach
 1. Get [Docker for Desktop For Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
 1. Docker for Desktop comes with docker-compose installed.
 
-#### Windows 10 Pro, Enterprise, or Education
+#### Windows 10 Pro, Enterprise, or Education (Hyper-V)
 
 1. Get [Docker for Desktop For Windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 1. Docker for Desktop comes with docker-compose installed.
+
+#### Windows 10 Pro, Enterprise, or Education (Insiders / WSL 2 / Docker)
+
+1. If your Windows build is below 1941, join the [insiders program](https://insider.windows.com/en-us/). Then, update your machine to a newer build through Automatic Updates.
+2. Once installed successfully, install [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install).
+3. Leverage the command `wsl --set-default-version 2`, and install Ubuntu from the Windows Store.
+4. Use `wsl -l -v` to see your Ubuntu instance version, if it's still using WSL version 1, convert it to WSL 2 using `wsl --set-version Ubuntu 2`.
+5. Install The Prerequisties listed on [Docker Desktop WSL Preview](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
+6. Download and install [Docker Desktop Edge Latest](https://download.docker.com/win/edge/Docker%20Desktop%20Installer.exe)
+7. Follow the instructions on the Docker Desktop WSL Preview to configure the WSL based engine. Docker-compose is installed with the Docker desktop application.
+8. Follow the Docker commands `docker-compose up --build` listed below in greater detail to start hacking.
 
 #### Windows 10 Home Edition and Windows Subsystem for Linux (WSL)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #936 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [X] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

### Documentation Change
Having reinstalled Windows 10 Pro on the development system due to a crashed Linux build, I saw that getting Telescope running with the Unix-esque WSL engine had some semantic issues which W10 Pro could improve on. That being, using the edge (unstable) version of Docker desktop and the WSL-2 engine for container pass-thru, so that we don't need to install Docker in Ubuntu itself, or utilize Virtual-box.


### Dockerfile Bug-fix

I realized while trying to optimize the builds that we could cache the front-end builds for the back-end developers, meaning that if no git commit occurs or front-end code is changed, the build time is reduced from minutes to seconds in some cases. This bug was realized when I saw that we had removed some older dependencies which required tools and files which existed outside the front-end folder. With their removal, we can now only copy the front-end directory and .git directory, thus allowing for that build container to be cached.

First build based on my [system](raygervais.dev)

```bash
real    1m14.537s
user    0m0.713s
sys     0m0.170s
```

Next build with a back-end change, no change to front-end.

```bash
real    0m3.607s
user    0m0.601s
sys     0m0.219s
```

### Docker Images
```bash
REPOSITORY                                      TAG                 IMAGE ID            CREATED              SIZE
telescope_telescope                             latest              26f01a0dbd7e        About a minute ago   216MB
<none>                                          <none>              0a8b0a7fce40        About a minute ago   680MB
<none>                                          <none>              d580c0e57e0d        17 minutes ago       216MB
<none>                                          <none>              b22e4e371f47        17 minutes ago       680MB
redis                                           latest              4cdbec704e47        6 days ago           98.2MB
node                                            lts-alpine          f77abbe89ac1        13 days ago          88.1MB
docker.elastic.co/elasticsearch/elasticsearch   7.5.0               911f580307ae        4 months ago         766MB
kristophjunge/test-saml-idp                     latest              a85d01fab7df        2 years ago          457MB
```

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [X] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
