### PR TITLE
Add UI for Admin to trigger reparsing all posts from feeds

### DIFF
--- a/src/backend/data/feed.js
+++ b/src/backend/data/feed.js
@@ -162,6 +162,21 @@ class Feed {
     const ids = await getFeeds();
     return Promise.all(ids.map(Feed.byId));
   }
+
+  /**
+   * Sets all stored feeds' lastModified + etag field to null. Used for production
+   * Returns a Promise
+   */
+  static async clearCache() {
+    const allFeeds = await this.all();
+    await Promise.all(
+      allFeeds.map((feed) => {
+        feed.etag = null;
+        feed.lastModified = null;
+        return feed.save();
+      })
+    );
+  }
 }
 
 module.exports = Feed;

--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -3,6 +3,7 @@ const Feed = require('../../data/feed');
 const { getFeeds } = require('../../utils/storage');
 const { logger } = require('../../utils/logger');
 const { protect } = require('../authentication');
+const { protectAdmin } = require('../authentication');
 
 const feeds = express.Router();
 
@@ -70,6 +71,18 @@ feeds.post('/', protect(), async (req, res) => {
     logger.error({ error }, 'Unable to add feed to Redis');
     return res.status(503).json({
       message: 'Unable to add to Feed',
+    });
+  }
+});
+
+feeds.delete('/cache', protectAdmin(true), async (req, res) => {
+  try {
+    await Feed.clearCache();
+    return res.status(204).send();
+  } catch (error) {
+    logger.error({ error }, 'Unable to reset Feed data in Redis');
+    return res.status(503).json({
+      message: 'Unable to reset data for Feeds',
     });
   }
 });

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -19,6 +19,24 @@ describe('Post data class tests', () => {
     lastModified: null,
   };
 
+  const data2 = {
+    author: 'Post Author2',
+    url: 'https://user2.feed.com/feed.rss',
+    user: 'user2',
+    link: 'https://user2.feed.com/',
+    etag: null,
+    lastModified: null,
+  };
+
+  const data3 = {
+    author: 'Post Author3',
+    url: 'https://user3.feed.com/feed.rss',
+    user: 'user3',
+    link: 'https://user3.feed.com/',
+    etag: null,
+    lastModified: null,
+  };
+
   const createFeed = () => new Feed(data.author, data.url, data.user, data.link, null, null);
 
   const articleData1 = {
@@ -171,6 +189,35 @@ describe('Post data class tests', () => {
       expect(removedPosts[0]).toBe(null);
       expect(esSearchDelete.values).toStrictEqual([]);
       expect(esSearchDelete.results).toBe(0);
+    });
+
+    test('clearCache should set lastModified and etag to null', async () => {
+      let feed = new Feed(data.author, data.url, data.user, data.link, 'etag', 'lastModified');
+      let feed2 = new Feed(data2.author, data2.url, data2.user, data2.link, 'etag', 'lastModified');
+      let feed3 = new Feed(data3.author, data3.url, data3.user, data3.link, 'etag', 'lastModified');
+
+      feed = await Feed.byId(await Feed.create(feed));
+      feed2 = await Feed.byId(await Feed.create(feed2));
+      feed3 = await Feed.byId(await Feed.create(feed3));
+      // Basic check
+      expect(feed.etag).toBe('etag');
+      expect(feed.lastModified).toBe('lastModified');
+      expect(feed2.etag).toBe('etag');
+      expect(feed2.lastModified).toBe('lastModified');
+      expect(feed3.etag).toBe('etag');
+      expect(feed3.lastModified).toBe('lastModified');
+
+      // Test clearCache()
+      await Feed.clearCache();
+      const clearedFeed = await Feed.byId(feed.id);
+      const clearedFeed2 = await Feed.byId(feed2.id);
+      const clearedFeed3 = await Feed.byId(feed3.id);
+      expect(clearedFeed.etag).toBe(null);
+      expect(clearedFeed.lastModified).toBe(null);
+      expect(clearedFeed2.etag).toBe(null);
+      expect(clearedFeed2.lastModified).toBe(null);
+      expect(clearedFeed3.etag).toBe(null);
+      expect(clearedFeed3.lastModified).toBe(null);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1030 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Allows admin users to "clear cache" for Redis through a put request at the route `feeds/cache`. This sets the `lastModified` + `etag` field to null.

Added a new PUT route - `feeds/cache/`
Added new function in `feed.js` - `clearCache()`
Added new tests to `feed.test.js`
Added new tests to `feeds.test.js`

Testing instructions:
**Requires local backend!**
1. Find an admin account
2. Use `redis-cli smembers t:feeds` to get a list of feedId and pick one of them
3. Use `redis-cli hgetall t:feed:(feedId)` to get info of all the fields for the feed, make sure the `etag` and the `lastModified` field is not null / populated
4. While logged in as admin, hit the route `telescopeUrl/feeds/cache`, this should clear the `etag` + `lastModified` fields in Redis and set it to `null`
5. Use `redis-cli hgetall t:feed:(feedId)` again(with the same Id as before), the `etag` and the `lastModified` field should be `null` this time

Or just run `npm test feed.test.js` + `npm test feeds.test.js` and trust my tests =D
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
