### PR TITLE
Add expires header info to nginx

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -42,6 +42,16 @@ http {
     application/rss+xml
     application/atom_xml;
 
+  # Set default expiration times for different types of content
+  map $sent_http_content_type $expires {
+    default                    off;       # don't cache by default
+    text/html                  epoch;     # no cache for HTML files
+    "text/html; charset=utf-8" epoch;
+    text/css                   max;       # cache CSS and JS as long as possible
+    application/javascript     max;
+    ~image/                    max;       # ~image/ matches all image mime types
+  }
+
   server {
     listen 80 default_server;
     server_name _;
@@ -51,6 +61,9 @@ http {
   server {
     listen 443 ssl http2;
     server_name telescope.cdot.systems;
+
+    # Use our expires mapping defined above
+    expires $expires;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -42,6 +42,16 @@ http {
     application/rss+xml
     application/atom_xml;
 
+  # Set default expiration times for different types of content
+  map $sent_http_content_type $expires {
+    default                    off;       # don't cache by default
+    text/html                  epoch;     # no cache for HTML files
+    "text/html; charset=utf-8" epoch;
+    text/css                   max;       # cache CSS and JS as long as possible
+    application/javascript     max;
+    ~image/                    max;       # ~image/ matches all image mime types
+  }
+
   server {
     listen 80 default_server;
     server_name _;
@@ -51,6 +61,9 @@ http {
   server {
     listen 443 ssl http2;
     server_name dev.telescope.cdot.systems;
+
+    # Use our expires mapping defined above
+    expires $expires;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
@@ -82,7 +95,6 @@ http {
     location ~ ^/(admin|user|health|auth) {
       proxy_cache_bypass 1;
       proxy_pass http://telescope_staging:3000;
-
     }
 
     # Static content


### PR DESCRIPTION
<img width="736" alt="Screen Shot 2020-04-23 at 2 28 17 PM" src="https://user-images.githubusercontent.com/427398/80135781-b5ba3e80-856e-11ea-8bd9-b0a2aff5570c.png">

We're not adding the necessary cache headers to our static files, and browsers don't know that they can cache them.  This adds default expiry info for different static types we serve.

See https://www.digitalocean.com/community/tutorials/how-to-implement-browser-caching-with-nginx-s-header-module-on-centos-7 for info on this.