### PR TITLE
Fix #869: wrap iframes and control their width

### DIFF
--- a/src/backend/utils/html/fix-iframe-width.js
+++ b/src/backend/utils/html/fix-iframe-width.js
@@ -1,0 +1,25 @@
+/**
+ * Take an <iframe> and return <div><iframe></div>
+ */
+function wrap(iframe, document) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'iframe-video-wrapper';
+
+  iframe.parentNode.insertBefore(wrapper, iframe);
+  wrapper.appendChild(iframe);
+}
+
+/**
+ * Given a parsed JSDOM Object, find all <iframe> elements and add
+ * an enclosing <div class="iframe-video-wrapper"> so we can control
+ * the width of the iframe.
+ */
+module.exports = function (dom) {
+  if (!(dom && dom.window && dom.window.document)) {
+    return;
+  }
+
+  dom.window.document
+    .querySelectorAll('iframe')
+    .forEach((iframe) => wrap(iframe, dom.window.document));
+};

--- a/src/backend/utils/html/index.js
+++ b/src/backend/utils/html/index.js
@@ -1,4 +1,5 @@
 const sanitize = require('./sanitize');
+const fixIFrameWidth = require('./fix-iframe-width');
 const lazyLoad = require('./lazy-load');
 const syntaxHighlight = require('./syntax-highlight');
 const toDOM = require('./dom');
@@ -21,6 +22,8 @@ module.exports = function process(html) {
   const dom = toDOM(clean);
   // Look for and syntax highlight <pre><code>...</code></pre> blocks
   syntaxHighlight(dom);
+  // Wrap <iframe> elements in a <div> so we can style their width
+  fixIFrameWidth(dom);
   // Update <img> and <iframe> elements to use native lazy loading.
   lazyLoad(dom);
 

--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -91,3 +91,22 @@
   display: block;
   font-style: italic;
 }
+
+/**
+ * For YouTube, Vimeo <iframe> elements, we wrap them
+ * in a <div> so we can expand them to fill the width.
+ * See https://css-tricks.com/fluid-width-video/#article-header-id-0
+ */
+.telescope-post-content .iframe-video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  height: 0;
+}
+
+.telescope-post-content .iframe-video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/test/fix-iframe-width.test.js
+++ b/test/fix-iframe-width.test.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const toDOM = require('../src/backend/utils/html/dom');
+const fixWidth = require('../src/backend/utils/html/fix-iframe-width');
+
+function fixIFrameWidth(html) {
+  const dom = toDOM(html);
+  fixWidth(dom);
+  return dom.window.document.body.innerHTML;
+}
+
+/**
+ * fixIFrameWidth() will update <iframe> elements so we can style with CSS
+ */
+describe('lazy-load tests', () => {
+  test('Non <iframe> elements are left alone', () => {
+    const original =
+      '<main><section><article><div><p><span>Hello</span> <em>World</em></p></div></article></section></main>';
+    const result = fixIFrameWidth(original);
+    expect(result).toEqual(original);
+  });
+
+  test('empty strings are left untouched', () => {
+    const original = '';
+    const result = fixIFrameWidth(original);
+    expect(result).toEqual(original);
+  });
+
+  test('regular prose is left untouched', () => {
+    const original = 'This should stay identical.';
+    const result = fixIFrameWidth(original);
+    expect(result).toEqual(original);
+  });
+
+  test('An <iframe> gets wrapped in a <div>', () => {
+    const original = '<iframe></iframe>';
+    const result = fixIFrameWidth(original);
+    expect(result).toEqual('<div class="iframe-video-wrapper"><iframe></iframe></div>');
+  });
+
+  test('Multiple <iframe>s get wrapped in their own <div>', () => {
+    const original = '<iframe></iframe> <iframe></iframe>';
+    const result = fixIFrameWidth(original);
+    expect(result).toEqual(
+      '<div class="iframe-video-wrapper"><iframe></iframe></div> <div class="iframe-video-wrapper"><iframe></iframe></div>'
+    );
+  });
+});


### PR DESCRIPTION
This adds a backend processing step for `<iframe>` elements to wrap them in a `<div>` that we can then style with CSS, and have the resulting videos occupy 100% of the available space.  Here's how it looks:

<img width="1063" alt="Screen Shot 2020-04-23 at 10 33 32 PM" src="https://user-images.githubusercontent.com/427398/80169192-ce4c4800-85b2-11ea-8696-0d24c531d801.png">

It uses the techniques described in https://css-tricks.com/fluid-width-video/#article-header-id-0.

Fixes #869.