### PR TITLE
Include nameID and nameIDFormat in req.user

### DIFF
--- a/src/backend/web/authentication.js
+++ b/src/backend/web/authentication.js
@@ -77,9 +77,9 @@ function init() {
      * more than one admin user.
      */
     if (Admin.isAdmin(user.id)) {
-      done(null, new Admin(user.name, user.email, user.id));
+      done(null, new Admin(user.name, user.email, user.id, user.nameID, user.nameIDFormat));
     } else {
-      done(null, new User(user.name, user.email, user.id));
+      done(null, new User(user.name, user.email, user.id, user.nameID, user.nameIDFormat));
     }
   });
 


### PR DESCRIPTION
In https://github.com/bergie/passport-saml/blob/master/lib/passport-saml/saml.js#L228-L246, the `saml.js` backend needs `req.user.nameID` to exist. My fix in #1051 missed adding this, even though I did it in the mock.

This includes it.
