### PR TITLE
Fixes #1203: Added Giphy as an iframe host and added test

### DIFF
--- a/src/backend/utils/html/sanitize.js
+++ b/src/backend/utils/html/sanitize.js
@@ -46,6 +46,6 @@ module.exports = function (dirty) {
       img: ['src'],
       a: ['href'],
     },
-    allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com'],
+    allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com', 'giphy.com'],
   });
 };

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -51,6 +51,11 @@ describe('Sanitize HTML', () => {
     expect(data).toBe('<iframe src="https://player.vimeo.com/video/395927811"></iframe>');
   });
 
+  test('<iframe> tag to a giphy embed should not get removed', () => {
+    const data = sanitizeHTML('<iframe src="https://giphy.com/embed/3osxYc2axjCJNsCXyE"></iframe>');
+    expect(data).toBe('<iframe src="https://giphy.com/embed/3osxYc2axjCJNsCXyE"></iframe>');
+  });
+
   test('<pre> with inline style, sanitize strips inline style', () => {
     const data = sanitizeHTML('<pre class="brush: plain; title: ; notranslate">Hello World</pre>');
     expect(data).toBe('<pre>Hello World</pre>');


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixed #1203 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Added the `giphy.com` host to list of host for iframe gifs and added the test for it. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
