### PR TITLE
Start moving syntax highlighting to the backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "graphql-iso-date": "3.6.1",
     "graphql-passport": "0.6.3",
     "helmet": "3.22.0",
+    "highlight.js": "9.18.1",
     "http-proxy-middleware": "1.0.3",
     "ioredis": "4.16.2",
     "ioredis-mock": "4.19.0",

--- a/src/backend/data/post.js
+++ b/src/backend/data/post.js
@@ -1,6 +1,7 @@
 const { getPost, addPost } = require('../utils/storage');
 const { logger } = require('../utils/logger');
 const sanitizeHTML = require('../utils/sanitize-html');
+const syntaxHighlight = require('../utils/syntax-highlighter');
 const textParser = require('../utils/text-parser');
 const Feed = require('./feed');
 const hash = require('./hash');
@@ -124,6 +125,8 @@ class Post {
       // The article.description is frequently the full HTML article content.
       // Sanitize it of any scripts or other dangerous attributes/elements
       sanitizedHTML = sanitizeHTML(article.description);
+      // We also add syntax highlighting for <pre>...</pre> blocks
+      sanitizedHTML = syntaxHighlight(sanitizedHTML);
     } catch (error) {
       logger.error({ error }, 'Unable to sanitize and parse HTML for feed');
       throw error;

--- a/src/backend/utils/syntax-highlighter.js
+++ b/src/backend/utils/syntax-highlighter.js
@@ -1,0 +1,64 @@
+const hljs = require('highlight.js/lib/highlight');
+const jsdom = require('jsdom');
+const { logger } = require('./logger');
+
+const { JSDOM } = jsdom;
+
+// Tweak the language list here, see https://highlightjs.org/usage/
+hljs.registerLanguage('cpp', require('highlight.js/lib/languages/cpp'));
+hljs.registerLanguage('sql', require('highlight.js/lib/languages/sql'));
+hljs.registerLanguage('powershell', require('highlight.js/lib/languages/powershell'));
+hljs.registerLanguage('cs', require('highlight.js/lib/languages/cs'));
+hljs.registerLanguage('go', require('highlight.js/lib/languages/go'));
+hljs.registerLanguage('css', require('highlight.js/lib/languages/css'));
+hljs.registerLanguage('makefile', require('highlight.js/lib/languages/makefile'));
+hljs.registerLanguage('markdown', require('highlight.js/lib/languages/markdown'));
+hljs.registerLanguage('swift', require('highlight.js/lib/languages/swift'));
+hljs.registerLanguage('armasm', require('highlight.js/lib/languages/armasm'));
+hljs.registerLanguage('diff', require('highlight.js/lib/languages/diff'));
+hljs.registerLanguage('python', require('highlight.js/lib/languages/python'));
+hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'));
+hljs.registerLanguage('http', require('highlight.js/lib/languages/http'));
+hljs.registerLanguage('typescript', require('highlight.js/lib/languages/typescript'));
+hljs.registerLanguage('ini', require('highlight.js/lib/languages/ini'));
+hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'));
+hljs.registerLanguage('nginx', require('highlight.js/lib/languages/nginx'));
+hljs.registerLanguage('java', require('highlight.js/lib/languages/java'));
+hljs.registerLanguage('javascript', require('highlight.js/lib/languages/javascript'));
+hljs.registerLanguage('rust', require('highlight.js/lib/languages/rust'));
+hljs.registerLanguage('json', require('highlight.js/lib/languages/json'));
+hljs.registerLanguage('x86asm', require('highlight.js/lib/languages/x86asm'));
+hljs.registerLanguage('kotlin', require('highlight.js/lib/languages/kotlin'));
+hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'));
+hljs.registerLanguage('shell', require('highlight.js/lib/languages/shell'));
+hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'));
+hljs.registerLanguage('php', require('highlight.js/lib/languages/php'));
+hljs.registerLanguage('dos', require('highlight.js/lib/languages/dos'));
+
+/**
+ * Given a String of HTML, find all <pre>...</pre> code blocks
+ * and apply syntax highlight markup.
+ */
+module.exports = function (html) {
+  try {
+    const dom = new JSDOM(html);
+    const doc = dom.window.document;
+
+    doc.querySelectorAll('pre code').forEach((code) => {
+      const { value, language } = hljs.highlightAuto(code.innerHTML);
+
+      // Decorate the <pre> with class names for highlighting this language
+      const pre = code.parentNode;
+      pre.classList.add('hljs', language);
+
+      // Replace the contents with newly marked up syntax highligting
+      code.innerHTML = value;
+    });
+
+    return doc.body.innerHTML;
+  } catch (err) {
+    logger.error({ err, html }, 'syntax highlight error');
+    // Return the html untouched.
+    return html;
+  }
+};

--- a/src/backend/utils/syntax-highlighter.js
+++ b/src/backend/utils/syntax-highlighter.js
@@ -40,6 +40,10 @@ hljs.registerLanguage('dos', require('highlight.js/lib/languages/dos'));
  * and apply syntax highlight markup.
  */
 module.exports = function (html) {
+  if (typeof html !== 'string') {
+    return html;
+  }
+
   try {
     const dom = new JSDOM(html);
     const doc = dom.window.document;
@@ -47,7 +51,12 @@ module.exports = function (html) {
     doc.querySelectorAll('pre code').forEach((code) => {
       const { value, language } = hljs.highlightAuto(code.innerHTML);
 
-      // Decorate the <pre> with class names for highlighting this language
+      // If the language wasn't detected, return the HTML untouched
+      if (!language) {
+        return;
+      }
+
+      // Otherwise, decorate the <pre> with class names for highlighting this language
       const pre = code.parentNode;
       pre.classList.add('hljs', language);
 
@@ -58,7 +67,7 @@ module.exports = function (html) {
     return doc.body.innerHTML;
   } catch (err) {
     logger.error({ err, html }, 'syntax highlight error');
-    // Return the html untouched.
+    // Return the HTML untouched.
     return html;
   }
 };

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -19,7 +19,6 @@
     "gatsby-transformer-remark": "2.7.1",
     "gatsby-transformer-sharp": "2.4.4",
     "graphql-tag": "2.10.3",
-    "highlight.js": "9.18.1",
     "material-ui-popup-state": "1.5.4",
     "node-fetch": "2.6.0",
     "prop-types": "15.7.2",

--- a/src/frontend/src/components/Post/syntax-highlight.js
+++ b/src/frontend/src/components/Post/syntax-highlight.js
@@ -65,6 +65,8 @@ hljs.registerLanguage('dos', dos);
 
 export default function (node) {
   if (node) {
-    node.querySelectorAll('pre').forEach((pre) => hljs.highlightBlock(pre));
+    // We're moving to doing this in the backend, so skip if it's already done.
+    // We'll rip this out once there's a way to trigger a rebuild of all post content.
+    node.querySelectorAll('pre:not(.hljs)').forEach((pre) => hljs.highlightBlock(pre));
   }
 }

--- a/test/syntax-highlighter.test.js
+++ b/test/syntax-highlighter.test.js
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const syntaxHighlighter = require('../src/backend/utils/syntax-highlighter');
+
+/**
+ * syntaxHighlighter() will markup code so it can be styled as code with CSS
+ */
+describe('syntax-highlighter tests', () => {
+  test('regular prose is left untouched', () => {
+    const original = 'This should stay identical.';
+    const result = syntaxHighlighter(original);
+    expect(result).toEqual(original);
+  });
+
+  test('code outside <pre><code>...</code></pre> should be left untouched', () => {
+    const original = 'function fn() { console.log("This should stay identical."); }\n\n';
+    const result = syntaxHighlighter(original);
+    expect(result).toEqual(original);
+  });
+
+  test('code inside <pre><code>...</code></pre> should get marked up', () => {
+    // C++ code example, in regular text and as code
+    const original = 'const int i = 5; <pre><code>const int i = 5;</code></pre>';
+    const result = syntaxHighlighter(original);
+    const expected =
+      'const int i = 5; <pre class="hljs cpp"><code><span class="hljs-keyword">const</span> <span class="hljs-keyword">int</span> i = <span class="hljs-number">5</span>;</code></pre>';
+    expect(result).toEqual(expected);
+  });
+
+  test('bash is correctly marked up', () => {
+    const original = '<pre><code>cd foo</code></pre>';
+    const result = syntaxHighlighter(original);
+    const expected =
+      '<pre class="hljs bash"><code><span class="hljs-built_in">cd</span> foo</code></pre>';
+    expect(result).toEqual(expected);
+  });
+
+  test('JavaScript is correctly marked up', () => {
+    const original =
+      '<pre><code>import React, { Component } from "react"; function main() { console.log("hi"); }</code></pre>';
+    const result = syntaxHighlighter(original);
+    const expected =
+      '<pre class="hljs javascript"><code><span class="hljs-keyword">import</span> React, { Component } <span class="hljs-keyword">from</span> <span class="hljs-string">"react"</span>; <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">main</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"hi"</span>); }</code></pre>';
+    expect(result).toEqual(expected);
+  });
+});

--- a/test/syntax-highlighter.test.js
+++ b/test/syntax-highlighter.test.js
@@ -8,6 +8,30 @@ const syntaxHighlighter = require('../src/backend/utils/syntax-highlighter');
  * syntaxHighlighter() will markup code so it can be styled as code with CSS
  */
 describe('syntax-highlighter tests', () => {
+  test('Objects are returned untouched', () => {
+    const original = {};
+    const result = syntaxHighlighter(original);
+    expect(result).toEqual(original);
+  });
+
+  test('undefined is returned untouched', () => {
+    const original = undefined;
+    const result = syntaxHighlighter(original);
+    expect(result).toEqual(original);
+  });
+
+  test('null is returned untouched', () => {
+    const original = null;
+    const result = syntaxHighlighter(original);
+    expect(result).toEqual(original);
+  });
+
+  test('empty code blocks are left untouched', () => {
+    const original = '';
+    const result = syntaxHighlighter(original);
+    expect(result).toEqual(original);
+  });
+
   test('regular prose is left untouched', () => {
     const original = 'This should stay identical.';
     const result = syntaxHighlighter(original);


### PR DESCRIPTION
I want to start moving any processing that can be done in the backend out of the frontend.  First up, syntax highlighting.

It's a bit more complicated to do it in node, because the library requires a DOM.  I use JSDOM to extract the bits it needs, feed them in one-by-one, and then replace the content with marked up versions.

I've added some basic tests, and we can extend this as we see things we like or don't like happening, and add little fixes.

NOTE: I'm not removing the frontend code fully yet, only reducing how much it runs.  The new code will check to see if it needs to run the highlighter or not, and skip it if it's already been run.

I need the work @c3ho is doing in #1033 to land first, since I need all post content to be highlighted in the backend when we store it.  Then I can do a new PR to remove the frontend code completely.