### PR TITLE
Fixes #1079: Align FAB button right on mobile

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import { Fab, Grid, Typography, Link } from '@material-ui/core';
 import useSiteMetadata from '../../hooks/use-site-metadata';
 import DynamicBackgroundContainer from '../DynamicBackgroundContainer';
-import { Fab, Grid, Typography, Link } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   h1: {
@@ -89,9 +89,9 @@ const useStyles = makeStyles((theme) => ({
     position: 'relative',
     bottom: theme.spacing(20),
     zIndex: 300,
+    margin: '0 auto',
     [theme.breakpoints.between('xs', 'sm')]: {
-      right: theme.spacing(4),
-      left: '80%',
+      left: '55%',
       bottom: theme.spacing(18),
     },
   },
@@ -219,7 +219,7 @@ export default function Banner() {
       <Grid
         container
         spacing={0}
-        direction="column"
+        direction="row"
         alignItems="center"
         justify="center"
         className={classes.container}

--- a/src/frontend/src/components/DynamicBackgroundContainer.jsx
+++ b/src/frontend/src/components/DynamicBackgroundContainer.jsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundSize: 'cover',
     transition: 'opacity 1s ease-in-out',
     position: 'absolute',
-    height: `calc(100vh - ${theme.spacing(8)}px)`,
+    height: '93vh',
     width: '100%',
     opacity: '.45',
     top: 0,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
Fixes #1079 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

Aligns the scroll down button on the right and removes the empty space at the bottom of image

No changes to large screens:
![image](https://user-images.githubusercontent.com/49992710/95027113-20b28a00-0664-11eb-8977-afa5a444f1ff.png)

Mobile view:
![image](https://user-images.githubusercontent.com/49992710/95027170-8141c700-0664-11eb-910b-acf1dc18440c.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
