### PR TITLE
Stop loading /posts twice on startup

### DIFF
--- a/src/frontend/src/pages/index.js
+++ b/src/frontend/src/pages/index.js
@@ -44,6 +44,7 @@ export default function IndexPage() {
   const [currentNumPosts, setCurrentNumPosts] = useState(0);
   const [endOfPosts, setEndOfPosts] = useState(false);
   const [alert, setAlert] = useState(false);
+  const [shouldCheckForNewPosts, setShouldCheckForNewPosts] = useState(false);
   const { telescopeUrl } = useSiteMetaData();
   const savedCallback = useRef();
   const snackbarMessage = 'There is new content available!';
@@ -90,6 +91,9 @@ export default function IndexPage() {
   }
 
   const getPostsCount = useCallback(async () => {
+    if (!shouldCheckForNewPosts) {
+      return null;
+    }
     try {
       const res = await fetch(`${telescopeUrl}/posts`, { method: 'HEAD' });
       if (!res.ok) {
@@ -98,9 +102,11 @@ export default function IndexPage() {
       return res.headers.get('x-total-count');
     } catch (error) {
       console.log(error);
+    } finally {
+      setShouldCheckForNewPosts(false);
     }
     return null;
-  }, [telescopeUrl]);
+  }, [telescopeUrl, shouldCheckForNewPosts]);
 
   const callback = useCallback(async () => {
     setCurrentNumPosts(await getPostsCount());
@@ -124,6 +130,7 @@ export default function IndexPage() {
 
   useEffect(() => {
     function getCurrentNumPosts() {
+      setShouldCheckForNewPosts(true);
       savedCallback.current();
     }
     savedCallback.current = callback;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1060 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Created new state [update, setUpdate] to let when `getPostsCount()` should run (not at the beginning). Only the first `useEffect` (line 56) should run now at startup.

To test:

1. open up dev tools on chrome and go to `Performance` tab.
2. Press the record button and reload telescope page, stop as soon as posts load
3. Check if there are two fetch requests to telescopeUrl/posts

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
