### PR TITLE
Update test authentication to return user object with id

### DIFF
--- a/src/backend/web/__mocks__/authentication.js
+++ b/src/backend/web/__mocks__/authentication.js
@@ -21,6 +21,7 @@ function init(name, email, isAdmin = false) {
     // Log out
     loggedInUser = null;
   }
+  return loggedInUser;
 }
 
 function samlMetadata() {

--- a/test/lib/authentication.js
+++ b/test/lib/authentication.js
@@ -8,12 +8,12 @@ const defaultEmail = 'user1@example.com';
 
 // Login as a regular user
 module.exports.login = function (name, email, isAdmin = false) {
-  init(name || defaultName, email || defaultEmail, isAdmin);
+  return init(name || defaultName, email || defaultEmail, isAdmin);
 };
 
 // Login as an Admin
 module.exports.loginAdmin = function (name, email) {
-  module.exports.login(name, email, true);
+  return module.exports.login(name, email, true);
 };
 
 // Logout


### PR DESCRIPTION
For #955 we need to be able to get the `id` of the currently logged in user in our tests.  This is necessary for doing any redis/elastic stuff with the current user, since it's all based on `id`, and the `id` is a hash of their email.