### PR TITLE
Add persistent storage for elasticsearch

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -39,6 +39,11 @@ services:
       - bootstrap.memory_lock=true
       - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
       - discovery.type=single-node
+    volumes:
+      # The directory in the host where the data from elasticsearch will be stored
+      # needs to be owned by 1000:1000
+      # https://discuss.elastic.co/t/elastic-elasticsearch-docker-not-assigning-permissions-to-data-directory-on-run/65812/3
+      - ../elastic-data:/usr/share/elasticsearch/data:rw
     restart: always
 
   nginx:

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -39,6 +39,11 @@ services:
       - bootstrap.memory_lock=true
       - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
       - discovery.type=single-node
+    volumes:
+      # The directory in the host where the data from elasticsearch will be stored
+      # needs to be owned by 1000:1000
+      # https://discuss.elastic.co/t/elastic-elasticsearch-docker-not-assigning-permissions-to-data-directory-on-run/65812/3
+      - ../elastic-data:/usr/share/elasticsearch/data:rw
     restart: always
 
   nginx:


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This adds persistent storage for Elasticsearch.
As explained [here](https://discuss.elastic.co/t/elastic-elasticsearch-docker-not-assigning-permissions-to-data-directory-on-run/65812/3), the directory in the host that will store Elasticsearch's data needs to be owned by `1000:1000`.
Since setting up Elasticsearch is always difficult for contributors, and adding this feature to the development workflow could mean another headache that developers would have to deal with (not everyone knows how to change file permissions and/or ownership), I thought it'd be better if persistent storage would only be available for staging and production.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
