### PR TITLE
Closes #992: Combine spinners from #985 and #937

### DIFF
--- a/src/frontend/src/pages/index.js
+++ b/src/frontend/src/pages/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { CircularProgress, Button, Grid } from '@material-ui/core';
+import { Button, Grid } from '@material-ui/core';
 import parse from 'parse-link-header';
 
 import PageBase from './PageBase';
@@ -9,6 +9,7 @@ import Posts from '../components/Posts';
 import ScrollToTop from '../components/ScrollToTop';
 import useSiteMetaData from '../hooks/use-site-metadata';
 import CustomizedSnackBar from '../components/SnackBar';
+import Spinner from '../components/Spinner';
 
 const useStyles = makeStyles((theme) => ({
   content: {
@@ -156,7 +157,7 @@ export default function IndexPage() {
       return 'No more posts.  Your turn! Add your feed...';
     }
     if (loading) {
-      return <CircularProgress color="secondary" size={24} />;
+      return <Spinner />;
     }
     return 'Load More Posts';
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Closes #992 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Description

This replaces the `Material-UI` spinner component used in `index.js` with [the one created for our search page](https://github.com/Seneca-CDOT/telescope/blob/master/src/frontend/src/components/Spinner/Spinner.jsx).

![spinner](https://user-images.githubusercontent.com/23108901/94213792-c831fe80-fea5-11ea-9702-794470f8a557.png)
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
