### PR TITLE
Add error handling, reporting to unsplash image download build step

### DIFF
--- a/src/frontend/gatsby-node.js
+++ b/src/frontend/gatsby-node.js
@@ -2,12 +2,21 @@ const path = require(`path`);
 const fs = require('fs').promises;
 const fetch = require('node-fetch');
 
+/**
+ * Download the image at `url` and write to `filename`
+ * @param {String} url - the URL to the image
+ * @param {String} filename - the local filename to use when writing
+ */
 async function downloadPhoto(url, filename) {
   const res = await fetch(url);
   const buf = await res.buffer();
   await fs.writeFile(filename, buf);
 }
 
+/**
+ * Check if the given filename is already available locally
+ * @param {String} filename - filename for image
+ */
 async function shouldDownload(filename) {
   try {
     await fs.access(filename, fs.FS_OK);
@@ -19,26 +28,36 @@ async function shouldDownload(filename) {
   }
 }
 
-exports.onPreInit = async function () {
-  const clientId = process.env.UNSPLASH_CLIENT_ID || '';
-
-  if (!clientId) {
-    return;
-  }
-
-  const collectionId = process.env.UNSPLASH_COLLECTION_ID || '9975402';
+/**
+ * Download all Unsplash.com images defined in the given collection
+ * @param {Object} reporter - Gatsby reporter
+ * @param {String} clientId - Unsplash.com client id
+ * @param {String} collectionId - Unsplash.com collection id
+ */
+async function downloadUnsplashCollection(reporter, clientId, collectionId) {
   const frontEndPath = path.join('src', 'images', 'backgrounds');
 
   // Get the list of photos from our Unsplash.com collection
-  const res = await fetch(
-    `https://api.unsplash.com/collections/${collectionId}/photos/?client_id=${clientId}&per_page=100`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  let photos;
+  try {
+    const res = await fetch(
+      `https://api.unsplash.com/collections/${collectionId}/photos/?client_id=${clientId}&per_page=100`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    photos = await res.json();
+
+    // We expect Unsplash to a return an array with photo info. Bail if it doesn't.
+    if (!Array.isArray(photos)) {
+      throw new Error('received unexpected photo data from Unsplash.com');
     }
-  );
-  const photos = await res.json();
+  } catch (err) {
+    reporter.error('Unable to download Unsplash.com image collection metadata', err);
+    return;
+  }
 
   // Process this list, since we only need to download photos we don't already have locally
   const downloads = photos
@@ -49,7 +68,22 @@ exports.onPreInit = async function () {
     .filter(shouldDownload);
 
   // Download any photos we don't have
-  await Promise.all(downloads.map(({ url, filename }) => downloadPhoto(url, filename)));
+  try {
+    await Promise.all(downloads.map(({ url, filename }) => downloadPhoto(url, filename)));
+  } catch (err) {
+    reporter.error('Error Unable to download Unsplash.com image(s)', err);
+  }
+}
+
+exports.onPreInit = async function ({ reporter }) {
+  const clientId = process.env.UNSPLASH_CLIENT_ID;
+  const collectionId = process.env.UNSPLASH_COLLECTION_ID || '9975402';
+  if (!clientId) {
+    reporter.info('No Unsplash Client ID specified in environment, skipping download');
+    return;
+  }
+
+  await downloadUnsplashCollection(reporter, clientId, collectionId);
 };
 
 exports.createPages = async ({ actions, graphql, reporter }) => {


### PR DESCRIPTION
I added some error handling and build reporting for the Unsplash image download logic in our Gatsby build.  We failed a build last night, and it crashes, so I wanted to get a fix in while I still remembered.

I've also refactored the code a bit to make it more readable.