### PR TITLE
Use a specific version of redis for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
       redis-cli info
     else
       # Install Redis
-      choco install redis-64 -v
+      choco install redis-64 --version 3.0.503 -v
       redis-server --service-install
       redis-server --service-start
       redis-cli info


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The new version of `redis` for windows on `chocolatey` causes `Travis` to fail. Since the project is [`no longer maintained`](https://chocolatey.org/packages/redis-64/), this PR changes our `Travis` config file so it now installs the previous version (the one that used to work right before `Travis` disappeared).

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
