### PR TITLE
Add cache-control headers for Gatsby's files

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -120,7 +120,6 @@ http {
     location ~ ^/(admin|user|health|auth) {
       proxy_cache_bypass 1;
       proxy_pass http://telescope_production:3000;
-
     }
 
     # Static content
@@ -130,6 +129,41 @@ http {
 
       # Try serving static content, and if not found continue with @proxy
       try_files $uri $uri/ @proxy;
+    }
+
+    # Specify cache behaviour for Gatsby's public build files.
+    # See docs in https://www.gatsbyjs.org/docs/caching.
+
+    # 1. Don't cache HTML: https://www.gatsbyjs.org/docs/caching/#html
+    location ~* \.(?:html)$ {
+      expires epoch;
+      add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    # 2. Don't cache /page-data (including app-data.json): https://www.gatsbyjs.org/docs/caching/#page-data
+    location /page-data {
+      expires epoch;
+      add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    # 3. Don't cache the service worker /sw.js script, see:
+    # https://www.gatsbyjs.org/docs/caching/#javascript-and-css
+    location = /sw.js {
+      expires epoch;
+      add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    # 4. Files in static/ can be cached forever: https://www.gatsbyjs.org/docs/caching/#static-files
+    location /static {
+      expires max;
+      add_header Cache-Control "public, max-age=31536000, immutable"
+    }
+
+    # 5. Cache js and css forever, see
+    # https://www.gatsbyjs.org/docs/caching/#javascript-and-css
+    location ~* \.(?:js|css)$ {
+      expires max;
+      add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     location @proxy {

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -131,6 +131,41 @@ http {
       try_files $uri $uri/ @proxy;
     }
 
+    # Specify cache behaviour for Gatsby's public build files.
+    # See docs in https://www.gatsbyjs.org/docs/caching.
+
+    # 1. Don't cache HTML: https://www.gatsbyjs.org/docs/caching/#html
+    location ~* \.(?:html)$ {
+      expires epoch;
+      add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    # 2. Don't cache /page-data (including app-data.json): https://www.gatsbyjs.org/docs/caching/#page-data
+    location /page-data {
+      expires epoch;
+      add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    # 3. Don't cache the service worker /sw.js script, see:
+    # https://www.gatsbyjs.org/docs/caching/#javascript-and-css
+    location = /sw.js {
+      expires epoch;
+      add_header Cache-Control "public, max-age=0, must-revalidate";
+    }
+
+    # 4. Files in static/ can be cached forever: https://www.gatsbyjs.org/docs/caching/#static-files
+    location /static {
+      expires max;
+      add_header Cache-Control "public, max-age=31536000, immutable"
+    }
+
+    # 5. Cache js and css forever, see
+    # https://www.gatsbyjs.org/docs/caching/#javascript-and-css
+    location ~* \.(?:js|css)$ {
+      expires max;
+      add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     location @proxy {
       proxy_cache telescope_cache;
 


### PR DESCRIPTION
We don't set proper `Cache-Control` headers on the files built by Gatsby.  This tries to fix that.  I'm not 100% sure that I've done it correctly yet, and would like to try on staging, then tweak.

The docs for Gatsby outline what needs to happen: https://www.gatsbyjs.org/docs/caching