### PR TITLE
Add cache-control headers for static Gatsby content.

### DIFF
--- a/nginx-production.conf
+++ b/nginx-production.conf
@@ -56,27 +56,6 @@ http {
     application/rss+xml
     application/atom_xml;
 
-  # Set default expiration times for different types of content
-  map $sent_http_content_type $expires {
-    # don't cache by default
-    default                         off;
-    # no cache for HTML files
-    text/html                       epoch;
-    "text/html; charset=utf-8"      epoch;
-    # cache CSS and JS as long as possible
-    text/css                        max;
-    application/javascript          max;
-    # cache all image types as long as possible
-    ~image/                         max;
-    # cache web fonts as long as possible
-    ~font/                          max;
-    ~application/vnd.ms-fontobject  max;
-    ~application/x-font-ttf         max;
-    ~application/x-font-woff        max;
-    ~application/font-woff          max;
-    ~application/font-woff2         max;
-  }
-
   server {
     listen 80 default_server;
     server_name _;
@@ -120,13 +99,39 @@ http {
     location ~ ^/(admin|user|health|auth) {
       proxy_cache_bypass 1;
       proxy_pass http://telescope_production:3000;
-
     }
 
     # Static content
     location / {
-      # Directory from which static content is served
+      # Directory from which we serve Gatsby's static content
       root /var/www/data;
+
+      # Specify cache behaviour, see docs: https://www.gatsbyjs.org/docs/caching.
+      # 1. Don't cache HTML
+      location ~* \.(?:html)$ {
+        expires epoch;
+        add_header Cache-Control "public, max-age=0";
+      }
+      # 2. Don't cache /page-data (including app-data.json)
+      location /page-data {
+        expires epoch;
+        add_header Cache-Control "public, max-age=0";
+      }
+      # 3. Don't cache the service worker /sw.js script, see:
+      location = /sw.js {
+        expires epoch;
+        add_header Cache-Control "public, max-age=0";
+      }
+      # 4. Files in icons/ and static/ can be cached forever
+      location  ~ ^/(static|icons) {
+        expires max;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+      }
+      # 5. Cache js and css forever
+      location ~* \.(?:js|css)$ {
+        expires max;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+      }
 
       # Try serving static content, and if not found continue with @proxy
       try_files $uri $uri/ @proxy;

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -56,27 +56,6 @@ http {
     application/rss+xml
     application/atom_xml;
 
-  # Set default expiration times for different types of content
-  map $sent_http_content_type $expires {
-    # don't cache by default
-    default                         off;
-    # no cache for HTML files
-    text/html                       epoch;
-    "text/html; charset=utf-8"      epoch;
-    # cache CSS and JS as long as possible
-    text/css                        max;
-    application/javascript          max;
-    # cache all image types as long as possible
-    ~image/                         max;
-    # cache web fonts as long as possible
-    ~font/                          max;
-    ~application/vnd.ms-fontobject  max;
-    ~application/x-font-ttf         max;
-    ~application/x-font-woff        max;
-    ~application/font-woff          max;
-    ~application/font-woff2         max;
-  }
-
   server {
     listen 80 default_server;
     server_name _;
@@ -124,8 +103,35 @@ http {
 
     # Static content
     location / {
-      # Directory from which static content is served
+      # Directory from which we serve Gatsby's static content
       root /var/www/data;
+
+      # Specify cache behaviour, see docs: https://www.gatsbyjs.org/docs/caching.
+      # 1. Don't cache HTML
+      location ~* \.(?:html)$ {
+        expires epoch;
+        add_header Cache-Control "public, max-age=0";
+      }
+      # 2. Don't cache /page-data (including app-data.json)
+      location /page-data {
+        expires epoch;
+        add_header Cache-Control "public, max-age=0";
+      }
+      # 3. Don't cache the service worker /sw.js script, see:
+      location = /sw.js {
+        expires epoch;
+        add_header Cache-Control "public, max-age=0";
+      }
+      # 4. Files in icons/ and static/ can be cached forever
+      location  ~ ^/(static|icons) {
+        expires max;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+      }
+      # 5. Cache js and css forever
+      location ~* \.(?:js|css)$ {
+        expires max;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+      }
 
       # Try serving static content, and if not found continue with @proxy
       try_files $uri $uri/ @proxy;


### PR DESCRIPTION
Co-authored-by calvinho125@gmail.com
Co-authored by jquilon-barrios@myseneca.ca

Building on the work from https://github.com/Seneca-CDOT/telescope/pull/1072#issuecomment-619329389, this tries again to add `cache-control` headers for the static assets we server via nginx.