### PR TITLE
Refactor admin code, add more tests

### DIFF
--- a/src/backend/data/admin.js
+++ b/src/backend/data/admin.js
@@ -1,5 +1,9 @@
 const Feed = require('./feed');
 const User = require('./user');
+const hash = require('./hash');
+
+// Get space separated list of admin accounts from env
+const administrators = process.env.ADMINISTRATORS ? process.env.ADMINISTRATORS.split(' ') : [];
 
 class Admin extends User {
   constructor(name, email, id) {
@@ -15,6 +19,15 @@ class Admin extends User {
   // Return every feed for this user
   feeds() {
     return Feed.all();
+  }
+
+  /**
+   * We define an administrator as someone who is specified in the .env
+   * ADMINISTRATORS variable list. We support bare email addresses and hashed.
+   * See env.sample for more details.
+   */
+  static isAdmin(id) {
+    return administrators.some((admin) => id === admin || id === hash(admin));
   }
 }
 

--- a/src/backend/data/user.js
+++ b/src/backend/data/user.js
@@ -13,6 +13,7 @@ class User {
       name: this.name,
       email: this.email,
       id: this.id,
+      isAdmin: this.isAdmin,
     };
   }
 

--- a/src/backend/web/__mocks__/authentication.js
+++ b/src/backend/web/__mocks__/authentication.js
@@ -63,27 +63,31 @@ function checkUser(requireAdmin, redirect, req, res, next) {
   }
 }
 
-// We'll deal with admin via init(), just let this pass
-function administration() {
-  return function (req, res, next) {
-    next();
-  };
+/**
+ * If we're logged in, build and return the appropriate user type (User vs. Admin).
+ * If we're not logged in, return null.
+ */
+function createUser() {
+  if (!loggedInUser) {
+    return null;
+  }
+
+  if (loggedInUser.isAdmin) {
+    return new Admin(loggedInUser.name, loggedInUser.email, loggedInUser.id);
+  }
+  return new User(loggedInUser.name, loggedInUser.email, loggedInUser.id);
 }
 
 function protect(redirect) {
   return function (req, res, next) {
-    if (loggedInUser) {
-      req.user = new User(loggedInUser.name, loggedInUser.email, loggedInUser.id);
-    }
+    req.user = createUser();
     checkUser(false, redirect, req, res, next);
   };
 }
 
 function protectAdmin(redirect) {
   return function (req, res, next) {
-    if (loggedInUser) {
-      req.user = new Admin(loggedInUser.name, loggedInUser.email, loggedInUser.id);
-    }
+    req.user = createUser();
     checkUser(true, redirect, req, res, next);
   };
 }
@@ -91,5 +95,4 @@ function protectAdmin(redirect) {
 module.exports.init = init;
 module.exports.protect = protect;
 module.exports.protectAdmin = protectAdmin;
-module.exports.administration = administration;
 module.exports.samlMetadata = samlMetadata;

--- a/src/backend/web/app.js
+++ b/src/backend/web/app.js
@@ -41,7 +41,6 @@ app.use(
 authentication.init();
 app.use(passport.initialize());
 app.use(passport.session());
-app.use(authentication.administration());
 
 // Add the Apollo server to app and define the `/graphql` endpoint
 const server = new ApolloServer({

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -3,13 +3,13 @@ const express = require('express');
 const { UI } = require('bull-board');
 const fs = require('fs');
 
-const { protect, protectAdmin } = require('../authentication');
+const { protectAdmin } = require('../authentication');
 const { logger } = require('../../utils/logger');
 
 const router = express.Router();
 
-// Only authenticated users can use these routes
-router.use('/queues', protect(true), UI);
+// Only authenticated admins can use these routes
+router.use('/queues', protectAdmin(true), UI);
 
 // Only authenticated admin users can see this route
 router.get('/log', protectAdmin(true), (req, res) => {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -7,7 +7,53 @@ jest.mock('../src/backend/utils/elastic');
 // Mock the internal authentication strategy
 jest.mock('../src/backend/web/authentication');
 // Use our authentication test helper
-const { login, logout } = require('./lib/authentication');
+const { login, loginAdmin, logout } = require('./lib/authentication');
+
+describe('test GET /user/info endpoint', () => {
+  afterAll(() => logout());
+
+  it('should respond with a 403 status when not logged in', async () => {
+    logout();
+    const res = await request(app).get(`/user/info`);
+    expect(res.status).toEqual(403);
+  });
+
+  it('should respond with a 200 status and JSON Object for logged in user', async () => {
+    const user = login();
+
+    const res = await request(app).get(`/user/info`);
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body instanceof Object).toBe(true);
+
+    // Data should match our logged in user
+    expect(res.body.name).toEqual(user.name);
+    expect(res.body.email).toEqual(user.email);
+    expect(res.body.id).toEqual(user.id);
+
+    // We are not an admin, so that should be false
+    expect(res.body.isAdmin).toEqual(user.isAdmin);
+    expect(res.body.isAdmin).toBe(false);
+  });
+
+  it('should respond with a 200 status and JSON Object for logged in admin', async () => {
+    const user = loginAdmin();
+
+    const res = await request(app).get(`/user/info`);
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.body instanceof Object).toBe(true);
+
+    // Data should match our logged in user
+    expect(res.body.name).toEqual(user.name);
+    expect(res.body.email).toEqual(user.email);
+    expect(res.body.id).toEqual(user.id);
+
+    // We are an admin, so that should be true
+    expect(res.body.isAdmin).toEqual(user.isAdmin);
+    expect(res.body.isAdmin).toBe(true);
+  });
+});
 
 describe('test GET /user/feeds endpoint', () => {
   afterAll(() => logout());
@@ -24,6 +70,25 @@ describe('test GET /user/feeds endpoint', () => {
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
     expect(res.body instanceof Array).toBe(true);
+  });
+
+  it('should get all feeds when logged in as admin', async () => {
+    loginAdmin();
+
+    // Get feeds for admin user using /user/feeds
+    const res1 = await request(app).get(`/user/feeds`);
+    expect(res1.status).toEqual(200);
+    expect(res1.get('Content-type')).toContain('application/json');
+    expect(res1.body instanceof Array).toBe(true);
+
+    // Get all feeds using /feeds route
+    const res2 = await request(app).get(`/feeds`);
+    expect(res2.status).toEqual(200);
+    expect(res2.get('Content-type')).toContain('application/json');
+    expect(res2.body instanceof Array).toBe(true);
+
+    // Make sure the two sets of feed arrays match
+    expect(res2.body).toEqual(res1.body);
   });
 
   it('should respond with an updated array after a new user feed is added/removed', async () => {


### PR DESCRIPTION
We added a bunch of code for user vs. admin routes, and didn't completely finish it, or fully integrate it.  We also didn't do proper test coverage for the admin side.

This fixes that, specifically:

- removes the `administration` middleware, and puts it in `passport.deserialize()`
- moves the administration account check into `Admin.isAdmin()`
- updates our authentication mock to properly support both user and admin accounts
- fixes a bug with how we serialize a user to the session, adding the `.isAdmin` property
- makes the `/admin/*` routes all require an admin account
- adds test for admins deleting a feed owned by a regular user
- adds tests for `/user/info` for users and admins
- adds tests for `/user/feeds` to make sure admins get all feeds vs. only ones they own

Much of this is changes to our tests, so CI should tell you if it's working.