### PR TITLE
Fix autodeployment script after merging #1142

### DIFF
--- a/tools/autodeployment/deploy.sh
+++ b/tools/autodeployment/deploy.sh
@@ -5,19 +5,6 @@ set -x
 
 DOCKER_FILE=docker-compose-production.yml
 
-# Set NGINX FILE + ENV_FILE
-if [ $1 = 'production' ]
-then
-  ENV_FILE=env.production
-elif [ $1 = 'staging' ]
-then
-  sed -i 's/telescope\./dev\.telescope\./g' ../telescope/nginx.conf
-  ENV_FILE=env.staging
-else
-  echo $1 is not a valid argument. Please use either production or staging.
-  exit 1
-fi
-
 # Shutdown
 cd ../telescope
 
@@ -36,6 +23,19 @@ git clone https://github.com/Seneca-CDOT/telescope.git --depth=1
 
 # Deploy
 cd telescope/
+
+# Set NGINX FILE + ENV_FILE
+if [ $1 = 'production' ]
+then
+  ENV_FILE=env.production
+elif [ $1 = 'staging' ]
+then
+  sed -i 's/telescope\./dev\.telescope\./g' nginx.conf
+  ENV_FILE=env.staging
+else
+  echo $1 is not a valid argument. Please use either production or staging.
+  exit 1
+fi
 
 # Takes the second argument the name of the env file to be used
 cp $ENV_FILE .env


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

While monitoring the autodeployment server during #1142 merge, I saw that the [deploy.sh](https://github.com/Seneca-CDOT/telescope/blob/master/tools/autodeployment/deploy.sh) script failed because it was trying to access the telescope folder before cloning the repo, causing the whole process to crash. This fix makes sure the telescope repo is cloned before altering config files and/or launching telescope.
