### PR TITLE
Set charset to utf-8 in nginx

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -12,6 +12,9 @@ http {
   include       mime.types;
   default_type  application/octet-stream;
 
+  # Use utf-8 for the charset on our content-type headers
+  charset utf-8;
+
   # Improve the efficiency of writes
   sendfile on;
 

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -12,6 +12,9 @@ http {
   include       mime.types;
   default_type  application/octet-stream;
 
+  # Use utf-8 for the charset on our content-type headers
+  charset utf-8;
+
   # Improve the efficiency of writes
   sendfile on;
 


### PR DESCRIPTION
We need to define `utf-8` for our `content-type` headers when nginx serves content.  This adds it. See http://nginx.org/en/docs/http/ngx_http_charset_module.html.