### PR TITLE
Tune nginx configs to run more efficiently

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -1,8 +1,19 @@
-events {}
+# Let nginx pick how many worker processes to run (based on CPU cores)
+worker_processes auto;
+
+events {
+  # Number of simultaneous client connections we can handle per worker
+  worker_connections 1024;
+  # Reduce CPU load (requires Linux 2.6 or later)
+  use epoll;
+}
 
 http {
   include       mime.types;
   default_type  application/octet-stream;
+
+  # Improve the efficiency of writes
+  sendfile on;
 
   # levels        - Defines hierarchy levels
   # keys_zone     - Name for these settings

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -1,8 +1,19 @@
-events {}
+# Let nginx pick how many worker processes to run (based on CPU cores)
+worker_processes auto;
+
+events {
+  # Number of simultaneous client connections we can handle per worker
+  worker_connections 1024;
+  # Reduce CPU load (requires Linux 2.6 or later)
+  use epoll;
+}
 
 http {
   include       mime.types;
   default_type  application/octet-stream;
+
+  # Improve the efficiency of writes
+  sendfile on;
 
   # levels        - Defines hierarchy levels
   # keys_zone     - Name for these settings


### PR DESCRIPTION
Fixes #1047

This tunes our nginx configs to use Linux and the hardware we have more efficiently.  It will run multiple worker processes instead of 1, and allow more connections per worker.  This also improves writes and how we poll in the kernel.

@manekenpix when we deploy this on staging, we should take a look at how the machine runs overall.