### PR TITLE
Add cached wiki feed list

### DIFF
--- a/src/frontend/static/cached-wiki-feed-list.html
+++ b/src/frontend/static/cached-wiki-feed-list.html
@@ -1,0 +1,3181 @@
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <!-- base href="https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List" -->
+  </head>
+  <body>
+    <div>
+      <pre>
+################# Failing Feeds Commented Out [Start] #################
+
+#Feed excluded due to getaddrinfo ENOTFOUND s-aleinikov.blog.ca s-aleinikov.blog.ca:80
+#[http://s-aleinikov.blog.ca/feed/atom/posts/]
+#name=Sergey Aleinikov
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND ejtorre.blog.ca ejtorre.blog.ca:80
+#[http://ejtorre.blog.ca/feed/rss2/posts/]
+#name=Eugene Torre
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND rickeyre.ca rickeyre.ca:80
+#[http://rickeyre.ca/open-source-feed.xml]
+#name=Rick Eyre
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://tea.cesaroliveira.net/archives/tag/seneca/feed]
+#name=Cesar Oliveira
+
+#Feed excluded due to getaddrinfo ENOTFOUND blog.marcussaad.com blog.marcussaad.com:80
+#[http://blog.marcussaad.com/?feed=rss2&amp;amp;lang=en]
+#name=Marcus Saad
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND matthewtorrance.com matthewtorrance.com:80
+#[http://matthewtorrance.com/category/osd/feed/]
+#name=Matthew Torrance
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND hesam-chobanlou.com hesam-chobanlou.com:80
+#[http://hesam-chobanlou.com/feed/atom.php]
+#name=Hesam Chobanlou
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://zadkielm.blogspot.com/feeds/posts/default/-/open%20source]
+#name=Ezadkiel Marbella
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://travisrawn.blogspot.com/feeds/posts/default]
+#name=Travis Rawn
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://dev-blog.zerogin.com/category/opensource/feed/]
+#name=Tom Wisniewski (t0mmyw)
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://peter.sykokillers.com/category/open-source/feed/]
+#name=Peter Chan
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND http http:80
+#[http://http://stephenruthland.wordpress.com/feed/]
+#name=Stephen Ruthland
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND main.justinflowers.ca main.justinflowers.ca:80
+#[http://main.justinflowers.ca/web/wordpress/?cat=2&amp;amp;feed=rss2]
+#name=Justin Flowers
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND http http:80
+#[http://http://hhashimi3.wordpress.com/feed/]
+#name=Hamid Hashimi
+
+
+#Feed excluded due to getaddrinfo ENOTFOUND dps909.defilippis.ca dps909.defilippis.ca:443
+#[https://dps909.defilippis.ca/index.php/feed/]
+#name=Steven De Filippis
+
+
+[https://jadach1201231188.wordpress.com/feed/]
+name=Jacob Adach
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://farhadnorouzi.blogspot.com/feeds/posts/default]
+#name=Farhad Norouzi
+
+
+#Feed excluded due to Request failed with status code 403
+#[http://blog.leapproject.ca/feed/]
+#name=LEAP Project
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://techtalkwithaaron.blogspot.com/feeds/posts/default/Open%20Source]
+#name=Aaron Scott
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://msousa3.blogspot.com/feeds/posts/default]
+#name=Michael Sousa
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://sjhan5.blogspot.ca/feeds/posts/default/]
+#name=Suk-Joong Han
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://aaronrey15.blogspot.com/feeds/posts/default/-/Seneca]
+#name=Aaron Chan
+
+
+#Feed excluded due to Request failed with status code 503
+#[http://www.danepstein.ca/category/open-source/feed]
+#name=Dan Epstein
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://amartinencosbr600.blogspot.com/feeds/posts/default]
+#name=Andrei Martinenco
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://sbr600.tumblr.com/rss]
+#name=Daniel Delidjakov
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://harjinderv.tumblr.com/tagged/Open_Source/rss]
+#name=Harjinder Virdi
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://www.bpcoding.com/blog/category/spo/]
+#name=Bruno Pereira
+
+
+#Feed excluded due to Hostname/IP does not match certificate's altnames: Host: assmith2017_.blogspot.ca. is not in the cert's altnames: DNS:*.googleusercontent.com, DNS:*.apps.googleusercontent.com, DNS:*.appspot.com.storage.googleapis.com, DNS:*.audiobook-additional-material-staging.googleusercontent.com, DNS:*.audiobook-additional-material.googleusercontent.com, DNS:*.blogspot.com, DNS:*.bp.blogspot.com, DNS:*.commondatastorage.googleapis.com, DNS:*.content-storage-download.googleapis.com, DNS:*.content-storage-upload.googleapis.com, DNS:*.content-storage.googleapis.com, DNS:*.doubleclickusercontent.com, DNS:*.ggpht.com, DNS:*.googledrive.com, DNS:*.googlesyndication.com, DNS:*.googleweblight.com, DNS:*.local.amp4mail.googleusercontent.com, DNS:*.playground-internal.amp4mail.googleusercontent.com, DNS:*.playground.amp4mail.googleusercontent.com, DNS:*.prod.amp4mail.googleusercontent.com, DNS:*.safenup.googleusercontent.com, DNS:*.sandbox.googleusercontent.com, DNS:*.storage-download.googleapis.com, DNS:*.storage-upload.googleapis.com, DNS:*.storage.googleapis.com, DNS:*.storage.select.googleapis.com, DNS:*.translate.goog, DNS:blogspot.com, DNS:bp.blogspot.com, DNS:commondatastorage.googleapis.com, DNS:doubleclickusercontent.com, DNS:ggpht.com, DNS:googledrive.com, DNS:googleusercontent.com, DNS:googleweblight.com, DNS:manifest.lh3.googleusercontent.com, DNS:manifest.lh3.photos.google.com, DNS:static.panoramio.com.storage.googleapis.com, DNS:storage.googleapis.com, DNS:storage.select.googleapis.com, DNS:translate.goog, DNS:unfiltered.news
+#[https://assmith2017_.blogspot.ca/feeds/posts/default]
+#name=Azusa Shimazaki
+
+
+#Feed excluded due to unable to verify the first certificate
+#[http://hcoelho.com/blog/feed]
+#name=Henrique Coelho
+
+
+#Feed excluded due to Request failed with status code 404
+#[https://jalemansite.wordpress.com/category/feed/]
+#name=Johann Aleman
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://sinomai.wordpress.com/category/planet-cdot/feed/]
+#name=Matt Jang
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://hzahoori.wordpress.com/category/open-source/feed]
+#name=Habib Zahoori
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://vprasanth.com/blog/archives/category/spo600-2/feed]
+#name=Prasanth Vaaheeswaran
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://rlawrence5.wordpress.com/feed/]
+#name=Ryan Lawrence
+
+
+#Feed excluded due to Request failed with status code 404
+#[https://apspo600.blogspot.com/feed/posts/default/]
+#name=Atilla Puskas
+
+
+#Feed excluded due to Request failed with status code 410
+#[https://bapetov.wordpress.com/category/opensourcedps909/feed]
+#name=Bakytzhan Apetov
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://adsantokhi.wordpress.com/category/open-source/feed]
+#name=Anil Santokhi
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://rawkamatic.github.io/opensourcefeed]
+#name=Hunter Jansen
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://ayufidin.blogspot.ca/feeds/posts/default]
+#name=Alon Yufidin
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://kevinpaiva.com/category/spo600/feed/]
+#name=Kevin Manuel Paiva
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://dboddie46.wordpress.com/category/SBR600A/feed/]
+#name=Derrick Boddie
+
+
+#Feed excluded due to Request failed with status code 404
+#[http://liandrew.ca/feed.opensource.xml]
+#name=Andrew Li
+
+
+#Feed excluded due to Client network socket disconnected before secure TLS connection was established
+#[https://fahadkarar1.wordpress.com/category/spo600/feed/]
+#name=Fahad Karar
+
+
+#Feed excluded due to Client network socket disconnected before secure TLS connection was established
+#[http://jgoguette.wordpress.com/category/open-source/feed]
+#name=Jerry Goguette
+
+
+#Feed excluded due to connect ECONNREFUSED 104.200.30.7:80
+#[http://dokidoki.duckdns.org/tag/polished/rss/]
+#name=Kenny Nguyen
+
+
+#Feed excluded due to Client network socket disconnected before secure TLS connection was established
+#[http://tjduavis.wordpress.com/category/open-source/feed/]
+#name=Timothy Duavis
+
+
+#Feed excluded due to Client network socket disconnected before secure TLS connection was established
+#[http://selmys.wordpress.com/category/opensource/feed]
+#name=John Selmys
+
+
+#Feed excluded due to Request failed with status code 410
+#[http://cldenobrega.wordpress.com/category/open-source/feed/]
+#name=Crystal de Nobrega (cldenobrega)
+
+
+#Feed excluded due to Request failed with status code 404
+#[https://www.jielselmani.me/blog?category=Open+Source&amp;amp;format=rss]
+#name=Jiel Selmani
+
+
+#Feed excluded due to Request failed with status code 410
+#[https://naperkovskiy.wordpress.com/feed/]
+#name=Igor Naperkovskiy
+
+
+#Feed excluded due to timeout of 10000ms exceeded
+#[http://belligero.org/index.php?option=com_content&amp;amp;view=section&amp;amp;id=1&amp;amp;format=feed&amp;amp;type=rss]
+#name=Jason Tarka
+
+
+#Feed excluded due to timeout of 10000ms exceeded
+#[http://stani.ca/?feed=rss2&amp;amp;cat=3]
+#name=Robert Stanica
+
+################# Failing Feeds Commented Out [End] #################
+
+
+##### pre-2020-start #######
+
+[http://joy3van.blogspot.com/feeds/posts/default/-/Open-Source?alt=rss]
+name=Yifan Zhao
+
+[https://damontui.blogspot.com/feeds/posts/default?alt=rss]
+name=Jianpeng Zhang
+
+[https://dev.to/feed/henryzerocool/]
+name=Henry Nguyen
+
+[https://danielsirkovich.blogspot.com/feeds/posts/default?alt=rss]
+name=Daniel Sirkovich
+
+[https://medium.com/feed/@@akakakak668]
+name=Ryeoeul Ko
+
+[https://abdulosd.blogspot.com/feeds/posts/default?alt=rss]
+name=Abdul Abdi
+
+[http://palak-chawla.blogspot.com/feeds/posts/default?alt=rss]
+name=Palak Chawla
+
+[http://zjjiang2.blogspot.com/feeds/posts/default/-/categorylabel?alt=rss]
+name=ZongJin (Jason) Jiang
+
+[https://dev.to/feed/phast184]
+name=Thanh Tien Phat Nguyen
+
+[https://hyunjijanelee.blogspot.com/feeds/posts/default/-/Open-Source?alt=rss]
+name=Hyunji Lee
+
+[https://osdnathanp.wordpress.com/feed/]
+name=Nathan Pang
+
+[https://medium.com/feed/@random4900]
+name=Alexi Joseph
+
+[https://medium.com/feed/@danishali_mussa]
+name=Danish Mussa
+
+[https://www.abuzayed.ca/my-blog/osd600/category/open-source/feed/]
+name=Abu Zayed Kazi
+
+[https://joelazwaros.blogspot.com/feeds/posts/default?alt=rss]
+name=Joel Azwar
+
+[https://mintaedotblog.wordpress.com/category/open-source/feed/]
+name=Mintae Kim
+
+[https://dev.to/feed/fluentinstroll]
+name=Raymond Rambo
+
+[http://weihuangosd.blogspot.com/feeds/posts/default/-/categorylabel?alt=rss]
+name=Wei Huang
+
+[https://sostellajung.blogspot.com/feeds/posts/default/-/openSource?alt=rss]
+name=Stella Jung
+
+[https://nesabyte.wordpress.com/feed/]
+name=Nesa Bertanico
+
+[https://tjstavern24697521.wordpress.com/feed]
+name=TJ LeBlanc
+
+[https://xingpancanada.blogspot.com/feeds/posts/default/-/open%20source?alt=rss]
+name=Xing Pan
+
+[https://dev.to/feed/slaterslater/]
+name=Anthony Slater
+
+[https://medium.com/feed/@roycedev]
+name=Royce Ayroso-Ong
+
+[https://dev.to/feed/yuanleemidori]
+name=Yuan-Hsi Lee
+
+[https://medium.com/feed/@moho472]
+name=Mohammed Ahmed
+
+[https://badalsarkar.ca/blog-opensource/feed.xml]
+name=Badal Sarkar
+
+[https://dev.to/feed/bpan2]
+name=Bing Pan
+
+[https://ryudeveloper.wordpress.com/category/open-source/feed/]
+name=Roger Yu
+
+[https://abhaseen.github.io/feed.xml]
+name=Andre Bhaseen
+
+[https://kmchan12.wordpress.com/category/open-source/feed/]
+name=Kam Chan
+
+[https://dev.to/feed/isabellaliu77/#opensource]
+name=Isabella Liu
+
+[http://gonewiththewind1982.blogspot.com/feeds/posts/default/-/Open%20Source?alt=rss]
+name=Leon Li
+
+[http://markham2020.blogspot.com/feeds/posts/default/-/open%20source?alt=rss]
+name=Hongbin Li
+
+[https://dev.to/feed/isabellaliu77]
+name=Isabella Liu
+
+[https://medium.com/feed/@rabautista]
+name=Ruby Anne Bautista
+
+[https://dev.to/feed/niazulhaque]
+name=Mohammed Niaz ul Haque
+
+[https://jongwon-jang.blogspot.com/feeds/posts/default?alt=rss]
+name=Jongwon Jang
+
+[https://jyangblogs.wordpress.com/category/open-source/feed/]
+name=Jie Yang
+
+[https://dev.to/feed/mljbrackett]
+name=Michael Brackett
+
+[https://fgaervgedwg.blogspot.com/feeds/posts/default?alt=rss]
+name=Tonghuyn Yi
+
+[https://dev.to/feed/hyperthd]
+name=Abdulbasid Guled
+
+[https://dev.to/feed/strawberries73]
+name=Jennifer Croft
+
+[https://medium.com/feed/@safrin2]
+name=Sanjida Afrin
+
+[https://dev.to/feed/zg3d]
+name=Devansh Shah
+
+[https://jliu396.blogspot.com/feeds/posts/default/-/Open%20Source?alt=rss]
+name=Junyong Liu
+
+[http://mamadou--diallo.blogspot.com/feeds/posts/default]
+name=Mamadou Diallo
+
+[https://muskanshinh.wordpress.com/category/open-source/feed/]
+name=Muskan Shinh
+
+[https://dev.to/feed/klee214]
+name=Kimin Lee
+
+[https://medium.com/feed/@ahugh2000]
+name=Alexander Hugh
+
+[https://muioverflow.wordpress.com/feed/]
+name=Jasper Mui
+
+[https://os-discovery.blogspot.com/feeds/posts/default]
+name=Matthew Ross
+
+[https://medium.com/feed/@tonyknvu]
+name=Tony Vu
+
+[https://dev.to/feed/chrispinkney]
+name=Chris Pinkney
+
+[https://1jz.tech.blog/feed]
+name=Philip Golovin
+
+[https://medium.com/feed/@egrinberg]
+name=Ekaterina Grinberg
+
+[https://matthew-k-stewardson.blogspot.com/feeds/posts/default?alt=rss]
+name=Matthew Stewardson
+
+[https://dev.to/feed/yzwdroid]
+name=Zongwei Yang
+
+[https://osd600.blogspot.com/feeds/posts/default/]
+name=Paul Sin
+
+[https://x7z.net/feed]
+name=Minh Huy Nguyen
+
+[https://medium.com/feed/@pedrofonsecadev]
+name=Pedro Fonseca
+
+[https://plamenvelkovtech.blogspot.com/feeds/posts/default]
+name=Plamen Velkov
+
+[https://ekim105.wordpress.com/category/open-source/feed/]
+name=Eunbee Kim
+
+[http://osd600-joey-assal.blogspot.com/feeds/posts/default/-/OpenSource?alt=rss]
+name=Joseph (Joey) Assal
+
+
+##### pre-2020-end #######
+
+[https://neilong31.wordpress.com/feed/]
+name=Neil Ong
+
+[http://ajhooper.blogspot.com/feeds/posts/default]
+name=Aaron Hooper
+
+
+[http://ljubomirgorscak.blogspot.com/feeds/posts/default]
+name=Ljubomir Gorscak
+
+
+[http://nashutzu.blogspot.com/feeds/posts/default]
+name=George Popescu (GeorgeP)
+
+
+[http://nadavid.blogspot.com/feeds/posts/default]
+name=Neil David
+
+
+[http://gkrilov.blogspot.com/feeds/posts/default]
+name=Greg Krilov
+
+
+[http://KrazyDre.blogspot.com/feeds/posts/default?alt=rss]
+name=Andrei Artamonov
+
+
+[http://dcucereavii.blogspot.com/feeds/posts/default?alt=rss]
+name=Diana Cucereavii
+
+
+[http://anastasias-myblog.blogspot.com/feeds/posts/default/-/OOP344]
+name=Anastasia Semionova
+
+
+[http://jdbcdps.blogspot.com/feeds/posts/default]
+name=Julia Vasserman
+
+
+[https://npolugari.wordpress.com/feed/]
+name=Nagashashank
+
+
+[http://sp0009.blogspot.ca/feeds/posts/default/-/spo600]
+name=ShlokKumar Purani
+
+
+[http://rkyoop344.blogspot.com/feeds/posts/default/]
+name=Keyan Ren
+
+
+[http://docsage.blogspot.com/feeds/posts/default/-/OOP344]
+name=Eric Dell
+
+
+[http://processingjs.org/blog/?feed=rss2]
+name=Processing.js Blog
+
+
+[http://shunyao-cpa.blogspot.com/feeds/posts/default]
+name=shun yao zhang
+
+
+[https://ebraublog.wordpress.com/category/CDOT/feed/]
+name=Eric Brauer
+
+
+[http://feeds.feedburner.com/lsblakk_open-source]
+name=Lukas Blakk (lsblakk)
+
+
+[http://88mishok.blogspot.com/feeds/posts/default]
+name=Francois Des Jarlais
+
+
+[http://sidsbr.blogspot.com/feeds/posts/default?alt=rss]
+name=Sadiki Latty
+
+
+[http://brookspatola.blogspot.ca/feeds/posts/default]
+name=Brooks Patola
+
+
+[https://sgupta44blog.wordpress.com/tag/open-source/feed/]
+name=Shivam Gupta
+
+
+[http://jabhad.blogspot.com/feeds/posts/default?alt=rss]
+name=Mohamed Aden
+
+[https://medium.com/feed/@aqeelparpia/]
+name=Aqeel Parpia
+
+[http://lchen97.blogspot.com/feeds/posts/default]
+name=Chris Chen
+
+
+[https://ppatel221.wordpress.com/category/open-source/feed/]
+name=Parthkumar Patel
+
+
+[https://gblogs2017.wordpress.com/category/open-source/feed/]
+name=Gaurav Verma
+
+
+[https://hfsimsspo.blogspot.com/feeds/posts/default/-/SPO600]
+name=Harley Sims
+
+
+[http://acfunktron.blogspot.com/feeds/posts/default]
+name=Anton Chan
+
+
+[http://oop344ylseow.blogspot.com/feeds/posts/default]
+name=Yip Lim Seow
+
+
+[http://oyoung4.blogspot.com/feeds/posts/default]
+name=Oliver Young
+
+
+[http://codingblub.blogspot.com/search/label/Open%20Source]
+name=Oluwaseyi Aketepe
+
+
+[http://senecajon.blogspot.com/feeds/posts/default]
+name=Jonathan Cheung (jcheung23)
+
+
+[https://stephentopensource.wordpress.com/category/osd600/feed/]
+name=Stephen Truong
+
+
+[http://ttsuji1.blogspot.com/feeds/posts/default]
+name=Trevor Tsuji
+
+
+[http://feihong-xiong.blogspot.com/feeds/posts/default]
+name=Feihong Xiong
+
+
+[http://sudodamha.blogspot.com/feeds/posts/default]
+name=Ahmad Taychouri
+
+
+[https://medium.com/feed/haorc/tagged/opensource]
+name=Hao Chen
+
+
+[http://drozhkov.blogspot.com/feeds/posts/default/-/seneca]
+name=Dmitriy Rozhkov
+
+
+[http://robplusplus.blogspot.com/feeds/posts/default/-/OpenSource]
+name=Robert Dittrich
+
+
+[http://pokerface3.blogspot.com/feeds/posts/default/-/SBR?alt=rss]
+name=David Cabral
+
+
+[https://medium.com/feed/@jrkong.hfd]
+name=Alex Kong
+
+
+[http://sbr600cabbott.blogspot.com/feeds/posts/default]
+name=Chris Abbott
+
+
+[http://opp344-yxue.blogspot.com/feeds/posts/default]
+name=Yong Xue
+
+
+[http://shivaris.blogspot.com/feeds/posts/default/-/OSD600]
+name=Hien Huynh
+
+
+[http://bharmidy.blogspot.ca/feeds/posts/default/-/open%20source]
+name=Bryce Harmidy
+
+
+[http://qwang135.wordpress.com/category/open_source/feed/]
+name=Qingwen Wang
+
+
+[https://jnguyen36blog.wordpress.com/category/spo600/feed/]
+name=John Nguyen
+
+
+[http://nedape.blogspot.com/feeds/posts/default]
+name=Neda Pezeshki
+
+
+[http://hmo6.blogspot.com/feeds/posts/default]
+name=Mo Hsiu Mei
+
+
+[https://abansalsspo600.wordpress.com/feed/]
+name=Arnav Bansal
+
+
+[https://akkabia.wordpress.com/category/open-source/feed]
+name=Abdul Kabia
+
+
+[http://blog.fardad.com/feeds/posts/default/-/Seneca]
+name=Fardad Soleimanloo
+
+
+[https://jyopensource.blogspot.ca/feeds/posts/default/-/open-source?alt=rss]
+name=Jay Yin
+
+
+[http://rselby-oop344.blogspot.com/feeds/posts/default?alt=rss]
+name=Remington Selby
+
+
+[http://ahiltssbr700.blogspot.com/feeds/posts/default?alt=rss]
+name=Adam Hilts
+
+
+[http://wfchen2010.blogspot.com/feeds/posts/default]
+name=Wen Fang Chen
+
+
+[https://vldmrkl.com/rss.xml]
+name=Volodymyr Klymenko
+
+
+[https://mithilanblog.wordpress.com/category/open-source/feed/]
+name=Mithilan Sivanesan
+
+
+[https://cartryblog.wordpress.com/category/open-source/feed/]
+name=Eugueni Antsyferov
+
+
+[http://shavedyak.blogspot.com/feeds/posts/default/-/opensource]
+name=Yoosuk Sim
+
+
+[http://hduan2.wordpress.com/feed/]
+name=Haoliang Duan
+
+
+[http://jonathandeni.blogspot.com/feeds/posts/default?alt=rss]
+name=Jonathan Deni
+
+
+[http://szymonsoop.blogspot.com/feeds/posts/default/]
+name=Szymon Ahmed
+
+
+[http://aadavis1.blogspot.ca//feeds/posts/default]
+name=Alexander Davis
+
+
+[https://alexwang.ca/feed]
+name=Alex Wang
+
+
+[http://gratnam1.blogspot.com/feeds/posts/default?alt=rss]
+name=Gajendran Ratnam (gratnam1)
+
+
+[http://justletmepassoop344.blogspot.com/feeds/posts/default]
+name=Brian Parreno
+
+
+[http://gtawaf.blogspot.com/feeds/posts/default/-/Seneca]
+name=Gamal Tawaf
+
+
+[http://mkavidas.wordpress.com/category/OSD/feed/]
+name=Michael Kavidas
+
+
+[http://t3rrychan.blogspot.com/feeds/posts/default?alt=rss]
+name=Terry Chen (jchen124)
+
+
+[http://rift-tlosam.blogspot.com/feeds/posts/default/-/seneca]
+name=Brendan McDorman
+
+
+[http://markieta.blogspot.ca/feeds/posts/default/]
+name=Christopher Markieta
+
+
+[http://sbr700.blogspot.com/feeds/posts/default?alt=rss]
+name=Jonathan Deni
+
+
+[https://ghkuo.wordpress.com/feed/]
+name=Guan Huei Kuo
+
+
+[http://cdot-callaghan.posterous.com/rss.xml?tag=CDOT]
+name=Peter Callaghan
+
+
+[http://ashtramwasser.blogspot.ca/feeds/posts/default]
+name=Alina Shtramwasser
+
+
+[http://alam61spo600.blogspot.ca/feeds/posts/default/]
+name=Alan Lam
+
+
+[http://manoutoftime.wordpress.com/category/open-source/feed/]
+name=Konstantin Novichikhin
+
+
+[http://coreyjames.me/feed/]
+name=Corey James
+
+
+[http://mikeshutov.blogspot.com/feeds/posts/default/-/open-source]
+name=Mike Shutov
+
+
+[https://ahkol.wordpress.com/category/Open-Source/feed/]
+name=Adam Kolodko
+
+
+[http://hopensources.blogspot.ca/feeds/posts/default/-/open%20source]
+name=Haiyu Qiao
+
+
+[http://mashhaque.blogspot.com/feeds/posts/default]
+name=Mashfique Haque
+
+
+[http://paul-oop344.blogspot.com/feeds/posts/default/]
+name=Paul Repasi
+
+
+[https://dps909blog.wordpress.com/category/Open-Source/feed/]
+name=Xiao Lei Huang
+
+
+[http://aadavis1.blogspot.ca/feeds/posts/default]
+name=Alexander Davis
+
+
+[https://mperuzziblog.wordpress.com/feed/]
+name=Matteo Peruzzi
+
+
+[http://shengwei-seneca.blogspot.com/feeds/posts/default]
+name=Shengwei Wang
+
+
+[http://s2000c.blogspot.com/feeds/posts/default/-/OOP344]
+name=Sunny Chau
+
+
+[http://pokim8989.blogspot.com/feeds/posts/default/-/Open%20source]
+name=John Kim
+
+
+[http://echanna.blogspot.ca/feeds/posts/default/-/open-source]
+name=Edward Hanna
+
+
+[http://rubensmaximus.blogspot.com/feeds/posts/default?alt=rss]
+name=Rubens Maximus (GameArtist)
+
+
+[http://tdao75.blogspot.com/feeds/posts/default]
+name=Thanh Dao
+
+
+[http://oop344ylseow.blogspot.com/feeds/posts/default]
+name=Yip Lim, Seow
+
+
+[https://brunodigiuseppe.wordpress.com/category/CDOT/feed/]
+name=Bruno Di Giuseppe
+
+
+[https://thelucasexcerpt.wordpress.com/category/SPO600/feed/]
+name=Lucas Verbeke
+
+
+[http://raynrant.blogspot.com/feeds/posts/default]
+name=Andrew Raynier (JM)
+
+
+[https://jpham14.wordpress.com/category/osd600/feed/]
+name=Joseph Pham
+
+
+[http://xrayon.blogspot.com/feeds/posts/default]
+name=Fima Kachinski
+
+
+[https://medium.com/feed/seanprashad/tagged/opensource]
+name=Sean Prashad
+
+
+[http://kqpham2.blogspot.com/feeds/posts/default/-/open-source/]
+name=Kevin Pham
+
+
+[http://oop-era.blogspot.com/feeds/posts/default]
+name=Eric Austerberry
+
+
+[http://kyleklerks.wordpress.com/category/CDOT/feed/]
+name=Kyle Klerks
+
+
+[http://codescriptplay.blogspot.ca/feeds/posts/default/-/opensource]
+name=Kajanthan Tharmabalan
+
+
+[http://yalongxyz.blogspot.com/feeds/posts/default/-/open-source/]
+name=Yalong Li
+
+
+[https://hudascoding.wordpress.com/category/open-source/feed/]
+name=Huda Al Dallal
+
+
+[https://osd600rhayes2.blogspot.com//feeds/posts/default/-/OpenSource]
+name=Ryan Hayes
+
+
+[http://adaniel3.blogspot.com/feeds/posts/default?alt=rss]
+name=Arlene Daniel
+
+
+[http://danielchangopen.blogspot.com/feeds/posts/default/-/opensource]
+name=Daniel Chang
+
+
+[http://saecob.blogspot.com/feeds/posts/default/-/OpenSource]
+name=Sergiu Ecob
+
+
+[http://sbr600.wordpress.com/2012/01/26/introduction/]
+name=Rachit Chaudhary (DJ)
+
+
+[http://sylask.wordpress.com/category/SPO600/feed/]
+name=Emmanuel Ho Fidelino
+
+
+[http://krazyazn.blogspot.com/feeds/posts/default]
+name=Michael Lin
+
+
+[https://pynnl.blogspot.com/feeds/posts/default/-/open-source]
+name=Ryan Vu
+
+[https://medium.com/feed/pynnl/tagged/open-source]
+name=Ryan Vu
+
+[http://minicheong.blogspot.com/feeds/posts/default]
+name=Frankie Law
+
+
+[http://jdeport.wordpress.com/category/software-development/open-source/feed/]
+name=John Dang
+
+
+[http://krevprogramming.blogspot.ca/feeds/posts/default/]
+name=Yehoshua Ghitis
+
+
+[http://mavillaflor.wordpress.com/category/open-source/feed]
+name=Mark Anthony Villaflor
+
+
+[https://cgsingh.wordpress.com/category/osd600/feed/]
+name=Christopher Singh
+
+
+[http://compiledsprawl.blogspot.com/feeds/posts/default/-/open-source]
+name=Matthew Grosvenor
+
+
+[http://dtychshenko.blogspot.com/feeds/posts/default/-/OOP344]
+name=Dmitriy Tychshenko
+
+
+[http://jeremyedgell.wordpress.com/category/Programming/feed/]
+name=Jeremy Edgell
+
+
+[http://kezhong.wordpress.com/feed/atom/]
+name=Kezhong Liang
+
+
+[https://wordpresscom98745.wordpress.com/]
+name=Ricardo Bocanegra Meza
+
+
+[https://kcleungdotblog.wordpress.com/category/spo600/feed/]
+name=Guozhao Liang
+
+
+[http://cty6sbr600.wordpress.com/feed/]
+name=Kalpaniya Parmar
+
+
+[https://achimienti.wordpress.com/category/spo600/feed]
+name=Adam Chimienti
+
+
+[http://chestersbr600.wordpress.com/]
+name=VicChester Ngo
+
+
+[http://craigcain.blogspot.com/feeds/posts/default?alt=rss]
+name=Craig Cain
+
+
+[http://scottdowne.wordpress.com/category/open-source/feed/]
+name=Scott Downe
+
+
+[https://medium.com/feed/mattphanalwaysastudent/tagged/opensource]
+name=Matthew Phan
+
+
+[http://apvsbr700.blogspot.com/feeds/posts/default?alt=rss]
+name=Alex Vlahopoulos
+
+
+[http://xderick.blogspot.com/feeds/posts/default/-/OSD]
+name=Yong Hong
+
+
+[http://dennyp.wordpress.com/category/Seneca/feed/]
+name=Denny Papagiannidis
+
+
+[https://nicholas95com.wordpress.com/category/spo600/feed/]
+name=Nicholas Krause
+
+
+[http://mschranz.wordpress.com/category/open_source/feed/]
+name=Matthew Schranz
+
+
+[http://www.shlee.ca/category/open-source/feed/]
+name=Sanghyun Lee
+
+
+[http://wangcong422.blogspot.com/feeds/posts/default/]
+name=Cong Wang
+
+
+[http://de-luxer.blogspot.com/feeds/posts/default?alt=rss]
+name=Nestor Chan
+
+[https://medium.com/feed/programmer-and-a-scholar/tagged/opensource]
+name=Maya Filipp
+
+
+[https://deepanjalidotblog.wordpress.com/category/open_source/feed/]
+name=Deepanjali Gerangal
+
+
+[http://chaoboxie.wordpress.com/category/open-source/feed/]
+name=Chaobo Xie
+
+
+[http://danielsopensource.blogspot.com/feeds/posts/default/-/open-source]
+name=Daniel Bogomazov
+
+
+[http://oleg-oop.blogspot.com/feeds/posts/default]
+name=Aleh Pliats
+
+
+[https://vincent20180916.blogspot.com/feeds/posts/default/]
+name=Vincent Wong
+
+
+[https://giorgiosadze.wordpress.com/category/spo600-osd600/feed]
+name=Giorgi Osadze
+
+
+[http://heidenreich.wordpress.com/tag/seneca-college/feed/]
+name=Michal Heidenreich
+
+
+[http://aryafarzan.wordpress.com/category/OOP344/feed/]
+name=Arya Farzan
+
+
+[http://minyxo.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Edward Sin
+
+
+[http://stronglytyped.ca/category/spo600/feed/]
+name=Bradly Hoover
+
+
+[https://bluesockphil.wordpress.com/category/open-source/feed/]
+name=Phil Henning
+
+
+[http://feeds.feedburner.com/Dps909-AndriyYevseytsev-Fall2018]
+name=Andriy Yevseytsev
+
+
+[http://feeds.feedburner.com/Fsreadfile]
+name=Victor Kubrak
+
+
+[http://adow2.wordpress.com/category/opensource/feed/]
+name=Ai Dow
+
+
+[http://wolfleaderslair.blogspot.com/feeds/posts/default?alt=rss]
+name=Dennis Villasenor
+
+
+[http://spo600.blogspot.com/feeds/posts/default]
+name=Claire Debika Sullivan
+
+
+[http://zhiboopensource.wordpress.com/category/Open_Source/feed/]
+name=Zhibo Dong
+
+
+[http://davidsosd60020102blog.blogspot.com/feeds/posts/default]
+name=David Takasaki
+
+
+[http://ywen10.blogspot.com/feeds/posts/default]
+name=Yue Wen
+
+
+[http://orbitalstation.wordpress.com/category/planetcdot/feed/]
+name=Hasan (northWind) Kamal-Al-Deen
+
+
+[http://brockmoote.wordpress.com/feed/]
+name=Stanley Moote
+
+
+[http://dejant.blogspot.com/feeds/posts/default]
+name=Dejan Tolj
+
+
+[https://techbreaksblog.wordpress.com/category/open-source/]
+name=Hadi Saeed
+
+
+[http://sedgestuff.wordpress.com/category/open-source-cdot/feed/]
+name=Kieran Sedgwick
+
+
+[http://zwang98.blogspot.com/feeds/posts/default]
+name=Joe Wang
+
+
+[http://sbr600blog.blogspot.com/feeds/posts/default]
+name=Andrew Greene
+
+
+[http://peterevanoff.wordpress.com/category/open-source/feed/]
+name=Peter Evanoff
+
+
+[http://jjakuseneca.blogspot.ca/feeds/posts/default/]
+name=Joseph Jaku
+
+
+[http://yhan11.wordpress.com/category/open-source/feed]
+name=Yongsheng Han
+
+
+[http://fuzzux.wordpress.com/category/SBR600/feed/]
+name=Tim Furzer
+
+
+[http://openthoughtsopensource.blogspot.com/feeds/posts/default/-/Open%20source]
+name=Evan Davies
+
+
+[http://ygcdw.blogspot.com/feeds/posts/default]
+name=Yoav Gurevich
+
+
+[https://hongcheng1993.wordpress.com/category/open-source/feed/]
+name=Hongcheng Zhang
+
+
+[https://kleverlogs.wordpress.com/feed/]
+name=Klever Loza Vega
+
+
+[http://dsegree.wordpress.com/feed/]
+name=Daniel Segree
+
+
+[http://cwdesautels.blogspot.com/feeds/posts/default]
+name=Carl Desautels
+
+
+[http://dima1086.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Dmytro Kostenyuk
+
+
+[http://jasonquan.wordpress.com/category/OOP344/feed/]
+name=Jason Quan
+
+
+[http://littlesvr.ca/grumble/category/safeforseneca/feed/]
+name=Andrew Smith
+
+
+[http://mariabustoss.wordpress.com/feed/]
+name=Maria Bustos-Roman
+
+
+[http://jasdeep.ca/ruby/feed/]
+name=Jasdeep Singh
+
+
+[http://lwu11.blogspot.com/feeds/posts/default]
+name=Ling Wu
+
+
+[https://jmrodriguesgoncalves.blogspot.ca/feeds/posts/default?alt=rss]
+name=Joao Rodrigues
+
+
+[http://elliottheguy.wordpress.com/tag/open-source/feed/]
+name=Elliot Kwan
+
+
+[http://ozhurbenko.blogspot.ca/feeds/posts/default/-/BigBlueButton]
+name=Oleksandr Zhurbenko
+
+
+[http://ericschvartzman.blogspot.com/feeds/posts/default]
+name=Eric Schvartzman
+
+
+[http://simon-jung.blogspot.com/feeds/posts/default]
+name=Simon Jung (old)
+
+
+[http://xshi18.blogspot.com/feeds/posts/default]
+name=Xiaozhe Shi
+
+
+[http://mikey-osd600a.blogspot.com/feeds/posts/default?alt=rss]
+name=Michael Dennis
+
+
+[http://ehren.wordpress.com/category/Seneca/feed/]
+name=Ehren Metcalfe
+
+
+[https://johnjamesa70.wordpress.com/category/spo600/feed]
+name=John James
+
+
+[https://marinsdevspace.wordpress.com/category/Open%20Source/feed/]
+name=Evan Marinzel
+
+
+[http://bertenshaw.blogspot.com/feeds/posts/default]
+name=David Bertenshaw
+
+
+[https://senecaram.wordpress.com/feed/]
+name=Ramanan Manokaran
+
+
+[http://ddinisalves.wordpress.com/category/open-source/feed/]
+name=Diana Dinis-Alves
+
+
+[https://jdseneca.wordpress.com/feed/]
+name=Jonathan Desmond
+
+
+#[https://medium.com/feed/@vraghubir]
+#name=Vimal Raghubir
+
+
+[http://bikarin.blogspot.com/feeds/posts/default]
+name=Irina Balzamova
+
+
+[http://qinzhi2001.blogspot.com/feeds/posts/default]
+name=David Chen
+
+
+[http://dgilloch.blogspot.com/feeds/posts/default]
+name=Daniel Gilloch
+
+
+[http://sedejong.blogspot.com/feeds/posts/default]
+name=Shomar Dejonge
+
+
+[http://cdnpadawan.wordpress.com/feed/]
+name=Matthew Daniels
+
+
+[http://ayhfung.blogspot.com/feeds/posts/default]
+name=Andrew Fung
+
+
+[http://actsangblog.wordpress.com/feed/]
+name=Alfred Tsang
+
+
+[http://haxbyte.wordpress.com/category/Open%20Source/feed/]
+name=Abel Simon Inocencio
+
+
+[http://tchen-oop344.blogspot.com/feeds/posts/default]
+name=Terence Chen
+
+
+[http://jmpiltz.blogspot.com/feeds/posts/default]
+name=Jonathan Piltz
+
+
+[http://joeysoddthoughts.blogspot.ca/feeds/posts/default/]
+name=Giuseppe Ranieri
+
+
+[http://galewis.blogspot.com/feeds/posts/default]
+name=Gustone Lewis
+
+
+[http://odjahanpour.wordpress.com/category/spo600/feed]
+name=Omid Djahanpour
+
+
+[http://spo600ninawip.blogspot.com/feeds/posts/default/]
+name=Nina Wip
+
+
+[http://mercedes-oop344.blogspot.com/feeds/posts/default]
+name=Suwon An
+
+
+[http://codingblub.blogspot.com/feeds/posts/default/]
+name=Oluwaseyi aketepe
+
+
+[https://jose-spo600.blogspot.ca/feeds/posts/default]
+name=José Aderbal Aragão Filho
+
+
+[http://hamabama.wordpress.com/feed]
+name=Dmitry Yastremskiy
+
+
+[https://marvinrsanchez.wordpress.com/feed/]
+name=Marvin Sanchez
+
+
+[https://aushakou.wordpress.com/category/open-source/feed/]
+name=Aliaksandr Ushakou
+
+
+[http://bhearsum.blogspot.com/feeds/posts/default/-/seneca]
+name=Ben Hearsum
+
+
+[http://andeic1.wordpress.com/category/open-source/feed/]
+name=Alex Craig
+
+
+[http://carolynwoodley.blogspot.com/feeds/posts/default]
+name=Carolyn Woodley
+
+
+[http://andrewgrimo.wordpress.com/category/open-source/feed/]
+name=Andrew Grimo
+
+
+[http://estereh.blogspot.com/feeds/posts/default/-/SPO600]
+name=Eugen (Jevenijs) Sterehov
+
+
+[http://softwarebuildrun.wordpress.com/feed/]
+name=Rudolf R Janns
+
+
+[http://maronin.wordpress.com/category/open-source/feed/]
+name=Mark Aronin
+
+
+[http://jlaverty.blogspot.com/feeds/posts/default]
+name=James Laverty
+
+
+[http://dliu53.wordpress.com/category/open-source/feed/]
+name=Donghui Liu
+
+
+[http://zbhuang1.blogspot.com/feeds/posts/default/-/open%20source]
+name=Zhibin Huang
+
+
+[http://dsventura.blogspot.com/feeds/posts/default?alt=rss]
+name=Dan Ventura
+
+
+[http://thedib.blogspot.ca/feeds/posts/default]
+name=Jose Giagonia
+
+
+[http://frankpanico.wordpress.com/category/open-source/feed/]
+name=Frank Panico
+
+
+[http://opensourcekennethlee.blogspot.com/feeds/posts/default]
+name=Kenneth Lee
+
+
+[https://jespiritutech.wordpress.com/category/spo600/feed/]
+name=Jeffrey Espiritu
+
+
+[http://rparsi.blogspot.com/feeds/posts/default?alt=rss]
+name=Rahi Parsi
+
+
+[https://yunhaowang.wordpress.com/feed/]
+name=Yunhao Wang
+
+
+[https://dyegorov.wordpress.com/category/spo600/feed/]
+name=Dmytro Yegorov
+
+
+[http://klepetinskiy.blogspot.ca/feeds/posts/default/-/spo600]
+name=Kirill Lepetinskiy
+
+
+[http://dtheosab.wordpress.com/category/open-source/feed/]
+name=Daino Theosabrata
+
+
+[http://pbouianov.wordpress.com/category/open-source/feed/]
+name=Petr Bouianov
+
+
+[https://rahul3guptablog.wordpress.com/category/dps909/feed/]
+name=Rahul Gupta
+
+
+[http://pliu.wordpress.com/category/open-source/feed/]
+name=Peter Liu
+
+
+[https://nolte96.wordpress.com/category/OSD600/feed/]
+name=Thomas Nolte
+
+
+[http://r3ap3r.wordpress.com/category/seneca/feed]
+name=Brandon Collins
+
+
+[http://mkmatthewblog.wordpress.com/feed]
+name=Matthew K Wong
+
+
+[http://lsdaly.blogspot.com/feeds/posts/default]
+name=Louis Daly (lsdaly)
+
+
+[https://andersoncdot.wordpress.com/feed/]
+name=Anderson Malagutti
+
+
+[https://minyingchen.wordpress.com/tag/open-source/feed/]
+name=Minying Chen
+
+
+[http://nageyi.wordpress.com/feed/]
+name=Faisal Nageyi
+
+
+[http://vijeysdps909.blogspot.com/feeds/posts/default]
+name=Vijey Bala
+
+
+[http://victran.blogspot.com/feeds/posts/default/-/OOP344]
+name=Victor Tran
+
+
+[https://firefoxmacblog.wordpress.com/category/open-source/feed/]
+name=Fateh Sandhu
+
+
+[http://zakoop344.blogspot.com/feeds/posts/default]
+name=Wei Tong
+
+
+[http://zyu26.wordpress.com/feed/]
+name=Zhiping Yu
+
+
+[http://ruihui.me/OSD600/category/open-source/feed/]
+name=Ruihui Yan
+
+
+[https://michaeloveralldps909.blogspot.com/feeds/posts/default/-/open-source]
+name=Michael Overall
+
+
+[http://blog.jordantheriault.com/category/open-source/feed/]
+name=Jordan Theriault
+
+
+[http://jsdoodnauth.wordpress.com/category/open-source/feed/]
+name=Joshua Doodnauth
+
+
+[https://rkspo600.wordpress.com/feed/]
+name=Raymond Kiguru
+
+
+[http://chadpilkey.wordpress.com/category/opensource/feed/]
+name=Chad Pilkey
+
+
+[https://jlonghiblog.wordpress.com/feed]
+name=Joshua Longhi
+
+
+[http://wb-os.blogspot.com/feeds/posts/default]
+name=Le Yang
+
+
+[http://mfainshtein4.wordpress.com/category/CDOT/feed/]
+name=Max Fainshtein
+
+
+[https://martinliam.wordpress.com/feed/]
+name=Liam Christopher Martin
+
+
+[http://jjleeos.blogspot.com/feeds/posts/default]
+name=Jeffrey Lee
+
+
+[https://jgricespo.wordpress.com/feed]
+name=Justin Grice
+
+
+[https://lucapadula.wordpress.com/category/SPO600/feed/]
+name=Luca Padula
+
+
+[http://cloudscorpion.blogspot.com/feeds/posts/default/-/open-source]
+name=Joseph Hughes
+
+
+[http://jamaljalali.wordpress.com/feed/]
+name=Jamal Jalali-Dolatshahi
+
+
+[http://openmillar.wordpress.com/feed-2/]
+name=Jeremy Millar
+
+
+[http://miltonpaiva.wordpress.com/feed/]
+name=Milton Paiva
+
+
+[https://tonypark0403.wordpress.com/category/Open-Source/feed/]
+name=Tony Park
+
+
+[http://sajed481.wordpress.com/opensource/feed/]
+name=Mohammad Abdullah Sajed Shadani
+
+
+[http://zhazhazenan.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Zenan Zha
+
+
+[http://kxu9.blogspot.com/feeds/posts/default]
+name=Kai Xu
+
+
+[http://shaj02.wordpress.com/feed/]
+name=Shajinth Pathmakulaseelan
+
+
+[https://johnjamesa70.wordpress.com/category/open-source/feed]
+name=John James
+
+
+[https://yuzhouchen.wordpress.com/category/open-source/feed/]
+name=Yuzhou Chen
+
+
+[http://sbr600.wordpress.com/2012/01/26/build-from-source/]
+name=Rachit Chaudhary (DJ)
+
+
+[https://shawnsblog447499268.wordpress.com/category/open-source/feed/]
+name=Shawn Mathew
+
+
+[http://opensourceproject.wordpress.com/category/open-source/feed/]
+name=Nabeel Khan (nkhan26)
+
+
+[http://www.kypertrast.net/seneca/category/open-source/feed/]
+name=Michael Afidchao
+
+
+[http://gkpatel2.blogspot.ca/feeds/posts/default/]
+name=Gaurav Patel
+
+
+[http://rgideonthomas.wordpress.com/feed/]
+name=Gideon Thomas
+
+
+[http://abraini.wordpress.com/category/seneca/feed/]
+name=Andrew Braini
+
+
+[http://spo600geoff.blogspot.com/feeds/posts/default/-/spo600]
+name=Geoffrey Wu
+
+
+[http://kirtonmike.wordpress.com/category/SBR600/feed/]
+name=Mike Kirton
+
+
+[http://lynart.wordpress.com/category/CDOT/feed/]
+name=Vince Lee
+
+
+[http://ysasaki600.wordpress.com/feed/]
+name=Yu Sasaki
+
+
+[http://gklo.github.io/feed.xml]
+name=Glaser Lo
+
+
+[http://jasoncarman.wordpress.com/category/sbr600/feed/]
+name=Jason Carman
+
+
+[https://aglazkovblog.wordpress.com/category/open-source/feed/]
+name=Aleksey Glazkov
+
+
+[http://tqyu.wordpress.com/]
+name=Tony Yu
+
+
+[https://osd600mytryniuk.wordpress.com/category/Open-Source/feed/]
+name=Oleg Mytryniuk
+
+[https://opensourcebywajeehsheikh.blogspot.com]
+name=Wajeeh Sheikh
+
+[http://bsmith19.wordpress.com/category/Seneca/feed/]
+name=Brandon Smith
+
+
+[http://www.hodgin.ca/?feed=rss2&amp;amp;cat=4]
+name=Daniel Hodgin
+
+
+[http://annafatsevych.com/blog/category/CDOT/feed/]
+name=Anna Fatsevych
+
+
+[http://dwauspo600.blogspot.ca/feeds/posts/default/]
+name=David Wesley Au
+
+
+[http://derekambrose.blogspot.com/feeds/posts/default/-/open%20source]
+name=Derek Ambrose
+
+
+[http://yakmarpro.wordpress.com/category/open-source/feed]
+name=Nicolas Ramkay
+
+
+[https://ewhite7blog.wordpress.com/tag/open-source/feed/]
+name=earle white
+
+
+[http://revenlight.wordpress.com/category/open-source/feed/]
+name=Dzmitry Kavalchyk
+
+
+[http://singhrajdeepblog.wordpress.com/feed/]
+name=Rajdeep Singh
+
+
+[http://marangonim.blogspot.ca/feeds/posts/default/-/BigBlueButton]
+name=Matthew Marangoni
+
+
+[http://varinderjhand.wordpress.com/feed/]
+name=Varinder Singh
+
+
+[http://kavisbr.blogspot.com/feeds/posts/default]
+name=Kavishankar Srivamathevan
+
+
+[https://ohodovaniuk.wordpress.com/feed/]
+name=Oleh Hodovaniuk
+
+
+[http://bombshelter13.blogspot.com/feeds/posts/default]
+name=Katherine Masseau
+
+
+[http://amehic.wordpress.com/category/open-source/feed]
+name=Ajla Mehic
+
+
+[http://dchenxd.wordpress.com/category/open-source/feed/]
+name=Xiaodong Chen
+
+
+[http://www.mandeepgarg.wordpress.com/feed/]
+name=Mandeep Garg
+
+
+[http://cleung.wordpress.com/category/Seneca/feed/]
+name=Catherine Leung
+
+
+[http://spo600yg.blogspot.com/feeds/posts/default]
+name=Yoav Gurevich
+
+
+[http://hojungan.blogspot.com/feeds/posts/default/-/spo600]
+name=Hojung An
+
+
+[https://thanhnguyen105337150.wordpress.com/category/open-source/feed/]
+name=Thanh Nguyen
+
+
+[https://andreybykin.wordpress.com/category/open-source/feed]
+name=Andrey Bykin
+
+
+[http://tecknologikk.blogspot.ca/feeds/posts/default/-/sbr600]
+name=Taylor Barras
+
+
+[https://lisyonok85.wordpress.com/feed/]
+name=Artem Luzyanin
+
+
+[https://andrewbennerlearn.wordpress.com/feed/]
+name=Andrew Benner
+
+
+[http://andrei600.wordpress.com/category/open-source/feed]
+name=Andrei Topala
+
+
+[https://ytian38.wordpress.com/category/OSD600/feed/]
+name=Yankai Tian
+
+
+[http://cjiang13.wordpress.com/category/SBR600/feed/]
+name=Charley Jiang
+
+
+[http://joelaro.wordpress.com/category/open-source/feed/]
+name=Joel Aro
+
+
+[https://barbaradegraafsoftware.wordpress.com/category/open-source/feed/]
+name=Barbara deGraaf
+
+
+[http://garykwong.wordpress.com/category/education/feed/]
+name=Gary Kwong (nth10sd)
+
+
+[http://jmulwani.wordpress.com/feed/]
+name=Jayaditya Mulwani
+
+
+[https://pyang16.wordpress.com/category/open-source/feed/]
+name=Peiying Yang
+
+
+[http://paulfedora.wordpress.com/tag/cdot/feed/]
+name=Paul Whalen
+
+
+[http://gbatumbya.wordpress.com/category/seneca/cdot/feed/]
+name=Grace Simon Batumbya
+
+
+[http://whilenotzero.wordpress.com/feed/]
+name=Stephen Ward
+
+
+[https://kdsbrowne.wordpress.com/feed/]
+name=Kert Browne
+
+
+[https://anthonylomagno.wordpress.com/category/open-source-development/feed/]
+name=Anthony LoMagno
+
+
+[https://dsych.wordpress.com/category/DPS909/feed/]
+name=Dmytro Sych
+
+
+[https://joshuablog716228556.wordpress.com/category/open-source/feed/]
+name=Joshua Mayers
+
+
+[https://medium.com/feed/margarytachepiga/tagged/opensource]
+name=Margaryta Chepiga
+
+
+[https://medium.com/feed/@arsalanskhalid]
+name=Arsalan Khalid
+
+
+[http://hdc23.wordpress.com/category/OOP344/feed]
+name=Dachuan Huang
+
+
+[http://ligangbory.wordpress.com/feed/]
+name=Gang Li
+
+
+[https://joulecpa.wordpress.com/feed]
+name=Hong Zhan Huang
+
+
+[http://msbreezy12.wordpress.com/category/SBR/feed/]
+name=Chantell Mcintosh
+
+
+[http://annasob.wordpress.com/feed/]
+name=Anna Sobiepanek
+
+
+[https://jespiritutech.wordpress.com/category/osd600/feed/]
+name=Jeffrey Espiritu
+
+
+[https://nicksopensource.wordpress.com/category/DPS909/feed/]
+name=Mykola Skuybeda
+
+
+[https://sanjitps.wordpress.com/feed/]
+name=Sanjit Pushpaseelan
+
+
+[http://tyrant911-processingdotjs.blogspot.com/feeds/posts/default/-/processing.js]
+name=Alex Londono
+
+
+[http://hosunghwang.wordpress.com/feed/]
+name=Hosung Hwang
+
+
+[http://garydengblog.wordpress.com/category/open-source/feed/]
+name=Gary Deng
+
+
+[https://medium.com/feed/merag/tagged/opensource]
+name=Mera Gangapersaud
+
+
+[http://pplam3.blogspot.com/feeds/posts/default]
+name=Patrick Lam
+
+
+[http://darthjawa.wordpress.com/category/sbr600/cdot-planet/feed/]
+name=Dmitry Kozunov
+
+
+[https://leandroosdblog.wordpress.com/category/open-source/feed/]
+name=Leandro Navarro
+
+
+[http://ywang268.blogspot.com/feeds/posts/default/]
+name=Yu Wang
+
+
+[http://sspaleta.wordpress.com/feed/]
+name=Shiela Spaleta
+
+
+[https://operationaladam.wordpress.com/category/open-source/feed/]
+name=Adam Pucciano
+
+
+[http://mlveis.wordpress.com/category/open-source/feed/]
+name=Michael Veis
+
+
+[http://aeraj.blogspot.com/feeds/posts/default/-/open%20source]
+name=AJ Rehman
+
+
+[http://pdirezze.blogspot.com/feeds/posts/default]
+name=Paul DiRezze
+
+
+[http://avadac.wordpress.com/category/open-source/feed/]
+name=Ava Dacayo
+
+
+[http://dmchisho.wordpress.com/feed/]
+name=David Chisholm
+
+
+[https://shawnblog1.wordpress.com/feed/]
+name=Shawn Pang
+
+
+[http://asalwi123.wordpress.com/feed/]
+name=Aries Alwi
+
+
+[http://admixdev.com/category/programming-2/feed/]
+name=Alexander Snurnikov
+
+
+[http://shunyao-cpa.blogspot.com/feeds/posts/default]
+name=Shun Yao Zhang
+
+
+[https://ddmedinski.wordpress.com/feed/]
+name=Danylo Medinski
+
+
+[https://leblogedeblotte.blogspot.com/feeds/posts/default/-/spo600]
+name=Lucas Blotta
+
+
+[http://dsmukherji.blogspot.com/feeds/posts/default?alt=rss]
+name=Devashish
+
+
+[http://sdealmeida.com/category/open-source/feed/]
+name=Simon de Almeida
+
+
+[http://nitinprakash.wordpress.com/category/open-source/feed/]
+name=Nitin Prakash Panicker
+
+
+[https://lawrencereyesoo.wordpress.com/feed/]
+name=Lawrence Reyes
+
+
+[https://kramsamujh.wordpress.com/category/OSD600/feed/]
+name=Kevin Ramsamujh
+
+
+[https://medium.com/feed/@jagmeetb]
+name=Jagmeet Bhamber
+
+
+[https://derrickwhleung.wordpress.com/category/open-source/feed/]
+name=Derrick Leung
+
+
+[http://mctenenbaum.wordpress.com/category/open-source/feed]
+name=Moshe Tenenbaum
+
+
+[http://fadiprogramming.wordpress.com/feed/]
+name=Fadi Tawfig
+
+
+[https://jlasob.wordpress.com/tag/SPO600/feed]
+name=Jayme Laso-Barros
+
+
+[http://wkhan10.wordpress.com/feed]
+name=Waqas Khan
+
+
+[https://pengqu.wordpress.com/2018/09/21/lab1-node-js-feature-copyfile/]
+name=Peng Qu
+
+
+[https://lenisac.wordpress.com/category/seneca/feed/]
+name=Len Isac
+
+
+[http://blog.auios.com/feed.php]
+name=Connor Ngo
+
+
+[https://jangabrielona.wordpress.com/category/open-source/feed]
+name=Jan Ona
+
+
+[http://hfazal.wordpress.com/category/open-source/feed/]
+name=Husain Fazal
+
+
+[http://pphanopensource.blogspot.ca/feeds/posts/default/]
+name=Phuoc Phan
+
+
+[http://horndavid.blogspot.com/feeds/posts/default?alt=rss]
+name=David Horn
+
+
+[http://cholantesh.wordpress.com/category/opensource/feed]
+name=Natesh Mayuranathan
+
+
+[http://avru.wordpress.com/category/open-source/feed/]
+name=Anh Tran
+
+
+[http://minooz.wordpress.com/category/CDOT/feed/]
+name=Minoo Ziaei
+
+
+[http://chalispo600.wordpress.com/feed/]
+name=Cha Li
+
+
+[http://kyle.barnhart.ca/feeds/posts/default/-/Open%20Source]
+name=Kyle Barnhart
+
+
+[http://kvuhome.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Khanh Vu
+
+
+[http://adamsharpe8.blogspot.ca/feeds/posts/default/-/Open%20Source]
+name=Adam Nicholas Sharpe
+
+
+[https://dennisarul.wordpress.com/category/spo600/feed/]
+name=Dennis Arul
+
+
+[http://migueldcode.wordpress.com/feed/]
+name=Miguel Dizon
+
+
+[http://daeseonmoon.wordpress.com/category/open-source/feed/]
+name=Daeseon Moon
+
+
+[http://paritosha.blogspot.com/feeds/posts/default]
+name=Paritosh Aggarwal(paritosh1010)
+
+
+[https://mswelke.wordpress.com/feed/]
+name=Matthew Welke
+
+
+[http://acadosdev.blogspot.com/feeds/posts/default/]
+name=Yoav Gurevich
+
+
+[https://bpatola.wordpress.com/feed/]
+name=Aaron Brooks Patola
+
+
+[http://spo600.wordpress.com/feed/]
+name=Thana Annis
+
+
+[http://mozcoz.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Amit Gundu
+
+
+[http://mmbabol.blogspot.com/feeds/posts/default/-/open-source]
+name=Mat Babol
+
+
+[http://asydik.wordpress.com/category/professional/open-source/feed/]
+name=Mickael Medel (aSydiK)
+
+
+[http://ttran57.blogspot.com/feeds/posts/default]
+name=Thanh Tran
+
+
+[https://theoduleblog.wordpress.com/category/school/dps909/feed/]
+name=Theo D
+
+
+[https://woodsondelhia.wordpress.com/category/opensourcedps909/feed/]
+name=Woodson Delhia
+
+
+[https://azouprogrammingblog.wordpress.com/category/open-source/feed/]
+name=Allan Zou
+
+
+[https://franklinchenw.blogspot.ca/feeds/posts/default/]
+name=Qichang Chen
+
+
+[https://markkrutikopensource.wordpress.com/category/Open-Source/feed/]
+name=Mark Krutik
+
+
+[https://choyzhihao.wordpress.com/category/open-source/feed/]
+name=Zhihao Cai
+
+
+[http://james.boelen.ca/category/open_source/feed/]
+name=James Boelen
+
+
+[http://blog.neilguzman.com/feed/category/cdot/atom]
+name=Neil Guzman
+
+
+[http://zghansar.wordpress.com/category/open-source/feed/]
+name=Zaid Ghansar
+
+
+[http://jcqiu.wordpress.com/feed/]
+name=Jiecheng Qiu
+
+
+[http://donmcarthur.wordpress.com/category/spo600/feed]
+name=Donald McArthur
+
+
+[http://england.cdot.systems/stuart-crust-mirror/index.xml]
+name=Stuart Crust
+
+
+[http://jrromasanta1.wordpress.com/feed/]
+name=Jose Romasanta
+
+
+[https://shreenasopensource.wordpress.com/category/open-source/feed/]
+name=Shreena Athia
+
+
+[http://limed3.wordpress.com/category/open-source/feed/]
+name=Edwin Lim
+
+
+[http://cty6.wordpress.com/feed/]
+name=Luis Fuentes
+
+
+[http://cdpatel1.blogspot.com/feeds/posts/default]
+name=Chinmay Patel
+
+
+[https://medium.com/feed/@chayadanz]
+name=Chaya Danzinger
+
+
+[http://blog.gabrielcastro.ca/feeds/posts/default/-/open%20source]
+name=Gabriel Castro
+
+
+[http://kwkofler.wordpress.com/category/open-source/feed/]
+name=Kevin Kofler
+
+
+[http://mikedohertyblog.wordpress.com]
+name=Mike Doherty
+
+
+[https://edyedyschool.tumblr.com/rss]
+name=Eduardo Sorozabal
+
+
+[http://mbbaig.wordpress.com/category/open-source/feed/]
+name=Mohamed Baig
+
+
+[http://jaejoblog.wordpress.com/feed/]
+name=Jae Jo
+
+
+[http://mdbellprog.blogspot.com/feeds/posts/default]
+name=Matthew Bell
+
+
+[http://atpenrose.wordpress.com/feed/]
+name=Adam Penrose
+
+
+[https://bbhawgandeen.wordpress.com/feed/]
+name=Brandon Bhagwandeen
+
+
+# [http://www.elliotmaude.com/category/spo600/feed]
+[http://england.cdot.systems/elliot-maude-mirror/index.xml]
+name=Elliot Maude
+
+
+[http://professorplumpi.wordpress.com/feed/]
+name=Richard Kim
+
+
+[http://blog.wikiscraps.com/feeds/posts/default/-/oss]
+name=M. Mead Armsby (mead)
+
+
+[http://jdlatorre.blogspot.ca/feeds/posts/default]
+name=Juan Latorre
+
+
+[http://dailypackage.fedorabook.com/index.php?/feeds/index.rss2]
+name=Fedora Daily Package
+
+
+[https://pabinski.wordpress.com/feed/]
+name=Pablo Calderon
+
+
+[https://xdtruong.blogspot.com/feeds/posts/default]
+name=Xuan Dinh Truong
+
+
+[http://wobblyretroaction.blogspot.com/feeds/posts/default/-/Open%20source]
+name=Matthew Lam
+
+
+[http://edwinlum.wordpress.com/category/open-source/feed/]
+name=Edwin Lum
+
+
+[http://shayanzafar.wordpress.com/category/open-source/feed/]
+name=Shayan Zafar Ahmad
+
+
+[http://yxue11.blogspot.com/feeds/posts/default]
+name=Yong Xue
+
+
+[https://kojimiyauchi.wordpress.com/feed/]
+name=Koji Miyauchi
+
+
+[https://maxwelllefevre.wordpress.com/feed/]
+name=Maxwell LeFevre
+
+
+[http://jvalianes.blogspot.com/feeds/posts/default]
+name=Jesse Valianes
+
+
+[https://srichardson6blog.wordpress.com/feed/]
+name=Shaun Richardson
+
+
+[http://istessema.wordpress.com/category/oop344/feed/]
+name=Iyosias Tessema
+
+
+[https://raygervais.dev/feed-open-source.xml]
+name=Ray Gervais
+
+
+[https://ryandangdeveloper.wordpress.com/feed/]
+name=Ryan Dang
+
+
+[http://compileofcrap.com/SPO600/feed.xml]
+name=Nathan Misener
+
+
+[http://acchung1.blogspot.com/feeds/posts/default/-/oop344]
+name=Alex Chun Yang Chung
+
+
+[http://gloriaip.wordpress.com/feed/]
+name=Gloria Ip
+
+
+[https://gapizzacalla.wordpress.com/]
+name=Garrett Pizzacalla
+
+
+[http://pgincanada.blogspot.ca/feeds/posts/default/-/BigBlueButton]
+name=Jaeeun Cho
+
+
+[http://nexjmdi.blogspot.com/feeds/posts/default]
+name=Yoav Gurevich
+
+
+[https://zedsdps909blog.wordpress.com/category/Open-Source/feed/]
+name=Zukhruf Khan
+
+
+[http://amkonopko.wordpress.com/feed/]
+name=Amadeus Konopko
+
+
+[https://wangpansopensource.wordpress.com/category/open-source/feed/]
+name=Wang Pan
+
+
+[http://dilanguneratne.ddns.net/tag/open-source/rss/]
+name=Dilan Guneratne
+
+
+[http://asalga.wordpress.com/category/open-source/feed/]
+name=Andor Salga (asalga)
+
+
+[http://kyu6.wordpress.com/feed/]
+name=Keren Yu
+
+
+[http://bbarcick.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Bartosz Barcicki
+
+
+[http://shavyg2.wordpress.com/category/open-source/feed/]
+name=Shavauhn Gabay
+
+
+[http://isong3.blogspot.com/feeds/posts/default/-/spo600]
+name=Ilkyu Song
+
+
+[https://stevenleopensourceblog.wordpress.com/feed/]
+name=Steven Le
+
+
+[http://marangonim.blogspot.ca/feeds/posts/default/-/SPO600]
+name=Matthew Marangoni
+
+
+[http://danlin007.wordpress.com/category/open_source/feed/]
+name=Dan Lin
+
+
+[http://vesperrin.blogspot.com/feeds/posts/default/-/open%20source]
+name=Leonard Lee (vesper)
+
+
+[http://pconstantino.wordpress.com/feed]
+name=Patricia Constantino
+
+
+[http://xizhangblog.blogspot.com/feeds/posts/default/-/oop344]
+name=Xi Zhang
+
+
+[https://ywpark1.wordpress.com/category/open-source/feed/]
+name=Yeonwoo Park
+
+
+[https://svitlanagalianova.blogspot.ca/feeds/posts/default/]
+name=Svitlana Galianova
+
+
+[http://jmchen11.wordpress.com/feed/]
+name=Jianming Chen
+
+
+[http://bzcareermongodb.blogspot.ca/feeds/posts/default]
+name=Zakeria Hassan
+
+
+[http://donna-oberes.blogspot.com/feeds/posts/default?alt=rss]
+name=Donna Oberes
+
+
+[http://basyager.wordpress.com/feed/]
+name=Slava Basatski
+
+
+[http://dseifried.wordpress.com/category/school/feed/]
+name=David Seifried
+
+
+[https://michaelpierreblog.wordpress.com/category/Open-Source/feed/]
+name=Michael Pierre
+
+
+[https://badrmodoukh.wordpress.com/tag/open-source/feed/]
+name=Badr Modoukh
+
+
+[http://blog.cresencia.ca/category/open-source/osd600/feed/]
+name=Joseph Cresencia
+
+
+[http://droxxes.wordpress.com/category/seneca/feed/]
+name=Tai Nguyen
+
+# blog.chris.tylers.info down during personal infra restructuring
+#[http://blog.chris.tylers.info/index.php?/feeds/categories/20-Seneca-Planet.rss]
+#name=Chris Tyler (ctyler)
+
+
+[https://lejara.wordpress.com/open-source/feed/]
+name=Leonel Jara
+
+
+[http://msmahmood1.blogspot.com/feeds/posts/default/-/opensource]
+name=Mohammad Shaheer Mahmood
+
+
+[https://ron-spo.blogspot.com/feeds/posts/default]
+name=Ronen Agarunov
+
+
+[https://joshuajadulco.wordpress.com/category/open-source/feed/]
+name=Joshua Jadulco
+
+
+[https://shivgajiwala.blogspot.ca/]
+name=Shiv Gajiwala
+
+
+[https://klvincho.wordpress.com/category/open-source/feed/]
+name=Kelvin Cho
+
+
+[http://wsong18.blogspot.com/feeds/posts/default/-/open-source]
+name=Wei Song
+
+
+[https://jybaeblog.wordpress.com/category/SPO600/feed/]
+name=Jiyoung Bae
+
+
+[http://i0x777.wordpress.com/feed/]
+name=Nikhil Sharma
+
+
+[http://spo-asm.blogspot.com/feeds/posts/default/-/SPO600/]
+name=James Boyer
+
+
+[https://yatsenkojulia.wordpress.com/category/opensource/feed/]
+name=Julia Yatsenko
+
+
+[http://belavina.me/feed.xml]
+name=Olga Belavina
+
+
+[https://trandangkhue27.wordpress.com/tag/open_source/feed/]
+name=Dang Khue Tran
+
+
+[https://quangdattran.wordpress.com/category/spo600/]
+name=Quang Dat Tran
+
+
+[http://berwoutcanada.blogspot.ca/feeds/posts/default/]
+name=Berwout de Vries Robles
+
+
+[http://aaronmt.github.com/atom.xml]
+name=Aaron Train
+
+
+[http://jbopensrc.wordpress.com/category/open-source/feed]
+name=Jesse Buchanan
+
+
+[http://kdayalingam.wordpress.com/category/dpi908/feed]
+name=Kowrinanthan Dayalingam
+
+
+[http://nrkemp4.tumblr.com/tagged/spo600/rss]
+name=Nick Kemp
+
+
+[http://paracr4ckbeginnings.wordpress.com/feed/]
+name=Brendan Donald Henderson
+
+
+[https://mattprogrammingblog.wordpress.com/feed/]
+name=Matthew Quan
+
+
+[http://linpei.blogspot.ca/feeds/posts/default]
+name=Linpei Fan
+
+
+[http://rsbr600.blogspot.ca/feeds/posts/default]
+name=Ronald Hernandez
+
+
+[http://ebaadali.wordpress.com/category/SPO600/feed/]
+name=Ebaad Ali
+
+
+[http://sabanane.wordpress.com/feed/]
+name=Japheth N.
+
+
+[https://medium.com/feed/@juliakmdev]
+name=Julia McGeoghan
+
+
+[http://blog.sidkalra.com/category/opensource/feed]
+name=Sid Kalra
+
+
+[http://gr8can8dian.wordpress.com/category/sbr600/feed/]
+name=Lorin Soura
+
+
+[https://matthewsspoblog.wordpress.com/category/spo600/feed/]
+name=Matthew Fletcher
+
+
+[http://mkavidas.wordpress.com/category/SPO/feed/]
+name=Michael Kavidas
+
+
+[https://gecaos.wordpress.com/feed/]
+name=Galina Erostenko
+
+
+[http://petermcintyre.wordpress.com/feed/]
+name=Peter McIntyre
+
+
+[http://blog.humphd.org/tag/seneca/rss/]
+name=David Humphrey
+
+
+[https://bhung6494.wordpress.com/category/open-source/feed/]
+name=Brendan Hung
+
+
+[http://england.cdot.systems/akdev-mirror/feed.xml]
+name=Edgard Arvelaez (akdev)
+
+
+[http://xiajunshi.wordpress.com/category/open-source/feed/]
+name=Shelley Shi
+
+
+[http://rtang12.blogspot.ca/feeds/posts/default]
+name=Ruowen Tang
+
+
+[http://techspotnewsx.blogspot.ca/feeds/posts/default/-/SPO600]
+name=Laily Ajellu
+
+
+[http://andreikopytov.wordpress.com/category/CDOT/feed/]
+name=Andrei Kopytov
+
+
+[https://tng23spo600.wordpress.com/feed/]
+name=Tom Ng
+
+
+[http://okevin0.wordpress.com/category/open-source/feed/]
+name=Shuming Lin
+
+
+[http://yuechengdotblog.wordpress.com/category/open-source/feed/]
+name=Yuecheng Wu
+
+
+[http://feliploko.wordpress.com/category/seneca/feed]
+name=Felipe de Oliveira
+
+
+[http://mjcorsame.wordpress.com/feed/]
+name=Michael John Corsame
+
+
+[http://sonnilion.wordpress.com/feed/]
+name=Matt Postill
+
+
+[http://fahmadi6.wordpress.com/feed/]
+name=Faranak Ahmadi
+
+
+[https://www.marcobeltempo.com/feed/]
+name=Marco Beltempo
+
+
+[http://xwn740arcadeproject.blogspot.com/feeds/posts/default]
+name=Arcade Project - LUX Group@
+
+
+[https://chunsinglam.wordpress.com/category/spo600/feed/]
+name=Chun Sing Lam
+
+
+[https://muchtarosd600.home.blog/category/open-source/feed/]
+name=Muchtar Salimov
+
+
+[http://mohaksblog.blogspot.com/feeds/posts/default]
+name=Mohak Vyas
+
+
+[https://makowen.wordpress.com/category/Open-Source/feed/]
+name=Owen Mak
+
+
+[http://arminoop344.blogspot.com/feeds/posts/default]
+name=Armin Kumarshellah
+
+
+[https://ysong55spd600.wordpress.com/category/SPO600/feed/]
+name=Yan Song
+
+
+[http://kmsingh.blogspot.com/feeds/posts/default?alt=rss]
+name=Kerry M. Singh
+
+
+[http://spo6002015.blogspot.ca/feeds/posts/default/]
+name=Nitish Bajaj
+
+
+[https://mycbprogramming.wordpress.com/tag/open-source/]
+name=Charlotte Baptist
+
+
+[http://hckim.wordpress.com/category/open-source/feed/]
+name=Han Chul Kim
+
+
+[https://sofiangotrong.wordpress.com/category/SPO600/feed/]
+name=Sofia Ngo-Trong
+
+
+[https://justosd.wordpress.com/category/open-source/feed/]
+name=Justin Vuu
+
+
+[http://kliu39.wordpress.com/feed/]
+name=Kun Liu
+
+
+[http://qchen102.blogspot.com/feeds/posts/default/]
+name=Qiliang Chen
+
+
+[http://fedoraisfun.wordpress.com/category/open_source/feed/]
+name=Alan Lau
+
+
+[http://wfred.wordpress.com/category/open-source/feed/]
+name=Fred Wang
+
+
+[http://kkmusinguzi.wordpress.com/feed/]
+name=Keith Musinguzi
+
+
+[http://eliocharles.wordpress.com/category/open-edx/feed/]
+name=Edward Hanna
+
+
+[https://myasir.ca/blog]
+name=Mohammad Yasir
+
+
+[http://alexkotliar.wordpress.com/category/open-source/feed/]
+name=Alex Kotliar
+
+
+[http://btulchinsky.wordpress.com/category/open-source/feed/]
+name=Barry Tulchinsky
+
+
+[http://hendrikinmozilla.wordpress.com/feed/]
+name=Hendrik
+
+
+[http://igoryen.wordpress.com/category/CDOT/feed/]
+name=Igor Entaltsev
+
+
+[https://mrrajevski.wordpress.com/category/spo600/feed]
+name=Matt Rajevski
+
+
+[http://yuriykartuzov.wordpress.com/category/Open%20Source/feed/]
+name=Yuriy Kartuzov
+
+
+[https://medium.com/feed/@alexei.kozachenko]
+name=Aleksei Kozachenko
+
+
+[http://minghans.wordpress.com/category/spo600/feed/]
+name=Minghan Xu
+
+
+[http://mbustossbr.wordpress.com/feed/]
+name=Maria Bustos-Roman
+
+
+[http://alicoding.com/rss/]
+name=Ali Al Dallal
+
+
+[http://okhattab.wordpress.com/feed/]
+name=Omarr Khattab
+
+
+[http://jsinghfoss.wordpress.com/category/spring-framework/feed/]
+name=Jatinder Singh
+
+
+[http://franksun123.blogspot.com/feeds/posts/default/]
+name=Dong Sun
+
+
+[http://maximumou.blogspot.com/feeds/posts/default]
+name=Zhi Chang Ou
+
+
+[http://scottosd.blogspot.com/feeds/posts/default/-/Open%20Source/]
+name=Scott Lunel
+
+
+[https://mb30myopensourceblog.blogspot.ca/feeds/posts/default]
+name=Patrick Godbout
+
+
+[https://opensourcetoronto.wordpress.com/category/open-source/feed/]
+name=Hans van den Pol
+
+
+[https://dcchen.home.blog/category/spo600/feed/]
+name=Danny Chen
+
+
+[http://gchau2.wordpress.com/feed/]
+name=Gary Chau
+
+
+[https://timothymoy.wordpress.com/tag/open-source/feed/]
+name=Timothy Moy
+
+
+[http://capereir.wordpress.com/feed/]
+name=Chris Pereira
+
+
+[http://dbaranski.wordpress.com/category/open-source/feed/]
+name=Dominic Baranski
+
+
+[http://enderstruth.wordpress.com/category/open-source/feed/]
+name=Roger Dicke
+
+
+[http://senecahealth.wordpress.com/feed/]
+name=Seneca Health Projects Blog
+
+
+[http://petepabs.wordpress.com/feed/]
+name=Peter Valerio
+
+
+[http://andrewow.wordpress.com/category/sbr600/feed/]
+name=Andrew Oatley-Willis
+
+
+[http://vlam6.wordpress.com/category/open-source/feed/]
+name=Vincent Lam
+
+
+[http://scorchedicee.wordpress.com/category/Seneca/feed/]
+name=Adam Sone
+
+
+[http://thevakaran.wordpress.com/category/open-source/feed/]
+name=Thevakaran Virutthasalam
+
+
+[http://dee132.blogspot.com/feeds/posts/default/-/seneca]
+name=Chris Bishop
+
+
+[https://brettlarney.wordpress.com/category/open-source/feed/]
+name=Brett Larney
+
+
+[http://dylansegna.wordpress.com/feed/]
+name=Dylan Segna
+
+
+[http://ben1amin.wordpress.com/category/seneca/feed/]
+name=Benjamin Chalovich
+
+
+[http://elnushaj.wordpress.com/feed/]
+name=Elsi Nushaj
+
+
+[https://ekatdev.wordpress.com/category/SPO600/feed/]
+name=Ekaterina Zaytseva
+
+
+[http://kopay.wordpress.com/category/sbr600-win2011/feed]
+name=Pirathapan Sivalingam
+
+
+[http://jessefulton.wordpress.com/category/SBR600/feed/]
+name=Jesse Fulton
+
+
+[http://eric-spo600.blogspot.com/feeds/posts/default]
+name=Eric Ferguson
+
+
+[http://armenzg.blogspot.com/feeds/posts/default/-/open%20source]
+name=Armen Zambrano G. (armenzg)
+
+
+[https://vishnuhacks.wordpress.com/category/spo600/feed/]
+name=Vishnu Santhosh Kumar
+
+
+[https://jamesshin37.wordpress.com/feed/]
+name=James Shin
+
+
+[http://donaldtn.blogspot.com/feeds/posts/default/-/spo600]
+name=Donald Nguyen
+
+
+[http://ausleyj.blogspot.com/feeds/posts/default]
+name=Ausley Johnson
+
+
+[http://spo600osp.blogspot.com/feeds/posts/default]
+name=Wayne Williams
+
+
+[http://hzhong10.blogspot.ca/feeds/posts/default]
+name=Hua Zhong
+
+[http://andrewkoung.wordpress.com/feed/]
+name=Andrew Koung
+
+[http://woosleparkdpd909.wordpress.com/feed/]
+name=Woosle Park
+
+[https://medium.com/feed/@sahibarora1997]
+name=Sahib Arora
+
+[https://jatinkumar.home.blog/category/open-source/feed/]
+name=Jatin Kumar
+
+[https://apolllondev.wordpress.com/feed/]
+name=Oleksii Polovyi
+
+[http://codingmoments1618.blogspot.com/feeds/posts/default]
+name=Vladimir Rozin
+
+[https://iraokth.wordpress.com/feed/]
+name=Iryna Thompson
+
+[https://luysh0420.wordpress.com/feed/]
+name=Yuansheng Lu
+
+[https://abonilla1.blogspot.com/feeds/posts/default]
+name=Alexei Bonilla
+
+[https://rscotchmer.blogspot.com/feeds/posts/default/-/open%20source]
+name=Rachael Scotchmer
+
+[https://medium.com/feed/@brandonjwissmann]
+name=Brandon Wissmann
+
+[https://olenavyshnevska.blogspot.com/feeds/posts/default/-/opensource]
+name=Olena Vyshnevska
+
+[https://paulmoonblog.wordpress.com/?tag=opensource&amp;amp;feed=rss2]
+name=Paul Moon
+
+[https://medium.com/feed/@a_elmasery]
+name=Adel El Masery
+
+[https://medium.com/feed/@priyankacodes]
+name=Priyanka Dhiman
+
+[https://harsh604310081.wordpress.com/category/uncategorized/feed/]
+name= Harsh Patel
+
+[https://violethxw.wordpress.com/category/open-source/feed/]
+name= Xiaowei Huang
+
+[https://tkacholeksandr.home.blog/feed/]
+name = Oleksandr Tkach
+
+[https://medium.com/feed/@abdishire15/]
+name= Abdirahman Guled
+
+[https://medium.com/feed/@aqeelparpia/]
+name = Aqeel Parpia
+
+[https://amddeeb.wordpress.com/feed/]
+name = Ahmed Deeb
+
+[https://terriblyuncreativeopensourceblogtitles.wordpress.com/category/open-source/feed/]
+name = Dillon Coull
+
+[https://alvinvaldez656226608.wordpress.com/feed/]
+name = Al Vincent Valdez
+
+[https://cmchumak.home.blog/category/open-source/feed/]
+name = Colin Chumak
+
+[http://vlogozzo.blogspot.com/feeds/posts/default/-/open-source]
+name = Vincent Logozzo
+
+[https://dli119seneca.wordpress.com/feed/]
+name = David Li
+
+[https://harsh604310081.wordpress.com/category/open-source-development/feed/]
+name = Harsh Patel
+
+[http://anhcoding.wordpress.com/feed/]
+name = Anh Hoai Ung
+
+[https://paulsprogramming.wordpress.com/feed/]
+name = Paul Jamieson
+
+[https://medium.com/feed/@hansal7014/]
+name = Hansal Bachkaniwala
+
+[http://lttse.wordpress.com/feed/]
+name = Louie Tse
+
+[https://juliephilipjames.wordpress.com/category/open-source/feed/]
+name = Julie Philip James
+
+[https://hmcildoon.wordpress.com/category/open-source/feed/]
+name = Hayley McIldoon
+
+[https://jacknian.wordpress.com/category/open-source/feed/]
+name = Xin (Jack) Nian
+
+[https://cindyledev.wordpress.com/category/open-source/feed/]
+name= Cindy Le
+
+[http://aprilprogrammer.blogspot.com/feeds/posts/default/-/open-source]
+name = Wing Tung Lau
+
+[https://medium.com/feed/sukhbeerdhillon/tagged/open-source]
+name = Sukhbeer Singh Dhillon
+
+[https://medium.com/feed/@rwilson31]
+name = Ryan Wilson
+
+[https://medium.com/feed/@sarikahanif]
+name = Sarika Hanif
+
+[https://adithsyam2.blogspot.com/feeds/posts/default/-/open-source/]
+name = Adith Syam
+
+[https://cagomezr.wordpress.com/category/open-source/feed/]
+name = Carlos A. Gomez
+
+[https://whataboutopensource.blogspot.com/feeds/posts/default/-/openSource?alt=rss]
+name = Josue Quilon Barrios
+
+[https://opensource172864682.wordpress.com/category/open-source/feed/]
+name = David Gurevich
+
+[https://jrdnlx.blogspot.com/feeds/posts/default/-/open-source]
+name = Jordan Sie
+
+[https://marss64.wordpress.com/category/open-source/feed/]
+name = Ryan Marzec
+
+[https://sentech849662565.wordpress.com/feed/]
+name = Igor Naperkovskiy
+
+[https://discoveropensource.blogspot.com/feeds/posts/default/-/open-source]
+name= David Medeiros
+
+[blog.cataldo.ca/index.php/category/open-source/feed?v=1]
+name = Luca  Cataldo
+
+[https://ultimaopensource.wordpress.com/feed/]
+name = Brett Dennis
+
+[https://medium.com/feed/@andrewvrosa]
+name = Andre Rosa
+
+[https://raungar.wordpress.com/tag/open-source/feed/]
+name=Rafi Ungar
+
+[https://jatinoopensource.wordpress.com/category/open-source-post/feed/]
+name = Jatin Arora
+
+[https://grommers.wordpress.com/category/open-source/feed/]
+name = James Inkster
+
+[https://varshannagarajan.wordpress.com/category/Open-Source/feed/]
+name = Varshan Nagarajan
+
+[https://medium.com/feed/@timfosteman]
+name = Timofei @fosteman Shchepkin
+
+[http://opensourceprojects19.blogspot.com/feeds/posts/default/-/opensource]
+name = Sina Lahsaee
+
+[https://eekbatani.blogspot.com/feeds/posts/default?alt=rss]
+name = Ehsan Ekbatani
+
+[https://ragnarokatz.wordpress.com/feed/]
+name = Bowei Yao
+
+[https://paulopensourceblog.wordpress.com/category/open-source/feed]
+name = Paul Luu
+
+[https:https://robertbegnatechblog.wordpress.com/category/open-source/feed]
+name= Robert Begna
+
+[https://medium.com/feed/@tjmorris56]
+name = Timothy Morris
+
+[https://pavankamra.blogspot.com/feeds/posts/default/-/open-source]
+name = Pavan Kamra
+
+[https://medium.com/feed/yohans-development-diary/tagged/open-source]
+name = Yohan Choi
+
+[https://bacmme.blogspot.com/feeds/posts/default/-/opensource]
+name = Bruno Alexander Cremonese de Morais
+
+[https://medium.com/feed/@ali.zufishan]
+name = Zufishan Ali
+
+[https://osstudent.blogspot.com/feeds/posts/default/-/open%20source]
+name = Cheng-Tuo Shueh
+
+[https://klopez8.blogspot.com/feeds/posts/default/-/opensource]
+name = Krystyna Lopez
+
+[https://minukpark.wordpress.com/feed/]
+name = Minuk Park
+
+[https://giatuongtran.wordpress.com/category/open-source/feed/]
+name = Gia Tuong Tran
+
+[https://semortea.wordpress.com/category/open-source/feed/]
+name = Ana Garcia
+
+[https://wradamsblog.wordpress.com/feed/]
+name = Wilson Adams
+
+[https://epicgamercharlie.wordpress.com/feed/]
+name = Charlie Le
+
+[https://medium.com/feed/@haichuan0424]
+Name = Haichuan He
+
+[https://danwithopensource.blogspot.com/feeds/posts/default/-/open source]
+Name = Daniel Beigi
+
+[https://mlforiphone.blogspot.com/feeds/posts/default?alt=rss]
+Name= Jayson Sherry
+
+[https://awesomeresponsibility.wordpress.com/category/open-source/feed/]
+name=Matthew Clifford
+
+[https://thomasopensourceblog.wordpress.com/tag/open-source/feed/]
+name=Thomas Luu
+
+[http://karlachen.blogspot.com/feeds/posts/default/-/open%20source]
+Name = Minyi Chen
+
+[https://medium.com/feed/@birtony/]
+name=Anton Biriukov
+
+[https://medium.com/feed/@jacobshuman7/]
+name=Jacob Shuman
+
+[http://khangnguyenopensource.blogspot.com/feeds/posts/default/-/Open%20Source]
+name=Ngoc Nam Khang Nguyen
+
+[https://manan-patels-blog.blogspot.com/feeds/posts/default]
+name=Manan Patel
+
+[https://evlnyng.tumblr.com/tagged/osd600/rss]
+name=Evelyn Yeung
+
+[https://dps909fall2019.blogspot.com/feeds/posts/default?alt=rss]
+name=Sefa Baah - Acheamphour
+
+[https://medium.com/feed/@ilya.zhurik]
+name=Ilya Zhuravlev
+
+[https://miggs125.wordpress.com/category/osd600/feed]
+name=Miguel Roncancio OSD600
+[https://miggs125.wordpress.com/category/spo600/feed]
+name=Miguel Roncancio SPO600
+
+[http://fengsiwen.blogspot.com/feeds/posts/default/-/Open%20Source]
+name = Siwen Feng
+
+[https://mobileopensourceproj.blogspot.com/search/label/open%20souce]
+name=Sajjad Patel
+
+[https://kartikopensource.wordpress.com/category/open-source/feed]
+name= Kartik Budhiraja
+[https://musawarbajwa.wordpress.com/2019/09/09/opensource/feed]
+name=Musawar Bajwa
+
+[https://muqingli.wordpress.com/2019/09/10/example-post/]
+name=Muqing Li
+
+[https://c3ho.blogspot.com/feeds/posts/default/-/open-source]
+name=Calvin Ho
+
+[https://c3ho.blogspot.com/feeds/posts/default/-/SPO600]
+name=Calvin Ho
+
+[https://jhyou1.wordpress.com/category/spo600/feed/]
+name=Jae You
+
+[https://inspirationalnation.wordpress.com/category/open-source/feed/]
+name=Nazneen Nahar
+
+[https://williamto10.wordpress.com/feed/]
+name=Liem Chi (William) To
+
+[https://whovsepyan.wordpress.com/feed]
+name=William Hovsepyan
+
+[http://opensourcebrowsing.blogspot.com/feeds/posts/default?alt=rss]
+name=Reza Rajabi
+
+[https://klopez8.blogspot.com/feeds/posts/default/-/FilerJS]
+name = Krystyna Lopez
+
+[https://cvvpk.github.io/spo600/feed]
+name=Cesar Valdizon
+
+[https://paulopensourceblog.wordpress.com/category/spo600/feed]
+name=Paul Luu
+
+[https://danielspo600.wordpress.com/feed]
+name=Daniel Ameresekere
+
+[https://armedwithx86.wordpress.com/feed]
+name=Brett Greenham
+
+[https://dereksblog456002294.wordpress.com/feed]
+name=Derek Neamtzu
+
+[https://penguins879376500.wordpress.com/feed]
+name=Lexis Holman
+
+[https://www.abuzayed.ca/my-blog/]
+name=Abu Zayed Kazi Masudan Nabi
+
+[https://wangpansopensource.wordpress.com/category/spo600/feed]
+name=Wang Pan
+
+[https://ipetrovopensource.wordpress.com/feed/]
+name=Igor Petrov
+
+[https://jasonsilvaroli.wordpress.com/feed/]
+name=Jason Silvaroli
+
+[https://wesliespo600.wordpress.com/feed/]
+name=Weslie Chung
+
+[https://yzhu123spo600.home.blog/feed/]
+name= Yiran Zhu
+
+[https://dev.to/feed/aalvarez89]
+name=Andrew Alvarez
+
+[https://dps909tddr.tech.blog/category/opensource/feed/]
+name=Tim Roberts
+
+[https://x7z.net/feed/]
+name=Minh Huy Nguyen
+
+[https://hyunjijanelee.blogspot.com/feeds/posts/default/-/Open-Source?alt=rss]
+name=Hyunji Lee
+
+      </pre>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Looks like the wiki is down and not coming back up quickly.  Let's host a static version of the feed list until we can rip out the code that needs this.  Once this is on staging or prod, we can update our `FEED_URL` in the `.env` to point at the cached one.

This file location should allow Gatsby to copy the HTML unmodified into the static assets it creates, see https://www.gatsbyjs.com/docs/static-folder/