### PR TITLE
Fixes #976: moves new feed form to above existing feeds list

### DIFF
--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -156,7 +156,6 @@ export default function MyFeeds() {
                 <Typography variant="h3" component="h3" align="center">
                   My Feeds
                 </Typography>
-                <ExistingFeedList feedHash={feedHash} />
                 <Grid container spacing={5}>
                   <Grid item>
                     <Grid container spacing={1} alignItems="flex-end">
@@ -215,6 +214,7 @@ export default function MyFeeds() {
                     </Grid>
                   </Grid>
                 </Grid>
+                <ExistingFeedList feedHash={feedHash} />
               </Box>
             </Card>
           </Container>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #976

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

From #976:
> it would be nice if the component for adding a new feed was always at the top vs. the bottom. To get mine, I'd have to scroll all the way to the end of the existing feeds:
> 
> What if we move that to the top, and maybe put a little bit of empty vertical space between it and the existing feed list?
> 
> Most users will only have 1 or 2 feeds, so this won't be an issue for everyone. Nevertheless, I think having the place that you add new ones always be at the top would be good.

This PR simply moves the existing feed list to after the new feed form controls, such that the new feed controls are always by the top of the component.

Further styling concerns related to this PR or #976 may be addressed via #945.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
