### PR TITLE
Fix #1036: reduce number of posts loaded on startup

### DIFF
--- a/env.example
+++ b/env.example
@@ -102,7 +102,7 @@ FEED_QUEUE_DELAY_MS=60000
 FEED_QUEUE_PARALLEL_WORKERS=1
 
 # Max number of posts per page
-MAX_POSTS_PER_PAGE=30
+MAX_POSTS_PER_PAGE=10
 
 # If you need to do a release, GitHub requires a Personal Access token.
 # You can create one at https://github.com/settings/tokens, and get more info:

--- a/env.production
+++ b/env.production
@@ -74,7 +74,7 @@ FEED_QUEUE_DELAY_MS=60000
 FEED_QUEUE_PARALLEL_WORKERS=1
 
 # Max number of posts per page
-MAX_POSTS_PER_PAGE=30
+MAX_POSTS_PER_PAGE=10
 
 # If you need to do a release, GitHub requires a Personal Access token.
 # You can create one at https://github.com/settings/tokens, and get more info:

--- a/env.staging
+++ b/env.staging
@@ -82,7 +82,7 @@ FEED_QUEUE_DELAY_MS=60000
 FEED_QUEUE_PARALLEL_WORKERS=1
 
 # Max number of posts per page
-MAX_POSTS_PER_PAGE=50
+MAX_POSTS_PER_PAGE=10
 
 # If you need to do a release, GitHub requires a Personal Access token.
 # You can create one at https://github.com/settings/tokens, and get more info:

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -9,7 +9,6 @@ const hash = require('../src/backend/data/hash');
 jest.mock('../src/backend/utils/elastic');
 
 describe('test /posts endpoint', () => {
-  const defaultItems = 30;
   const requestedItems = 50;
   const maxItems = 100;
   const createdItems = 150;
@@ -38,7 +37,8 @@ describe('test /posts endpoint', () => {
     expect(res.status).toEqual(200);
     expect(res.get('Content-type')).toContain('application/json');
     expect(res.get('X-Total-Count')).toBe(createdItems.toString());
-    expect(res.body.length).toBe(defaultItems);
+    // This will depend on the env value, so as long as we get back something.
+    expect(res.body.length).toBeGreaterThan(0);
     expect(res.body instanceof Array).toBe(true);
   });
 


### PR DESCRIPTION
Fixes #1036

As part of #1042, we need to reduce the size of our DOM.  The easiest way to do this is to load fewer posts.  We have code to "load more" now, so we don't need so many at once.

This drops it down to 10.  We might be able to go lower still, but let's see how this performs.