### PR TITLE
Closes #981: Make "Add Yours!" link to /myfeeds

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import useSiteMetadata from '../../hooks/use-site-metadata';
 import DynamicBackgroundContainer from '../DynamicBackgroundContainer';
-import { Fab, Grid, Typography } from '@material-ui/core';
+import { Fab, Grid, Typography, Link } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   h1: {
@@ -94,6 +94,9 @@ const useStyles = makeStyles((theme) => ({
       bottom: theme.spacing(18),
     },
   },
+  addYours: {
+    color: 'white',
+  },
 }));
 
 function ScrollDown(props) {
@@ -152,7 +155,15 @@ function RetrieveBannerDynamicAssets() {
       >
         <DynamicBackgroundContainer />
         <Typography variant="caption" className={classes.stats}>
-          This year {stats.authors} of us have written {stats.words} words and counting. Add yours!
+          This year {stats.authors} of us have written {stats.words} words and counting.{' '}
+          <Link
+            className={classes.addYours}
+            href={`${telescopeUrl}/myfeeds`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Add yours!
+          </Link>
         </Typography>
       </div>
     );

--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -96,6 +96,7 @@ const useStyles = makeStyles((theme) => ({
   },
   addYours: {
     color: 'white',
+    textDecorationLine: 'underline',
   },
 }));
 
@@ -156,12 +157,7 @@ function RetrieveBannerDynamicAssets() {
         <DynamicBackgroundContainer />
         <Typography variant="caption" className={classes.stats}>
           This year {stats.authors} of us have written {stats.words} words and counting.{' '}
-          <Link
-            className={classes.addYours}
-            href={`${telescopeUrl}/myfeeds`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <Link className={classes.addYours} href={`${telescopeUrl}/myfeeds`}>
             Add yours!
           </Link>
         </Typography>


### PR DESCRIPTION
Added the 'Add yours' link onto the banner which redirects to /myfeeds

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #981 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
If you are already signed in... when you click on 'Add yours' on the banner, a new tab opens up linking into /myfeeds.
However, If you are not signed in, a new tab opens directing you to the login page to sign in.

If there is anything I need to to fix or add, let me know! :)


<!-- Please add a detailed description of what this PR does and why it is needed -->

![image](https://user-images.githubusercontent.com/35276477/94373006-41ad3500-00d0-11eb-9b18-126dca3a5dfa.png)



## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
