### PR TITLE
Remove HTTP-Redirect auth request binding

### DIFF
--- a/src/backend/web/authentication.js
+++ b/src/backend/web/authentication.js
@@ -94,7 +94,6 @@ function init() {
       issuer: SAML_ENTITY_ID,
       cert: SSO_IDP_PUBLIC_KEY_CERT,
       disableRequestedAuthnContext: true,
-      authnRequestBinding: 'HTTP-Redirect',
       signatureAlgorithm: 'sha256',
     },
     function (profile, done) {


### PR DESCRIPTION
This line got added for testing, but I don't think it's helping, and could potentially be causing our failure to logout.  Let's remove it.