### PR TITLE
Fixes #1088: Add Icons for Admin to delete/flag a feed

### DIFF
--- a/src/frontend/src/components/AdminButtons/AdminButtons.jsx
+++ b/src/frontend/src/components/AdminButtons/AdminButtons.jsx
@@ -1,0 +1,40 @@
+import React, { useContext } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { IconButton } from '@material-ui/core';
+import FlagIcon from '@material-ui/icons/Flag';
+import DeleteIcon from '@material-ui/icons/Delete';
+import { UserStateContext } from '../../contexts/User/UserContext';
+
+const useStyles = makeStyles(() => ({
+  iconDiv: {
+    float: 'right',
+  },
+  iconSpan: {
+    paddingLeft: '10px',
+    paddingRight: '10px',
+  },
+}));
+
+function AdminButtons() {
+  const classes = useStyles();
+  const user = useContext(UserStateContext);
+
+  return (
+    user.isAdmin && (
+      <div className={classes.iconDiv}>
+        <span className={classes.iconSpan}>
+          <IconButton size="small">
+            <FlagIcon fontSize="large" />
+          </IconButton>
+        </span>
+        <span className={classes.iconSpan}>
+          <IconButton size="small">
+            <DeleteIcon fontSize="large" />
+          </IconButton>
+        </span>
+      </div>
+    )
+  );
+}
+
+export default AdminButtons;

--- a/src/frontend/src/components/AdminButtons/index.js
+++ b/src/frontend/src/components/AdminButtons/index.js
@@ -1,0 +1,3 @@
+import AdminButtons from './AdminButtons.jsx';
+
+export default AdminButtons;

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -5,6 +5,7 @@ import useSWR from 'swr';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Grid, Typography, ListSubheader } from '@material-ui/core';
 import './telescope-post-content.css';
+import AdminButtons from '../AdminButtons';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -95,6 +96,7 @@ const Post = ({ postUrl }) => {
   return (
     <Box className={classes.root} boxShadow={2}>
       <ListSubheader className={classes.header}>
+        <AdminButtons />
         <Typography variant="h1" title={post.title} id={post.id} className={classes.title}>
           {post.title}
         </Typography>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1088
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Not sure if wiring up the buttons is part of this PR, I had use inline styling for the icons as I was not able to change the icon size or colour through the classes way. The PR can be checked in Vercel Deployment (I think). Otherwise it will require a running local backend + `npm run build` and logging in with user1 // user1pass. `npm run develop` will not work for this.

EDIT: I'm going to split this up into two parts, one for the icons and the next one for functionality(wiring up buttons + displaying a confirmation/popup message)

When not logged in / user is not admin
![image](https://user-images.githubusercontent.com/18711727/96509782-8f7a1080-122a-11eb-8de8-51ab934042ab.png)

When logged in / user is admin
![image](https://user-images.githubusercontent.com/18711727/96509852-a7519480-122a-11eb-958c-b563fa79cf70.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
