### PR TITLE
Move img and iframe lazy loading to server

### DIFF
--- a/src/backend/utils/html/dom.js
+++ b/src/backend/utils/html/dom.js
@@ -1,0 +1,18 @@
+const jsdom = require('jsdom');
+
+const { JSDOM } = jsdom;
+
+/**
+ * Parse and return the String `html` into a JSDOM instance, or return `null`.
+ */
+module.exports = function toDOM(html) {
+  if (typeof html !== 'string') {
+    return null;
+  }
+
+  try {
+    return new JSDOM(html);
+  } catch (err) {
+    return null;
+  }
+};

--- a/src/backend/utils/html/index.js
+++ b/src/backend/utils/html/index.js
@@ -1,0 +1,29 @@
+const sanitize = require('./sanitize');
+const lazyLoad = require('./lazy-load');
+const syntaxHighlight = require('./syntax-highlight');
+const toDOM = require('./dom');
+
+/**
+ * Takes a String of HTML and sanitizes, syntax highlights, and
+ * modifies <img> and <iframe> elements to be lazy loaded. Returns
+ * the updated HTML.
+ */
+module.exports = function process(html) {
+  // Expect a String, return anything else untouched.
+  if (typeof html !== 'string') {
+    return html;
+  }
+
+  // Sanitize the HTML to remove unwanted elements and attributes
+  const clean = sanitize(html);
+
+  // Create a document we can process
+  const dom = toDOM(clean);
+  // Look for and syntax highlight <pre><code>...</code></pre> blocks
+  syntaxHighlight(dom);
+  // Update <img> and <iframe> elements to use native lazy loading.
+  lazyLoad(dom);
+
+  // Return the resulting HTML
+  return dom.window.document.body.innerHTML;
+};

--- a/src/backend/utils/html/lazy-load.js
+++ b/src/backend/utils/html/lazy-load.js
@@ -1,0 +1,13 @@
+/**
+ * Given a parsed JSDOM Object, find all <img> and <iframe> elements and add
+ * the native lazy load attribute, `loading="lazy"`.
+ */
+module.exports = function (dom) {
+  if (!(dom && dom.window && dom.window.document)) {
+    return;
+  }
+
+  dom.window.document
+    .querySelectorAll('iframe, img')
+    .forEach((elem) => elem.setAttribute('loading', 'lazy'));
+};

--- a/src/backend/utils/html/sanitize.js
+++ b/src/backend/utils/html/sanitize.js
@@ -5,7 +5,6 @@ const sanitizeHtml = require('sanitize-html');
 
 module.exports = function (dirty) {
   return sanitizeHtml(dirty, {
-    // Add <img> to the list of allowed tags, see:
     // https://github.com/apostrophecms/sanitize-html#what-are-the-default-options
     allowedTags: [
       'a',

--- a/src/backend/utils/html/syntax-highlight.js
+++ b/src/backend/utils/html/syntax-highlight.js
@@ -50,9 +50,11 @@ module.exports = function (dom) {
 
     // Otherwise, decorate the <pre> with class names for highlighting this language
     const pre = code.parentNode;
-    pre.classList.add('hljs', language);
+    if (pre) {
+      pre.classList.add('hljs', language);
+    }
 
-    // Replace the contents with newly marked up syntax highligting
+    // Replace the contents with newly marked up syntax highlighting
     code.innerHTML = value;
   });
 };

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -53,14 +53,6 @@ function formatPublishedDate(dateString) {
   return `Last Updated ${formatted}`;
 }
 
-function lazyLoad(text) {
-  const dom = document.createElement('template');
-  dom.innerHTML = text;
-  dom.content.querySelectorAll('iframe,img').forEach(function (elem) {
-    elem.setAttribute('loading', 'lazy');
-  });
-  return dom.innerHTML;
-}
 const Post = ({ id, html, author, url, title, date, link }) => {
   const classes = useStyles();
   // We need a ref to our post content, which we inject into a <section> below.
@@ -94,7 +86,7 @@ const Post = ({ id, html, author, url, title, date, link }) => {
           <section
             ref={sectionEl}
             className="telescope-post-content"
-            dangerouslySetInnerHTML={{ __html: lazyLoad(html) }}
+            dangerouslySetInnerHTML={{ __html: html }}
           />
         </Grid>
       </Grid>

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const toDOM = require('../src/backend/utils/html/dom');
+
+function isDOM(dom) {
+  return !!(dom && dom.window && dom.window.document && dom.window.document.body);
+}
+
+/**
+ * toDOM() produces a JSDOM from HTML strings
+ */
+describe('toDOM tests', () => {
+  test('an HTML string is turned into a DOM', () => {
+    const original =
+      '<main><section><article><div><p><span>Hello</span> <em>World</em></p></div></article></section></main>';
+    const result = toDOM(original);
+    expect(isDOM(result)).toBe(true);
+    expect(result.window.document.body.innerHTML).toEqual(original);
+  });
+
+  test('empty strings are OK', () => {
+    const original = '';
+    const result = toDOM(original);
+    expect(isDOM(result)).toBe(true);
+  });
+
+  test('regular prose is OK', () => {
+    const original = 'This should work';
+    const result = toDOM(original);
+    expect(isDOM(result)).toBe(true);
+  });
+});

--- a/test/lazy-load.test.js
+++ b/test/lazy-load.test.js
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const toDOM = require('../src/backend/utils/html/dom');
+const lazy = require('../src/backend/utils/html/lazy-load');
+
+function lazyLoad(html) {
+  const dom = toDOM(html);
+  lazy(dom);
+  return dom.window.document.body.innerHTML;
+}
+
+/**
+ * lazyLoad() will update <img> and <iframe> elements to use loading="lazy"
+ */
+describe('lazy-load tests', () => {
+  test('Non <img> and <iframe> elements are left alone', () => {
+    const original =
+      '<main><section><article><div><p><span>Hello</span> <em>World</em></p></div></article></section></main>';
+    const result = lazyLoad(original);
+    expect(result).toEqual(original);
+  });
+
+  test('empty strings are left untouched', () => {
+    const original = '';
+    const result = lazyLoad(original);
+    expect(result).toEqual(original);
+  });
+
+  test('regular prose is left untouched', () => {
+    const original = 'This should stay identical.';
+    const result = lazyLoad(original);
+    expect(result).toEqual(original);
+  });
+
+  describe('<img> lazy loading', () => {
+    test('An <img> has lazy loading added', () => {
+      const original = '<img src="dog.jpg">';
+      const result = lazyLoad(original);
+      expect(result).toEqual('<img src="dog.jpg" loading="lazy">');
+    });
+
+    test('An <img> has lazy loading added only once', () => {
+      const original = '<img src="dog.jpg" loading="lazy">';
+      const result = lazyLoad(original);
+      expect(result).toEqual('<img src="dog.jpg" loading="lazy">');
+    });
+
+    test('Multiple <img>s have lazy loading added', () => {
+      const original = '<img src="dog.jpg"> <img src="cat.jpg">';
+      const result = lazyLoad(original);
+      expect(result).toEqual(
+        '<img src="dog.jpg" loading="lazy"> <img src="cat.jpg" loading="lazy">'
+      );
+    });
+  });
+
+  describe('<iframe> lazy loading', () => {
+    test('An <iframe> has lazy loading added', () => {
+      const original = '<iframe src="index.html"></iframe>';
+      const result = lazyLoad(original);
+      expect(result).toEqual('<iframe src="index.html" loading="lazy"></iframe>');
+    });
+
+    test('An <iframe> has lazy loading added only once', () => {
+      const original = '<iframe src="index.html" loading="lazy"></iframe>';
+      const result = lazyLoad(original);
+      expect(result).toEqual('<iframe src="index.html" loading="lazy"></iframe>');
+    });
+
+    test('Multiple <iframe>s have lazy loading added', () => {
+      const original =
+        '<iframe src="one.html" loading="lazy"></iframe> <iframe src="two.html" loading="lazy"></iframe>';
+      const result = lazyLoad(original);
+      expect(result).toEqual(original);
+    });
+  });
+});

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -1,4 +1,4 @@
-const sanitizeHTML = require('../src/backend/utils/sanitize-html');
+const sanitizeHTML = require('../src/backend/utils/html/sanitize');
 
 describe('Sanitize HTML', () => {
   test('<img> should work, but inline js should not', () => {

--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -2,30 +2,19 @@
  * @jest-environment jsdom
  */
 
-const syntaxHighlighter = require('../src/backend/utils/syntax-highlighter');
+const toDOM = require('../src/backend/utils/html/dom');
+const highlight = require('../src/backend/utils/html/syntax-highlight');
+
+function syntaxHighlighter(html) {
+  const dom = toDOM(html);
+  highlight(dom);
+  return dom.window.document.body.innerHTML;
+}
 
 /**
  * syntaxHighlighter() will markup code so it can be styled as code with CSS
  */
-describe('syntax-highlighter tests', () => {
-  test('Objects are returned untouched', () => {
-    const original = {};
-    const result = syntaxHighlighter(original);
-    expect(result).toEqual(original);
-  });
-
-  test('undefined is returned untouched', () => {
-    const original = undefined;
-    const result = syntaxHighlighter(original);
-    expect(result).toEqual(original);
-  });
-
-  test('null is returned untouched', () => {
-    const original = null;
-    const result = syntaxHighlighter(original);
-    expect(result).toEqual(original);
-  });
-
+describe('syntax-highlight tests', () => {
   test('empty code blocks are left untouched', () => {
     const original = '';
     const result = syntaxHighlighter(original);


### PR DESCRIPTION
This moves the `<img>` and `<iframe>` lazy loading out of the frontend and does it in the backend during feed processing.  I've refactored the backend HTML processing code to share some common bits (e.g., use the same JSDOM instance).  I've also added and updated tests.

I still want to test this more, but it's close I think.