### PR TITLE
fixes: shows the loading spinner first instead of "no more posts"

### DIFF
--- a/src/frontend/src/pages/index.js
+++ b/src/frontend/src/pages/index.js
@@ -42,7 +42,7 @@ export default function IndexPage() {
   const [posts, setPosts] = useState([]);
   const [initNumPosts, setInitNumPosts] = useState(0);
   const [currentNumPosts, setCurrentNumPosts] = useState(0);
-  const [endOfPosts, setEndOfPosts] = useState(true);
+  const [endOfPosts, setEndOfPosts] = useState(false);
   const [alert, setAlert] = useState(false);
   const { telescopeUrl } = useSiteMetaData();
   const savedCallback = useRef();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
#fixes #999 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

Changes the intitial state of `endOfPosts`, which would display `'No more posts.  Your turn! Add your feed...'` if defaulted to true. Instead we default to false and allow the spinner to take priority in the render view.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
