### PR TITLE
Fixes #1199 adjusts svg icon sizes in post content so they're not 100% width

### DIFF
--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -35,6 +35,12 @@
   vertical-align: text-top;
 }
 
+.telescope-post-content img[src*='svg'] {
+  width: 2rem;
+  padding: 0;
+  vertical-align: center;
+}
+
 .telescope-post-content h1 {
   font-size: 2em;
   max-width: 670px;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1199 adjusts svg icon sizes in post content so they're not taking up 100% width

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Before
![Screenshot 2020-10-19 151757](https://user-images.githubusercontent.com/36822198/96501854-fc87a900-121e-11eb-8fb3-21e93cfd65ff.png)

## After
![Screenshot 2020-10-19 151704](https://user-images.githubusercontent.com/36822198/96501857-fe516c80-121e-11eb-8241-ddbf51060da2.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
