### PR TITLE
Fixes #1122: Author Link + Date of Last Post Link for Search feature doesn't work

### DIFF
--- a/src/frontend/src/components/AuthorResult/AuthorResult.jsx
+++ b/src/frontend/src/components/AuthorResult/AuthorResult.jsx
@@ -53,11 +53,15 @@ const useStyles = makeStyles((theme) => ({
 
 export default function AuthorResult(props) {
   const classes = useStyles();
-  const { author } = props;
+  const { author, link } = props;
   const { postDate, title, postLink } = props.post;
 
   const handleLatestPostClick = () => {
     window.open(postLink);
+  };
+
+  const handleLinkClick = () => {
+    window.open(link);
   };
 
   return (
@@ -74,7 +78,7 @@ export default function AuthorResult(props) {
                 aria-labelledby="nested-list-subheader"
                 className={classes.root}
               >
-                <ListItem button className={classes.infoLine}>
+                <ListItem button className={classes.infoLine} onClick={handleLinkClick}>
                   <ListItemIcon className={classes.icons}>
                     <PermContactCalendarIcon />
                   </ListItemIcon>

--- a/src/frontend/src/components/AuthorResult/AuthorResult.jsx
+++ b/src/frontend/src/components/AuthorResult/AuthorResult.jsx
@@ -84,7 +84,7 @@ export default function AuthorResult(props) {
                   </ListItemIcon>
                   <ListItemText className={classes.font} primary={`Author: ${author}`} />
                 </ListItem>
-                <ListItem button className={classes.infoLine}>
+                <ListItem disabled className={classes.infoLine}>
                   <ListItemIcon className={classes.icons}>
                     <EventIcon />
                   </ListItemIcon>

--- a/src/frontend/src/components/SearchPage/SearchPage.jsx
+++ b/src/frontend/src/components/SearchPage/SearchPage.jsx
@@ -35,6 +35,7 @@ const SearchPage = () => {
         title
         published
         url
+        link
         feed {
           id
           author
@@ -63,6 +64,7 @@ const SearchPage = () => {
           return {
             id: result.feed.id,
             author: result.feed.author,
+            link: result.feed.link,
             // The post will contain information about their most recent post to be used for AuthorResult component
             post: {
               title: result.title,
@@ -145,7 +147,12 @@ const SearchPage = () => {
     //  for each with feed guid as key
     if (results.type === 'author') {
       return results.searchResults.map((result) => (
-        <AuthorResult key={result.id} author={result.author} post={result.post} />
+        <AuthorResult
+          key={result.id}
+          author={result.author}
+          link={result.link}
+          post={result.post}
+        />
       ));
     }
     // If result type is post return Posts component for each result

--- a/src/frontend/src/components/SearchPage/SearchPage.jsx
+++ b/src/frontend/src/components/SearchPage/SearchPage.jsx
@@ -35,10 +35,10 @@ const SearchPage = () => {
         title
         published
         url
-        link
         feed {
           id
           author
+          link
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
Fixes #1122 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
I disabled the Date of Last Post <ListItem> and provided a url for the Author <ListItem> in Author search results. When users click on it Author: (Name Here), they will be redirected to the author's blog. Date of Last post should now be disabled

To Test:
Use the Vercel Preview, try searching for your own name in Author, clicking on Author should take you to their open-source tagged url. Date of last post should not be clickable

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
