### PR TITLE
Fixes #1172 reduce tracking pixel size back to 1px 1px

### DIFF
--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -41,6 +41,12 @@
   vertical-align: center;
 }
 
+.telescope-post-content img[src*='https://medium.com/_/stat']
+{
+  width: 1px;
+  height: 1px;
+}
+
 .telescope-post-content h1 {
   font-size: 2em;
   max-width: 670px;

--- a/src/frontend/src/components/Post/telescope-post-content.css
+++ b/src/frontend/src/components/Post/telescope-post-content.css
@@ -41,8 +41,7 @@
   vertical-align: center;
 }
 
-.telescope-post-content img[src*='https://medium.com/_/stat']
-{
+.telescope-post-content img[src*='medium.com/_/stat'] {
   width: 1px;
   height: 1px;
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1172 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR reduces the size of the tracking pixels found in Medium.com blogs to 1px 1px

## Before
![Screenshot 2020-10-20 122822](https://user-images.githubusercontent.com/36822198/96616739-bb4fd180-12d0-11eb-8be1-f07da08636d6.png)

## After
![Screenshot 2020-10-20 122919](https://user-images.githubusercontent.com/36822198/96616753-bf7bef00-12d0-11eb-83b7-8ae9335a6fa1.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
