### PR TITLE
Add Telescope VSCode debug launch configuration + docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,9 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Program",
-      "program": "${workspaceFolder}/src/index.js",
+      "name": "Launch Telescope",
+      "program": "${workspaceFolder}/src/backend/index.js",
+      "envFile": "${workspaceRoot}/.env",
       "skipFiles": ["<node_internals>/**"]
     }
   ]

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -62,6 +62,13 @@ Then use `add-feed`
 
 `add-feed --name "Bender Bending Rodriguez" --url futurama.wordpress.com/feed`
 
+## Debugging
+
+The Telescope backend can be debugged using VSCode. See the [VSCode Debugging docs](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) and use the Launch Telescope configuration to start the server and debugger within VSCode.
+
+The Telescope frontend can be debugged in the browser using dev tools and the
+React Developer Tools [for Chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) and [for Firefox](https://addons.mozilla.org/en-CA/firefox/addon/react-devtools/).
+
 ## Squashing Commits
 
 Before creating your pull request you may want to squash all your commits down to one. Ideally this should be done before you rebase on the upstream master.


### PR DESCRIPTION
I updated our VSCode config so that we an debug Telescope from within VSCode.  This allows starting the server and attaching the VSCode debugging environment.

I wanted to add this so that people can debug things more easily from their editor, and without having to do anything difficult to get node debugging to work.

Here's an example of what it looks like.  I'm debugging the `/stats/year` route bug in #858, and I've clicked on "Run" in the VSCode debugger.  This started our backend, and then I set a breakpoint.  After that I hit the `/stats/year` route and it dropped me into the debugger, where I can step through code, inspect things, etc.

<img width="1231" alt="Screen Shot 2020-04-12 at 11 06 42 PM" src="https://user-images.githubusercontent.com/427398/79089034-915e9680-7d12-11ea-8531-89bc7db6fc28.png">
