### PR TITLE
adds: prebuild (blue/green) style deployment script

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -28,15 +28,17 @@ redis-server
 ```
 
 #### Windows:
-There are two methods to install Redis on Windows. We strongly recommend the first approach. 
 
-##### Option 1: Using [WSL2 (Windows Subsystem Linux)](https://docs.microsoft.com/en-us/windows/wsl/about)   
+There are two methods to install Redis on Windows. We strongly recommend the first approach.
+
+##### Option 1: Using [WSL2 (Windows Subsystem Linux)](https://docs.microsoft.com/en-us/windows/wsl/about)
+
 1. Follow Microsoft WSL2 [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to complete the installation
 2. Follow Redis [installation guide](https://redis.io/topics/quickstart#installing-redis) to install Redis
-3. Suggest to install [Windows Terminal](https://docs.microsoft.com/en-us/windows/wsl/install-win10#install-windows-terminal-optional), it facilitates you to switch directories between WSL2 Ubuntu bash and Windows drive 
-
+3. Suggest to install [Windows Terminal](https://docs.microsoft.com/en-us/windows/wsl/install-win10#install-windows-terminal-optional), it facilitates you to switch directories between WSL2 Ubuntu bash and Windows drive
 
 ##### Option 2: Using [Chocolatey package manager](https://chocolatey.org/) to install Redis on Windows
+
 To get Chocolatey, simply follow this [guide](https://chocolatey.org/install) and run the following commands:
 
 1. To install Redis: `choco install redis-64 -v`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
fixes #1130 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Adds pre-building of Docker containers prior to spinning down environment, also doesn't destroy services so that we can switch within seconds to either environment. `Dockerfile` is updated to now leverage multiple containers for each dependency (frontend, backend) so that work between the two doesn't trigger a complete npm install chain. It's the small optimizations. 

*TODO*: Integrate into `deploy.sh` logic

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


## Script Output Example
```bash
Successfully built 7577b012e84b
Successfully tagged green_telescope:latest
Waiting...
Stopping blue Container
Stopping telescope_production ... done
Stopping blue_redis_1         ... done
Stopping blue_elasticsearch_1 ... done
Removing orphan container "blue_certbot_1"
Removing orphan container "blue_logrotate_1"
Removing orphan container "blue_nginx_1"
Removing telescope_production ... done
Removing blue_redis_1         ... done
Removing blue_elasticsearch_1 ... done
Removing network blue_default
Starting green Container
Creating network "green_default" with the default driver
Creating green_redis_1         ... done
Creating green_elasticsearch_1 ... done
Creating green_logrotate_1     ... done
Creating green_certbot_1       ... done
Creating telescope_production  ... done
Creating green_nginx_1         ... done
bash