### PR TITLE
Add /status to deploy server, fix callback missing bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,14 @@
       "program": "${workspaceFolder}/src/backend/index.js",
       "envFile": "${workspaceRoot}/.env",
       "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Auto Deployment",
+      "program": "${workspaceFolder}/tools/autodeployment/server.js",
+      "envFile": "${workspaceRoot}/tools/autodeployment/.env",
+      "skipFiles": ["<node_internals>/**"]
     }
   ]
 }

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -45,37 +45,26 @@ router.get('/log', protectAdmin(true), (req, res) => {
  * is for piping build logs in real-time.  Get the port for the deploy server
  * from the tools/autodeployment/.env file.
  */
-let DEPLOY_PORT;
-try {
-  const deployEnv = dotenv.config({
-    path: path.join(__dirname, '../../../../', 'tools/autodeployment/.env'),
-  });
-  DEPLOY_PORT = parseInt(deployEnv.parsed.DEPLOY_PORT, 10);
-} catch (err) {
-  logger.debug('No DEPLOY_PORT found, skipping /admin/build/status and /admin/build/log routes');
-}
-
-if (DEPLOY_PORT) {
-  router.use(
-    '/build/status',
-    protectAdmin(true),
-    createProxyMiddleware({
-      target: `http://localhost:${DEPLOY_PORT}`,
-      pathRewrite: {
-        '^/admin/build/status': '/status',
-      },
-    })
-  );
-  router.use(
-    '/build/log',
-    protectAdmin(true),
-    createProxyMiddleware({
-      target: `http://localhost:${DEPLOY_PORT}`,
-      pathRewrite: {
-        '^/admin/build/log': '/log',
-      },
-    })
-  );
-}
+const DEPLOY_PORT = 4000; // we assume this, see tools/autodeployment/.env
+router.use(
+  '/build/status',
+  protectAdmin(true),
+  createProxyMiddleware({
+    target: `http://localhost:${DEPLOY_PORT}`,
+    pathRewrite: {
+      '^/admin/build/status': '/status',
+    },
+  })
+);
+router.use(
+  '/build/log',
+  protectAdmin(true),
+  createProxyMiddleware({
+    target: `http://localhost:${DEPLOY_PORT}`,
+    pathRewrite: {
+      '^/admin/build/log': '/log',
+    },
+  })
+);
 
 module.exports = router;

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -1,7 +1,10 @@
 require('../../lib/config');
 const express = require('express');
 const { UI } = require('bull-board');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const path = require('path');
 const fs = require('fs');
+const dotenv = require('dotenv');
 
 const { protectAdmin } = require('../authentication');
 const { logger } = require('../../utils/logger');
@@ -35,5 +38,44 @@ router.get('/log', protectAdmin(true), (req, res) => {
     res.send(error.message);
   }
 });
+
+/**
+ * Proxy a few useful requests from the auto deployment server here.  The first
+ * is for getting status info about the state of the deploy server.  The second
+ * is for piping build logs in real-time.  Get the port for the deploy server
+ * from the tools/autodeployment/.env file.
+ */
+let DEPLOY_PORT;
+try {
+  const deployEnv = dotenv.config({
+    path: path.join(__dirname, '../../../../', 'tools/autodeployment/.env'),
+  });
+  DEPLOY_PORT = parseInt(deployEnv.parsed.DEPLOY_PORT, 10);
+} catch (err) {
+  logger.debug('No DEPLOY_PORT found, skipping /admin/build/status and /admin/build/log routes');
+}
+
+if (DEPLOY_PORT) {
+  router.use(
+    '/build/status',
+    protectAdmin(true),
+    createProxyMiddleware({
+      target: `http://localhost:${DEPLOY_PORT}`,
+      pathRewrite: {
+        '^/admin/build/status': '/status',
+      },
+    })
+  );
+  router.use(
+    '/build/log',
+    protectAdmin(true),
+    createProxyMiddleware({
+      target: `http://localhost:${DEPLOY_PORT}`,
+      pathRewrite: {
+        '^/admin/build/log': '/log',
+      },
+    })
+  );
+}
 
 module.exports = router;

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -2,9 +2,7 @@ require('../../lib/config');
 const express = require('express');
 const { UI } = require('bull-board');
 const { createProxyMiddleware } = require('http-proxy-middleware');
-const path = require('path');
 const fs = require('fs');
-const dotenv = require('dotenv');
 
 const { protectAdmin } = require('../authentication');
 const { logger } = require('../../utils/logger');

--- a/tools/autodeployment/README.md
+++ b/tools/autodeployment/README.md
@@ -1,0 +1,26 @@
+# Auto Deployment
+
+Telescope uses a separate HTTP server to listen for
+[GitHub Webhook](https://developer.github.com/webhooks/)Events. The server's
+configuration is stored in an `.env` file, which must be created based on
+`env.example`.
+
+On our staging (https://dev.telescope.cdot.systems) and production
+(https://telescope.cdot.systems) machines we use these webhooks to trigger a new
+build and deploy. For staging, this happens on every push to the `master`
+branch. On production, we listen for GitHub releases (e.g., when a new release
+is created on GitHub).
+
+There are also a few other routes you can use to get information about the
+auto deployment server:
+
+- `GET :4000/status`: returns JSON data about the current status of the build.
+- `GET :4000/log`: returns a real-time stream of current build log output, if any.
+
+On staging you can go to http://dev.telescope.cdot.systems/status and
+http://dev.telescope.cdot.systems/log, and on production you can use
+http://telescope.cdot.systems/status and http://telescope.cdot.systems/log.
+
+```
+$ curl http://dev.telescope.cdot.systems/log
+```

--- a/tools/autodeployment/env.example
+++ b/tools/autodeployment/env.example
@@ -1,5 +1,6 @@
-# Port on which the server will be listening
-DEPLOY_PORT=
+# Port on which the server will be listening.
+# If you change this, update DEPLOY_PORT in src/backend/web/routes/admin.js as well
+DEPLOY_PORT=4000
 
 # Secret to be shared between GitHub and the server
 SECRET=

--- a/tools/autodeployment/info.js
+++ b/tools/autodeployment/info.js
@@ -1,0 +1,48 @@
+const formatDistance = require('date-fns/formatDistance');
+
+// One of 'idle' or 'building'
+let currentStatus = 'idle';
+// When the last build completed
+let recentBuildDate = null;
+// Whether last build worked or failed
+let recentBuildResult = null;
+// Date when the last build began, null if not building.
+let currentBuildStartedAt = null;
+
+function handleStatus(req, res) {
+  const info = {
+    status: currentStatus,
+  };
+
+  if (recentBuildDate) {
+    info.recentBuildDate = recentBuildDate;
+  }
+
+  if (recentBuildResult) {
+    info.recentBuildResult = recentBuildResult;
+  }
+
+  // If a build is in progress, and we have a start time, format a duration
+  if (currentBuildStartedAt) {
+    info.started = currentBuildStartedAt;
+    info.duration = formatDistance(new Date(), currentBuildStartedAt);
+  }
+
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.write(JSON.stringify(info));
+  res.end();
+}
+
+module.exports.buildStart = function (type) {
+  currentBuildStartedAt = new Date();
+  currentStatus = `building ${type}`;
+};
+
+module.exports.buildStop = function (code) {
+  currentBuildStartedAt = null;
+  recentBuildResult = code === 0 ? 'success' : 'failure';
+  recentBuildDate = new Date();
+  currentStatus = 'idle';
+};
+
+module.exports.handleStatus = handleStatus;

--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -4,6 +4,7 @@
   "description": "A tool for automatic deployment",
   "main": "server.js",
   "dependencies": {
+    "date-fns": "^2.12.0",
     "dotenv": "^8.2.0",
     "github-webhook-handler": "^1.0.0",
     "pm2": "^4.2.3",

--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -7,6 +7,7 @@
     "date-fns": "^2.12.0",
     "dotenv": "^8.2.0",
     "github-webhook-handler": "^1.0.0",
+    "merge-stream": "^2.0.0",
     "pm2": "^4.2.3",
     "shelljs": "^0.8.3"
   },

--- a/tools/autodeployment/server.js
+++ b/tools/autodeployment/server.js
@@ -68,10 +68,10 @@ if (!(DEPLOY_TYPE === 'staging' || DEPLOY_TYPE === 'production')) {
 
 /**
  * Create a handler for the particular GitHub push event and build type
- * @param {String} gitHubEvent - the GitHub Push Event name
  * @param {String} buildType - one of `production` or `staging`
+ * @param {String} gitHubEvent - the GitHub Push Event name
  */
-function handleEventType(gitHubEvent, buildType) {
+function handleEventType(buildType, gitHubEvent) {
   if (DEPLOY_TYPE !== buildType) {
     return;
   }


### PR DESCRIPTION
This updates the deployment server to do a few things:

1. adds a `/status` endpoint, so we can get info on what's happening (idle or building), what the duration of the build is, what the result of the last build was, etc.
1. fixes a bug where we would crash if someone tried to hit an endpoint other than the ones we expect (we needed a callback)
1. added logging for stdout and stderr