### PR TITLE
Fix eslint issues in index.js

### DIFF
--- a/src/frontend/src/pages/index.js
+++ b/src/frontend/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { CircularProgress, Button, Grid } from '@material-ui/core';
 import parse from 'parse-link-header';
@@ -88,7 +88,7 @@ export default function IndexPage() {
     setNumPages(numPages + 1);
   }
 
-  async function getPostsCount() {
+  const getPostsCount = useCallback(async () => {
     try {
       const res = await fetch(`${telescopeUrl}/posts`, { method: 'HEAD' });
       if (!res.ok) {
@@ -99,43 +99,37 @@ export default function IndexPage() {
       console.log(error);
     }
     return null;
-  }
+  }, [telescopeUrl]);
 
-  function callback() {
-    getPostsCount()
-      .then(setCurrentNumPosts)
-      .catch((error) => console.log(error));
-  }
+  const callback = useCallback(async () => {
+    setCurrentNumPosts(await getPostsCount());
+  }, [getPostsCount]);
 
   useEffect(() => {
     savedCallback.current = callback;
   });
 
-  // Get the current + initial posts count when page loads
+  // Get the initial posts count when currentNumPosts value changes (re-render)
   useEffect(() => {
     async function setPostsInfo() {
       try {
-        await Promise.all([
-          setInitNumPosts(await getPostsCount()),
-          setCurrentNumPosts(await getPostsCount()),
-        ]);
+        setInitNumPosts(await getPostsCount());
       } catch (error) {
         console.log({ error });
       }
     }
     setPostsInfo();
-  }, []);
+  }, [getPostsCount, currentNumPosts]);
 
   useEffect(() => {
     function getCurrentNumPosts() {
       savedCallback.current();
     }
-
     savedCallback.current = callback;
     // Polls every 5 minutes
     const interval = setInterval(getCurrentNumPosts, 5 * 60 * 1000);
     return () => clearInterval(interval);
-  }, [currentNumPosts]);
+  }, [callback]);
 
   function GenerateLoadButtonContent() {
     if (endOfPosts) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Part of #990 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Refactored our async functions existing outside of `useEffect()` hooks to use `useCallback()`. The only es lint warnings remaining are on line 84 and from my testing, adding the dependencies `post` or `nextPageLink` as recommended will cause the issue in #1018 


I kind of hate the front-end and its dependencies...
From what I understand:
1. `useEffect` line 108 is called every re-render

2. `useEffect` on line 113 is caused by either `getPostsCount`(async function) or change to `currentNumPosts`(state). This sets the current and initial # of posts to whatever the current # of posts in redis is

3. `useEffect` on line 127 should be caused by the callback on line 108? This causes it to start the timer to get the updated # of posts every 5 mins and set currentNumPosts to the new #. Once this is set, it should cause the `useEffect` from 2.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
