### PR TITLE
Fixed snackbar appearing on page load

### DIFF
--- a/src/frontend/src/pages/index.js
+++ b/src/frontend/src/pages/index.js
@@ -43,6 +43,7 @@ export default function IndexPage() {
   const [initNumPosts, setInitNumPosts] = useState(0);
   const [currentNumPosts, setCurrentNumPosts] = useState(0);
   const [endOfPosts, setEndOfPosts] = useState(true);
+  const [alert, setAlert] = useState(false);
   const { telescopeUrl } = useSiteMetaData();
   const savedCallback = useRef();
   const snackbarMessage = 'There is new content available!';
@@ -131,6 +132,16 @@ export default function IndexPage() {
     return () => clearInterval(interval);
   }, [callback]);
 
+  useEffect(() => {
+    // Prevents alert from appearing upon page loading.
+    // Also checks whether there are new posts available
+    if (!loading && currentNumPosts !== initNumPosts && currentNumPosts !== 0) {
+      setAlert(true);
+    } else {
+      setAlert(false);
+    }
+  }, [currentNumPosts, initNumPosts, loading]);
+
   function GenerateLoadButtonContent() {
     if (endOfPosts) {
       return 'No more posts.  Your turn! Add your feed...';
@@ -162,9 +173,7 @@ export default function IndexPage() {
           </Grid>
         </Grid>
 
-        {currentNumPosts !== initNumPosts ? (
-          <CustomizedSnackBar posts={currentNumPosts} message={snackbarMessage} />
-        ) : null}
+        {alert ? <CustomizedSnackBar posts={currentNumPosts} message={snackbarMessage} /> : null}
       </main>
     </PageBase>
   );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1027 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Regression test:
1. Set line 131 to a more frequent number unless you want to check every 5 mins for the change. To make sure fixes didn't break current functionality
2. Flush redis db (`redis-cli flushall`)
3. Make sure you're using localhost:3000 for the backend
4. `npm run develop` + `npm run start`
5. Alert should appear on interval set as redis is being populated

To test bug fix:
1. run `npm develop`
2. go to `localhost:8000`, the alert shouldn't appear at the start anymore before posts load + unless there are actual new posts

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
