### PR TITLE
Fixed eslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "pino": "6.2.0",
     "pino-pretty": "4.0.0",
     "sanitize-html": "1.23.0",
+    "set-interval-async": "1.0.32",
     "stoppable": "1.1.0",
     "valid-url": "1.0.9"
   },


### PR DESCRIPTION
## Issue This PR Addresses

Progress towards #990 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This removes the warnings related to elasticsearch 
```
/Users/humphd/repos/telescope/src/backend/utils/elastic.js
  116:10  warning  Prefer await to then()  promise/prefer-await-to-then
```
and wiki-feed-parser
```
/Users/humphd/repos/telescope/src/backend/utils/wiki-feed-parser.js
  59:10  warning  Prefer await to then()  promise/prefer-await-to-then
```

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
