### PR TITLE
Move Roboto web font into our tree

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -55,12 +55,23 @@ http {
 
   # Set default expiration times for different types of content
   map $sent_http_content_type $expires {
-    default                    off;       # don't cache by default
-    text/html                  epoch;     # no cache for HTML files
-    "text/html; charset=utf-8" epoch;
-    text/css                   max;       # cache CSS and JS as long as possible
-    application/javascript     max;
-    ~image/                    max;       # ~image/ matches all image mime types
+    # don't cache by default
+    default                         off;
+    # no cache for HTML files
+    text/html                       epoch;
+    "text/html; charset=utf-8"      epoch;
+    # cache CSS and JS as long as possible
+    text/css                        max;
+    application/javascript          max;
+    # cache all image types as long as possible
+    ~image/                         max;
+    # cache web fonts as long as possible
+    ~font/                          max;
+    ~application/vnd.ms-fontobject  max;
+    ~application/x-font-ttf         max;
+    ~application/x-font-woff        max;
+    ~application/font-woff          max;
+    ~application/font-woff2         max;
   }
 
   server {

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -55,12 +55,23 @@ http {
 
   # Set default expiration times for different types of content
   map $sent_http_content_type $expires {
-    default                    off;       # don't cache by default
-    text/html                  epoch;     # no cache for HTML files
-    "text/html; charset=utf-8" epoch;
-    text/css                   max;       # cache CSS and JS as long as possible
-    application/javascript     max;
-    ~image/                    max;       # ~image/ matches all image mime types
+    # don't cache by default
+    default                         off;
+    # no cache for HTML files
+    text/html                       epoch;
+    "text/html; charset=utf-8"      epoch;
+    # cache CSS and JS as long as possible
+    text/css                        max;
+    application/javascript          max;
+    # cache all image types as long as possible
+    ~image/                         max;
+    # cache web fonts as long as possible
+    ~font/                          max;
+    ~application/vnd.ms-fontobject  max;
+    ~application/x-font-ttf         max;
+    ~application/x-font-woff        max;
+    ~application/font-woff          max;
+    ~application/font-woff2         max;
   }
 
   server {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -21,12 +21,13 @@
     "graphql-tag": "2.10.3",
     "material-ui-popup-state": "1.5.4",
     "node-fetch": "2.6.0",
+    "parse-link-header": "1.0.1",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-helmet": "6.0.0",
     "react-material-ui-form-validator": "2.0.10",
-    "parse-link-header": "1.0.1"
+    "typeface-roboto": "0.0.75"
   },
   "devDependencies": {
     "json-loader": "0.5.7"

--- a/src/frontend/plugins/gatsby-plugin-top-layout/TopLayout.js
+++ b/src/frontend/plugins/gatsby-plugin-top-layout/TopLayout.js
@@ -10,13 +10,8 @@ export default function TopLayout(props) {
     <>
       <Helmet>
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
-        <link
-          href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap"
-          rel="stylesheet"
-        />
       </Helmet>
       <ThemeProvider theme={theme}>
-        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
         {props.children}
       </ThemeProvider>

--- a/src/frontend/plugins/gatsby-plugin-top-layout/gatsby-browser.js
+++ b/src/frontend/plugins/gatsby-plugin-top-layout/gatsby-browser.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export, react/prop-types */
 import React from 'react';
+import 'typeface-roboto';
 import TopLayout from './TopLayout';
 
 export const wrapRootElement = ({ element }) => {

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -4,7 +4,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Fab from '@material-ui/core/Fab';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import useSiteMetadata from '../../hooks/use-site-metadata';
 import DynamicBackgroundContainer from '../DynamicBackgroundContainer';
 
@@ -190,7 +189,6 @@ export default function Banner() {
 
   return (
     <>
-      <CssBaseline />
       <div className={classes.heroBanner}>
         <RetrieveBannerDynamicAssets />
         <Typography variant="h1" className={classes.h1}>

--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -6,7 +6,7 @@
   word-wrap: break-word;
   hyphens: auto;
   font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica,
-    Ubuntu, roboto, noto, segoe ui, arial, sans-serif;
+    Ubuntu, Roboto, noto, segoe ui, arial, sans-serif;
 }
 
 .telescope-post-content p {

--- a/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Toolbar from '@material-ui/core/Toolbar';
 import { makeStyles } from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import useScrollTrigger from '@material-ui/core/useScrollTrigger';
 import Fab from '@material-ui/core/Fab';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
@@ -57,7 +56,6 @@ ScrollTop.propTypes = {
 export default function BackToTop(props) {
   return (
     <>
-      <CssBaseline />
       <Toolbar id="back-to-top-anchor" />
       <ScrollTop {...props}>
         <Fab color="primary" aria-label="scroll back to top">

--- a/src/frontend/src/pages/PageBase.js
+++ b/src/frontend/src/pages/PageBase.js
@@ -11,7 +11,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import SEO from '../components/SEO';
 import Header from '../components/Header';
 
@@ -27,7 +26,6 @@ const styles = {
 function PageBase({ children, title }) {
   return (
     <>
-      <CssBaseline />
       <SEO title={title} />
       <Header />
       {children}


### PR DESCRIPTION
<img width="713" alt="Screen Shot 2020-04-23 at 8 39 37 PM" src="https://user-images.githubusercontent.com/427398/80162906-95a47280-85a2-11ea-9b5a-e5a747d1de4a.png">

This changes how we load the Roboto web font.  Instead of pulling it from Google, this installs it into our tree using the `typeface-roboto` package, which is how [Gatsby suggests you do it](https://github.com/gatsbyjs/gatsby/search?q=typeface&type=Code&utf8=%E2%9C%93).

I've also added caching info for web fonts to our nginx so they will get held at the browser and not need to be re-downloaded.

I've also removed all the duplicate CSS resets we had, fixed a typo with one of the Roboto instances (lower case r), 