### PR TITLE
Add flag routes and function to backend

### DIFF
--- a/src/backend/data/feed.js
+++ b/src/backend/data/feed.js
@@ -12,6 +12,9 @@ const {
   removePost,
   getPost,
   getPosts,
+  getFlaggedFeeds,
+  setFlaggedFeed,
+  unsetFlaggedFeed,
 } = require('../utils/storage');
 
 const { deletePost } = require('../utils/elastic');
@@ -112,6 +115,22 @@ class Feed {
   }
 
   /**
+   * Flags the feed, preventing posts from the feed to be displayed
+   * Returns a Promise<Boolean>
+   */
+  flag() {
+    return setFlaggedFeed(this.id);
+  }
+
+  /**
+   * Unflags the feed, allowing posts from the feed to be displayed
+   * Returns a Promise<Boolean>
+   */
+  unflag() {
+    return unsetFlaggedFeed(this.id);
+  }
+
+  /**
    * Creates a new Feed object by extracting data from the given feed-like object.
    * @param {Object} feedData - an Object containing the necessary fields.
    * Returns the newly created Feed's id as a Promise<String>
@@ -155,11 +174,20 @@ class Feed {
   }
 
   /**
-   * Returns all the feeds
+   * Returns all unflagged feeds
    * Returns a Promise<Feeds>
    */
   static async all() {
     const ids = await getFeeds();
+    return Promise.all(ids.map(Feed.byId));
+  }
+
+  /**
+   * Returns all flagged feeds
+   * Returns a Promise<Feeds>
+   */
+  static async flagged() {
+    const ids = await getFlaggedFeeds();
     return Promise.all(ids.map(Feed.byId));
   }
 

--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -52,6 +52,27 @@ feeds.get('/:id', async (req, res) => {
   }
 });
 
+feeds.put('/:id/flag', protectAdmin(), async (req, res) => {
+  const { id } = req.params;
+  try {
+    const feed = await Feed.byId(id);
+    if (!feed) {
+      return res.status(404).json({
+        message: `Feed for Feed ID ${id} doesn't exist.`,
+      });
+    }
+    await feed.flag();
+    return res.status(200).json({
+      message: `Feed successfully flagged`,
+    });
+  } catch (error) {
+    logger.error({ error }, 'Unable to flag feed in Redis');
+    return res.status(503).json({
+      message: 'Unable to flag Feed',
+    });
+  }
+});
+
 feeds.post('/', protect(), async (req, res) => {
   const feedData = req.body;
   const { user } = req;
@@ -104,6 +125,23 @@ feeds.delete('/:id', protect(), async (req, res) => {
     logger.error({ error }, 'Unable to delete feed to Redis');
     return res.status(503).json({
       message: 'Unable to delete to Feed',
+    });
+  }
+});
+
+feeds.delete('/:id/flag', protectAdmin(), async (req, res) => {
+  const { id } = req.params;
+  try {
+    const feed = await Feed.byId(id);
+    if (!feed) {
+      return res.status(404).json({ message: `Feed for Feed ID ${id} doesn't exist.` });
+    }
+    await feed.unflag();
+    return res.status(204).json({ message: `Feed ${id} was successfully unflagged.` });
+  } catch (error) {
+    logger.error({ error }, 'Unable to unflag feed in Redis');
+    return res.status(503).json({
+      message: 'Unable to unflag Feed',
     });
   }
 });

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -2,8 +2,11 @@ const {
   addFeed,
   getFeed,
   getFeeds,
+  getFlaggedFeeds,
   getFeedsCount,
   removeFeed,
+  setFlaggedFeed,
+  unsetFlaggedFeed,
   addPost,
   getPost,
   getPosts,
@@ -74,11 +77,31 @@ describe('Storage tests for feeds', () => {
   it('feed4 should not exist after being removed', async () => {
     const feed = await getFeed(feed4.id);
     await removeFeed(feed.id);
+    // Removing an already removed Feed should not error
+    await removeFeed(feed.id);
     const removedFeed = await getFeed(feed.id);
     // This should return an empty Object {} (no id)
     const feeds = await getFeeds();
     expect(removedFeed.id).toBe(undefined);
     expect(feeds.includes(feed.id)).toBe(false);
+  });
+
+  it('feed3 should appear in flaggedFeed set after being flagged', async () => {
+    const feed = await getFeed(feed3.id);
+    await setFlaggedFeed(feed3.id);
+    const feeds = await getFeeds();
+    const flaggedFeeds = await getFlaggedFeeds();
+    expect(flaggedFeeds.includes(feed.id)).toBe(true);
+    expect(feeds.includes(feed.id)).toBe(false);
+  });
+
+  it('feed3 should not appear in flaggedFeed set after being unflagged', async () => {
+    const feed = await getFeed(feed3.id);
+    await unsetFlaggedFeed(feed3.id);
+    const feeds = await getFeeds();
+    const flaggedFeeds = await getFlaggedFeeds();
+    expect(feeds.includes(feed.id)).toBe(true);
+    expect(flaggedFeeds.includes(feed.id)).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1071 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Adds feature to flag/unflag feeds by hitting the `/feed/:id/flag` route

Done:
Added functions to `storage.js` to flag/unflag
Added functions to `feed.js`
Added tests to `feed.test.js` and `feeds.test.js`
Added routes to `/feed`

**Two ways to test:**
Run my tests

_or..._ 
1. Find an admin account
2. Use `redis-cli smembers t:feeds` to get a list of `feedId` and pick one of them. Keep note of the # of feeds in `t:feeds`
3. While logged in as admin, hit the route `(telescopeUrl)/feeds/(feedId)/flag`. Please use the below screenshot as reference to test `PUT`/`DELETE` routes
![image](https://user-images.githubusercontent.com/18711727/80300563-df8c8480-876b-11ea-9e44-0f6f43e92b04.png)
4. Use `redis-cli smembers t:feeds` again after a `PUT` method. The count should be the previous # you got - 1
5. Verify the feed has moved with `redis-cli smembers t:feeds:flagged`. There should be one lonely feed in there with the `feedId` used in the PUT method
6. Use `redis-cli smembers t:feeds` again after a `DELETE` method. The count should be back to your starting count.
7. Verify the feed has moved with `redis-cli smembers t:feeds:flagged`. The lonely feed should have joined its friends again
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
