### PR TITLE
Remove second meta viewport declaration

### DIFF
--- a/src/frontend/plugins/gatsby-plugin-top-layout/TopLayout.js
+++ b/src/frontend/plugins/gatsby-plugin-top-layout/TopLayout.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import theme from '../../src/theme';
@@ -8,9 +7,6 @@ import theme from '../../src/theme';
 export default function TopLayout(props) {
   return (
     <>
-      <Helmet>
-        <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
-      </Helmet>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         {props.children}


### PR DESCRIPTION
I'm starting to work on webhint fixes, and one problem we have is that we have two `<meta name="viewport">` declarations.  This removes the second:

<img width="370" alt="Screen Shot 2020-04-24 at 10 00 05 AM" src="https://user-images.githubusercontent.com/427398/80220960-9a087400-8612-11ea-98a3-1ac44c558ca4.png">
