### PR TITLE
Fixes #1155: Route /myfeeds goes to blank page with user not logged in

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
 import { makeStyles } from '@material-ui/core/styles';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import { Fab, Grid, Typography, Link } from '@material-ui/core';
+import { Fab, Grid, Typography } from '@material-ui/core';
 import useSiteMetadata from '../../hooks/use-site-metadata';
 import DynamicBackgroundContainer from '../DynamicBackgroundContainer';
 
@@ -158,7 +159,7 @@ function RetrieveBannerDynamicAssets() {
         <DynamicBackgroundContainer />
         <Typography variant="caption" className={classes.stats}>
           This year {stats.authors} of us have written {stats.words} words and counting.{' '}
-          <Link className={classes.addYours} href={`${telescopeUrl}/myfeeds`}>
+          <Link className={classes.addYours} to="/myfeeds">
             Add yours!
           </Link>
         </Typography>

--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { navigate } from 'gatsby';
 import { Box, Card, Container, Grid, IconButton, Typography } from '@material-ui/core';
 import { AccountCircle, AddCircle, RssFeed } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
@@ -33,7 +34,7 @@ export default function MyFeeds() {
   const { telescopeUrl } = useSiteMetadata();
 
   useEffect(() => {
-    if (user.name === '') window.location.href = `${telescopeUrl}/auth/login`;
+    if (user.name === '') navigate(`${telescopeUrl}/auth/login`);
     setNewFeedAuthor(user.name);
     ValidatorForm.addValidationRule('isUrl', (value) => !!isWebUri(value));
     return ValidatorForm.removeValidationRule.bind('isUrl');

--- a/src/frontend/src/pages/myfeeds.js
+++ b/src/frontend/src/pages/myfeeds.js
@@ -33,6 +33,7 @@ export default function MyFeeds() {
   const { telescopeUrl } = useSiteMetadata();
 
   useEffect(() => {
+    if (user.name === '') window.location.href = `${telescopeUrl}/auth/login`;
     setNewFeedAuthor(user.name);
     ValidatorForm.addValidationRule('isUrl', (value) => !!isWebUri(value));
     return ValidatorForm.removeValidationRule.bind('isUrl');


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #1155 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This change makes sure that `Add yours` takes users to the login page when the user is not logged in.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
