### PR TITLE
Enable gzip compression in nginx

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -1,6 +1,9 @@
 events {}
 
 http {
+  include       mime.types;
+  default_type  application/octet-stream;
+
   # levels        - Defines hierarchy levels
   # keys_zone     - Name for these settings
   # inactive      - Cached data that are not accessed during the time specified by the inactive parameter get removed from the cache regardless of their freshness

--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -9,6 +9,36 @@ http {
   proxy_cache_path /tmp/nginx levels=1:2 keys_zone=telescope_cache:10m inactive=60m max_size=100M use_temp_path=off;
   proxy_cache_key "$scheme$request_method$host$request_uri";
 
+  # Enable gzip compression (level 6) for text file types over 256 bytes.
+  gzip on;
+  gzip_min_length 256;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_vary on;
+  gzip_http_version 1.1;
+  gzip_proxied any;
+  gzip_types
+    text/html
+  	text/css
+	  text/plain
+    text/cache-manifest
+    text/javascript
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/x-javascript
+    application/xml
+    application/xml+rss
+    application/xhtml+xml
+    application/x-font-ttf
+    application/x-font-opentype
+    application/vnd.ms-fontobject
+    image/svg+xml
+    image/x-icon
+    application/rss+xml
+    application/atom_xml;
+
   server {
     listen 80 default_server;
     server_name _;

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -1,6 +1,9 @@
 events {}
 
 http {
+  include       mime.types;
+  default_type  application/octet-stream;
+
   # levels        - Defines hierarchy levels
   # keys_zone     - Name for these settings
   # inactive      - Cached data that are not accessed during the time specified by the inactive parameter get removed from the cache regardless of their freshness

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -9,6 +9,36 @@ http {
   proxy_cache_path /tmp/nginx levels=1:2 keys_zone=telescope_cache:10m inactive=60m max_size=100M use_temp_path=off;
   proxy_cache_key "$scheme$request_method$host$request_uri";
 
+  # Enable gzip compression (level 6) for text file types over 256 bytes.
+  gzip on;
+  gzip_min_length 256;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_vary on;
+  gzip_http_version 1.1;
+  gzip_proxied any;
+  gzip_types
+    text/html
+  	text/css
+	  text/plain
+    text/cache-manifest
+    text/javascript
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/x-javascript
+    application/xml
+    application/xml+rss
+    application/xhtml+xml
+    application/x-font-ttf
+    application/x-font-opentype
+    application/vnd.ms-fontobject
+    image/svg+xml
+    image/x-icon
+    application/rss+xml
+    application/atom_xml;
+
   server {
     listen 80 default_server;
     server_name _;


### PR DESCRIPTION
More work toward #1042, this alters our nginx config to add gzip compression for text types we serve.

For reference:

- https://docs.nginx.com/nginx/admin-guide/web-server/compression/
- https://www.digitalocean.com/community/tutorials/how-to-increase-pagespeed-score-by-changing-your-nginx-configuration-on-ubuntu-16-04
- http://nginx.org/en/docs/http/ngx_http_gzip_module.html

This should help further reduce the size of our transferred html, js, etc. on the network.