### PR TITLE
Add Gatsby dev server proxying (PROXY_GATSBY)

### DIFF
--- a/docs/gatsbyjs.md
+++ b/docs/gatsbyjs.md
@@ -35,9 +35,12 @@ and re-run the command above.
 
 ### 2. Frontend With Gatsby Dev Server and Local Backend with Docker
 
-In your `.env` file, set `API_URL=http://localhost:3000` to tell the frontend
-to connect to a backend API server running at `http://localhost:3000`. Now
-you need to run Redis (natively or via docker-compose, see [Environment Setup docs](environment-setup.md)), then start the node app natively:
+In your `.env` file, you need to make a few changes:
+
+1. set `API_URL=http://localhost:3000` to tell the frontend to connect to a backend API server running at `http://localhost:3000`.
+2. set `PROXY_GATSBY=1` so that our node server will proxy the frontend to the Gatsby development server
+
+Now you need to run Redis (natively or via docker-compose, see [Environment Setup docs](environment-setup.md)), then start the node app natively:
 
 ```
 docker-compose up redis
@@ -50,8 +53,7 @@ In a second terminal, start the Gatsby dev server:
 npm run develop
 ```
 
-This will run the Gatsby app with hot-reloading on `http://localhost:8000` and
-use `http://localhost:3000` as your backend api.
+Browse to `http://localhost:3000/`. The backend will proxy the Gatsby app with hot-reloading from `http://localhost:8000`.
 
 ### 3. Frontend With Gatsby Dev Server and Staging Server Backend
 

--- a/env.example
+++ b/env.example
@@ -14,6 +14,16 @@ PORT=3000
 #   API_URL=https://telescope.cdot.systems (our production server)
 API_URL=http://localhost:3000
 
+# PROXY_GATSBY=1 will allow proxying the Gatsby dev server (http://localhost:8000)
+# through our node server (http://localhost:3000). Useful for testing locally.
+# To run:
+#
+# 1. set PROXY_GATSBY=1 in the .env
+# 2. run the web server: `npm start`
+# 3. run the Gatsby dev server: `npm run develop`
+# 4. open http://localhost:3000/ and you'll get content from http://localhost:8000
+PROXY_GATSBY=
+
 # LOG_LEVEL is used to set the level of debugging for the logs.
 # info, error and debug are commonly used levels. See http://getpino.io/#/docs/api?id=level for more info on levels.
 # to completely disable all logs, use silent.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "graphql-iso-date": "3.6.1",
     "graphql-passport": "0.6.3",
     "helmet": "3.22.0",
+    "http-proxy-middleware": "1.0.3",
     "ioredis": "4.16.1",
     "ioredis-mock": "4.19.0",
     "jsdom": "16.2.2",


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #732

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Cindy wanted to be able to use the Gatsby hot-reload dev server with our backend.  I've added a proxy middleware that does this if you set `NODE_ENV=development` and `PROXY_GATSBY=1` in your `.env`.  It will only work on a development box.

This should save people hours when developing the frontend and needing to quickly test changes without a rebuild.

It also supports logging in, which is awesome.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
