### PR TITLE
Fixes #1077 added zIndex of 1100 to ScrollToTop

### DIFF
--- a/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
@@ -9,6 +9,7 @@ const useStyles = makeStyles((theme) => ({
     position: 'fixed',
     bottom: theme.spacing(2),
     right: theme.spacing(2),
+    zIndex: 1100,
   },
   anchor: {
     minHeight: '1px',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1077 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
- added zIndex of 1100 to ScrollToTop component. The ScrollToTop button will show on top of the Blog post header but underneath the side drawer when the side drawer is open.

https://material-ui.com/customization/z-index/

Before:
![1077_mobile](https://user-images.githubusercontent.com/36822198/80314463-a54cd280-87bf-11ea-889c-21b1fa6f212c.gif)

After:
![1077_mobile_fix](https://user-images.githubusercontent.com/36822198/80314511-dfb66f80-87bf-11ea-8f1f-c773e084ee95.gif)


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
