### PR TITLE
Fix #982: restore nameID to user info for logout requests

### DIFF
--- a/src/backend/data/admin.js
+++ b/src/backend/data/admin.js
@@ -6,8 +6,8 @@ const hash = require('./hash');
 const administrators = process.env.ADMINISTRATORS ? process.env.ADMINISTRATORS.split(' ') : [];
 
 class Admin extends User {
-  constructor(name, email, id) {
-    super(name, email, id);
+  constructor(name, email, id, nameID, nameIDFormat) {
+    super(name, email, id, nameID, nameIDFormat);
     this.isAdmin = true;
   }
 

--- a/src/backend/data/user.js
+++ b/src/backend/data/user.js
@@ -1,10 +1,12 @@
 const Feed = require('./feed');
 
 class User {
-  constructor(name, email, id) {
+  constructor(name, email, id, nameID, nameIDFormat) {
     this.name = name;
     this.email = email;
     this.id = id;
+    this.nameID = nameID;
+    this.nameIDFormat = nameIDFormat;
     this.isAdmin = false;
   }
 
@@ -13,6 +15,8 @@ class User {
       name: this.name,
       email: this.email,
       id: this.id,
+      nameID: this.nameID,
+      nameIDFormat: this.nameIDFormat,
       isAdmin: this.isAdmin,
     };
   }

--- a/src/backend/web/__mocks__/authentication.js
+++ b/src/backend/web/__mocks__/authentication.js
@@ -72,10 +72,14 @@ function createUser() {
     return null;
   }
 
+  // Hard-code required fields that we need internally, but don't use in mocks
+  const nameID = loggedInUser.email;
+  const nameIDFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress';
+
   if (loggedInUser.isAdmin) {
-    return new Admin(loggedInUser.name, loggedInUser.email, loggedInUser.id);
+    return new Admin(loggedInUser.name, loggedInUser.email, loggedInUser.id, nameID, nameIDFormat);
   }
-  return new User(loggedInUser.name, loggedInUser.email, loggedInUser.id);
+  return new User(loggedInUser.name, loggedInUser.email, loggedInUser.id, nameID, nameIDFormat);
 }
 
 function protect(redirect) {

--- a/src/backend/web/authentication.js
+++ b/src/backend/web/authentication.js
@@ -104,8 +104,46 @@ function init() {
         return done(error);
       }
 
-      // We only use the displayname, emailaddress, and nameID (hashed, for use in our db)
+      /**
+       * The object we get back from Seneca takes this form:
+       * {
+       *   "issuer": "https://sts.windows.net/...",
+       *   "inResponseTo": "_851650d2472d2921c6ac",
+       *   "sessionIndex": "_dfa0c21c-b4d6-43cb-a277-2cf456d43600",
+       *   "nameID": "first.last@senecacollege.ca",
+       *   "nameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+       *   "http://schemas.microsoft.com/identity/claims/tenantid": "3dd...",
+       *   "http://schemas.microsoft.com/identity/claims/objectidentifier": "4b4a05ff-04a4-49d9-91b8-1f92d2077f80",
+       *   "http://schemas.microsoft.com/identity/claims/displayname": "First Last",
+       *   "http://schemas.microsoft.com/identity/claims/identityprovider": "https://sts...",
+       *   "http://schemas.microsoft.com/claims/authnmethodsreferences": "http://schemas.microsoft.com/ws/2008/06/identity/authenticationmethod/password",
+       *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname": "First",
+       *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": "Last",
+       *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": "first.last@senecacollege.ca",
+       *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name": "first.last@senecacollege.ca",
+       * }
+       *
+       * The SimpleSamlPHP testing IdP looks like this:
+       *
+       * {
+       *   "issuer": "https://localhost:8443/simplesaml/saml2/idp/metadata.php",
+       *   "sessionIndex": "_db0e7ecb9c82615a9abf21f0fc97c39b5b3e5857d0",
+       *   "nameID": "_566172266563daa8980f7a8fa73a6ef45172aac020",
+       *   "nameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+       *   "spNameQualifier": "...",
+       *   "uid": "1",
+       *   "eduPersonAffiliation": "group1",
+       *   "http://schemas.microsoft.com/identity/claims/displayname": "First Last",
+       *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": "first.last@email.com"
+       *   "email": "first.last@email.com"
+       * }
+       */
+
+      // We only use the displayname, emailaddress, and nameID info (hashed, for use in our db)
       return done(null, {
+        // Include nameID so we can use it for Logout Requests back to the IdP.
+        nameID: profile.nameID,
+        nameIDFormat: profile.nameIDFormat,
         name: profile['http://schemas.microsoft.com/identity/claims/displayname'],
         email: profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'],
         id: hash(profile.nameID),


### PR DESCRIPTION
Fixes #982.  This adds back the `nameID` and `nameIDFormat` values we get from the Seneca IdP.  We need this to be able to properly do an IdP SLO Logout.

This is impossible to test until it lands on staging.  So I mostly need a code review here, and if someone could test it locally.