### PR TITLE
Fix #899: add image width and styling the figure tag in the post

### DIFF
--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -10,7 +10,9 @@
 }
 
 .telescope-post-content p {
-  margin: 1.2rem 0;
+  padding: 0;
+  margin: 0;
+  display: inline;
 }
 
 .telescope-post-content img {
@@ -19,7 +21,14 @@
   max-width: 100%;
   padding-top: 1.5rem;
   padding-bottom: 1rem;
+  width: 100%;
 }
+.telescope-post-content figure {
+  display: block;
+  margin: 0;
+  text-align: center;
+}
+
 .telescope-post-content img[src*='emoji'],
 .telescope-post-content img[src*='smileys'] {
   display: inline-block;

--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -10,9 +10,7 @@
 }
 
 .telescope-post-content p {
-  padding: 0;
-  margin: 0;
-  display: inline;
+  margin: 1.2rem 0;
 }
 
 .telescope-post-content img {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #899. 
This PR will style img wdth to 100% and also style the figure tag. 
After investigation on the problem that is describe in issue #899 styling figure tag does not remove extra space under the figure tag. Moreover the extra space under the figure tag does not apply to it. This extra space comes with the paragraph element. 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
