### PR TITLE
Add elasticsearch delete for posts, update elastic mock

### DIFF
--- a/src/backend/utils/__mocks__/elastic.js
+++ b/src/backend/utils/__mocks__/elastic.js
@@ -1,3 +1,33 @@
-exports.indexPost = () => Promise.resolve();
+// Mock storage for our es data
+const db = {};
 
-exports.checkConnection = () => Promise.resolve();
+const indexPost = (text, postId) => {
+  db[postId] = text;
+  return Promise.resolve();
+};
+
+const deletePost = (postId) => {
+  delete db[postId];
+  return Promise.resolve();
+};
+
+// TODO
+const search = () =>
+  Promise.resolve({
+    results: 0,
+    values: [],
+  });
+
+const checkConnection = () => Promise.resolve();
+
+const waitOnReady = () => Promise.resolve();
+
+module.exports = {
+  // Expose the internal db for testing
+  db,
+  indexPost,
+  deletePost,
+  checkConnection,
+  search,
+  waitOnReady,
+};

--- a/src/backend/utils/elastic.js
+++ b/src/backend/utils/elastic.js
@@ -32,6 +32,22 @@ const indexPost = async (text, postId) => {
 };
 
 /**
+ * Deletes a previously indexed post by its id
+ * @param postId same id used to store on redis the post object where the text is from
+ */
+const deletePost = async (postId) => {
+  try {
+    await esClient.delete({
+      index,
+      type,
+      id: postId,
+    });
+  } catch (error) {
+    logger.error({ error }, `There was an error deleting the post with id ${postId}`);
+  }
+};
+
+/**
  * Searches text in elasticsearch
  * @param textToSearch
  * @return all the results matching the passed text
@@ -110,6 +126,7 @@ const waitOnReady = async () => {
 
 module.exports = {
   indexPost,
+  deletePost,
   checkConnection,
   search,
   waitOnReady,


### PR DESCRIPTION
## Issue This PR Addresses

Part of #908, #919 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This adds a `deletePost()` method to our elastic client library.  It allows us to remove a post from the index.

One thing I'm not sure about is whether or not to refresh the index as part of doing this.  See https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#_delete and  https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docs-refresh.html:

> `refresh`:   'true' | 'false' | 'wait_for' - If true then refresh the affected shards to make this operation visible to search, if wait_for then wait for a refresh to make this operation visible to search, if false (the default) then do nothing with refreshes.

I've also updated the elastic mock to have more methods.  I haven't implemented a proper mock for `search()`, but we could make it work.
