### PR TITLE
Extend User type and add Admin type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,5 +103,11 @@ module.exports = {
     'react/jsx-uses-vars': 'error',
 
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+
+    /**
+     * Allow ES6 classes to override methods without using this
+     * https://eslint.org/docs/rules/class-methods-use-this
+     */
+    'class-methods-use-this': 'off',
   },
 };

--- a/src/backend/data/admin.js
+++ b/src/backend/data/admin.js
@@ -1,0 +1,21 @@
+const Feed = require('./feed');
+const User = require('./user');
+
+class Admin extends User {
+  constructor(name, email, id) {
+    super(name, email, id);
+    this.isAdmin = true;
+  }
+
+  // An admin owns all feeds
+  owns() {
+    return true;
+  }
+
+  // Return every feed for this user
+  feeds() {
+    return Feed.all();
+  }
+}
+
+module.exports = Admin;

--- a/src/backend/data/user.js
+++ b/src/backend/data/user.js
@@ -1,10 +1,11 @@
-const Feed = require('./feed.js');
+const Feed = require('./feed');
 
 class User {
   constructor(name, email, id) {
     this.name = name;
     this.email = email;
     this.id = id;
+    this.isAdmin = false;
   }
 
   toJSON() {


### PR DESCRIPTION
Builds on the `User` type, and adds an `Admin`.  I've connected it into our administration middleware, which runs after passport.js, but before the router.  Any user who is an admin will get automatically upgraded.