### PR TITLE
Process Redis feeds in addition to Wiki feeds

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -76,9 +76,9 @@ function processFeeds(feeds) {
 async function processAllFeeds() {
   try {
     // Get an Array of Feed objects from the wiki feed list and Redis
-    const feeds = await Promise.all([...Feed.all(), ...getWikiFeeds()]);
+    const [all, wiki] = await Promise.all([Feed.all(), getWikiFeeds()]);
     // Process these feeds into the database and feed queue
-    await processFeeds(feeds);
+    await processFeeds([...all, ...wiki]);
   } catch (err) {
     logger.error({ err }, 'Error queuing feeds');
   }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -76,7 +76,7 @@ function processFeeds(feeds) {
 async function processAllFeeds() {
   try {
     // Get an Array of Feed objects from the wiki feed list and Redis
-    const feeds = Promise.all([...(await Feed.all()), ...(await getWikiFeeds())]);
+    const feeds = await Promise.all([...Feed.all(), ...getWikiFeeds()]);
     // Process these feeds into the database and feed queue
     await processFeeds(feeds);
   } catch (err) {

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -70,24 +70,24 @@ function processFeeds(feeds) {
 }
 
 /**
- * Download and parse feed author/URL info from the wiki, and process
+ * Download and parse feed author/URL info from the wiki and redis, and process
  * these into Feed Objects to be added to the database and feed queue.
  */
-async function processWikiFeeds() {
+async function processAllFeeds() {
   try {
-    // Get an Array of Feed objects from the wiki feed list
-    const feeds = await getWikiFeeds();
+    // Get an Array of Feed objects from the wiki feed list and Redis
+    const feeds = Promise.all([...(await Feed.all()), ...(await getWikiFeeds())]);
     // Process these feeds into the database and feed queue
     await processFeeds(feeds);
   } catch (err) {
-    logger.error({ err }, 'Error queuing wiki feeds');
+    logger.error({ err }, 'Error queuing feeds');
   }
 }
 
 function loadFeedsIntoQueue() {
   logger.info('Loading all feeds into feed queue for processing');
-  processWikiFeeds().catch((error) => {
-    logger.error({ error }, 'Unable to enqueue wiki feeds');
+  processAllFeeds().catch((error) => {
+    logger.error({ error }, 'Unable to enqueue feeds');
   });
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Addresses #920

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Issue #920 lists two end-goals for our feed processing:
> 1. We need to keep downloading the wiki feed list regularly, so we can get updates
> 1. We need to stop using the wiki feeds as our feed list in the feed queue, and instead need to get our feeds from Redis

This draft attempts the first step towards the completion of the second stated end-goal: enqueuing Redis feeds _in addition to_ Wiki feeds for processing.

Once I can be sure that we have established a good starting point, here, I will seek guidance on any next steps involved.

I did note that the Wiki feed list is processed and saved to Redis _as part of_ the enqueuing process:
```
loadFeedsIntoQueue()
  → processWikiFeeds()
    → processFeeds()
      → updateFeed()
        → Feed.create()
          → Feed.save()
```

Since our end-goal is to: `(a)` fetch the Wiki feeds, `(b)` save them to Redis, but _not_ `(c)` enqueue them for processing, I am not sure how necessary it will be to rewrite any of the above functions (such that coupling is reduced between the functionality of `(a)`/`(b)` and that of `(c)`)...

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
