### PR TITLE
Part of #1145: Added setup for frontend testing and Added test for Spinner component

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "<rootDir>/src/frontend/public/",
-      "<rootDir>/src/frontend/.cache/"
+      "<rootDir>/src/frontend/.cache/",
+      "<rootDir>/src/frontend/test/"
     ],
     "automock": false,
     "setupFiles": [
@@ -17,7 +18,8 @@
     "testPathIgnorePatterns": [
       "/node_modules/",
       "<rootDir>/src/frontend/public/",
-      "<rootDir>/src/frontend/.cache/"
+      "<rootDir>/src/frontend/.cache/",
+      "<rootDir>/src/frontend/test/"
     ]
   },
   "bin": {
@@ -36,7 +38,8 @@
     "prettier": "prettier --write \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "prettier-check": "prettier --check \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "pretest": "npm run lint",
-    "test": "npm run jest",
+    "test-frontend": "cd src/frontend/test && jest",
+    "test": "npm run jest && npm run test-frontend",
     "jest": "cross-env LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest --",
     "coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest --collectCoverage --",
     "jest-watch": "cross-env MOCK_REDIS=1 jest --watch --",

--- a/src/frontend/.babelrc
+++ b/src/frontend/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": ["babel-preset-gatsby"],
+  "env": {
+    "production": {
+      "plugins": [["react-remove-properties", { "properties": ["data-testid"] }]]
+    },
+    "development": {
+      "plugins": [["react-remove-properties", { "properties": ["data-testid"] }]]
+    }
+  }
+}

--- a/src/frontend/__mocks__/file-mock.js
+++ b/src/frontend/__mocks__/file-mock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/src/frontend/__mocks__/gatsby.js
+++ b/src/frontend/__mocks__/gatsby.js
@@ -1,0 +1,28 @@
+const React = require('react');
+
+const gatsby = jest.requireActual('gatsby');
+
+module.exports = {
+  ...gatsby,
+  graphql: jest.fn(),
+  Link: jest.fn().mockImplementation(
+    // these props are invalid for an `a` tag
+    ({
+      activeClassName,
+      activeStyle,
+      getProps,
+      innerRef,
+      partiallyActive,
+      ref,
+      replace,
+      to,
+      ...rest
+    }) =>
+      React.createElement('a', {
+        ...rest,
+        href: to,
+      })
+  ),
+  StaticQuery: jest.fn(),
+  useStaticQuery: jest.fn(),
+};

--- a/src/frontend/jest-preprocess.js
+++ b/src/frontend/jest-preprocess.js
@@ -1,0 +1,5 @@
+const babelOptions = {
+  presets: ['babel-preset-gatsby'],
+};
+
+module.exports = require('babel-jest').createTransformer(babelOptions);

--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  transform: {
+    '^.+\\.jsx?$': `<rootDir>/jest-preprocess.js`,
+  },
+  moduleNameMapper: {
+    '.+\\.(css|styl|less|sass|scss)$': `identity-obj-proxy`,
+    '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': `<rootDir>/__mocks__/file-mock.js`,
+  },
+  testPathIgnorePatterns: [`node_modules`, `\\.cache`, `frontend.*/public`],
+  transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
+  globals: {
+    __PATH_PREFIX__: ``,
+  },
+  testURL: `http://localhost`,
+  setupFiles: [`<rootDir>/loadershim.js`],
+  setupFilesAfterEnv: ['<rootDir>/setup-test-env.js'],
+};

--- a/src/frontend/loadershim.js
+++ b/src/frontend/loadershim.js
@@ -1,0 +1,4 @@
+/* eslint no-underscore-dangle: 0 */
+global.___loader = {
+  enqueue: jest.fn(),
+};

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -9,6 +9,7 @@
     "@svgr/webpack": "5.4.0",
     "apollo-boost": "0.4.9",
     "apollo-link-http": "1.5.17",
+    "babel-preset-gatsby": "0.5.14",
     "dotenv": "8.2.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "gatsby": "2.24.85",
@@ -36,13 +37,21 @@
     "typeface-roboto": "1.1.13"
   },
   "devDependencies": {
-    "json-loader": "0.5.7"
+    "@testing-library/jest-dom": "5.11.5",
+    "@testing-library/react": "11.1.0",
+    "babel-jest": "26.6.1",
+    "babel-plugin-react-remove-properties": "0.3.0",
+    "identity-obj-proxy": "3.0.0",
+    "jest": "26.6.1",
+    "json-loader": "0.5.7",
+    "react-test-renderer": "17.0.1"
   },
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean"
+    "clean": "gatsby clean",
+    "test": "jest --watchAll"
   }
 }

--- a/src/frontend/setup-test-env.js
+++ b/src/frontend/setup-test-env.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/frontend/src/components/ScrollToTop/ScrollToTop.jsx
@@ -35,7 +35,12 @@ function ScrollTop(props) {
 
   return (
     <Zoom in={trigger}>
-      <div onClick={handleClick} role="presentation" className={classes.root}>
+      <div
+        onClick={handleClick}
+        role="presentation"
+        className={classes.root}
+        data-testid="scroll-to-top-component"
+      >
         {children}
       </div>
     </Zoom>

--- a/src/frontend/src/components/Spinner/Spinner.jsx
+++ b/src/frontend/src/components/Spinner/Spinner.jsx
@@ -15,8 +15,8 @@ export default function Spinner() {
   const classes = useStyles();
 
   return (
-    <div className={classes.root}>
-      <CircularProgress />
+    <div className={classes.root} data-testid="spinner-wrapper">
+      <CircularProgress data-testid="circular-process" />
     </div>
   );
 }

--- a/src/frontend/test/Spinner.test.js
+++ b/src/frontend/test/Spinner.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Spinner from '../src/components/Spinner/Spinner.jsx';
+
+describe('Tests Spinner component', () => {
+  beforeEach(() => {
+    render(<Spinner />);
+  });
+  test('Renders without errors', async () => {
+    const spinner = await screen.findAllByTestId('spinner-wrapper');
+    expect(spinner.length).toBe(1);
+  });
+  test('Renders CircularProgress component', async () => {
+    const circularProcess = await screen.findAllByTestId('circular-process');
+    expect(circularProcess.length).toBe(1);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Part of #1145. What's in this PR?
1. Set up files required for testing
2. Provided tests for Spinner component
3. Changed jest config in package.json to ignore frontend test when run `npm run test`

## Type of Change
- [x] Add frontend tests


## Description
I would like to provide details on what I did to set up testing environment for front end
1. I followed Gatsby documentation on [Unit Testing](https://www.gatsbyjs.com/docs/unit-testing/) and [Testing React Components](https://www.gatsbyjs.com/docs/testing-react-components/). And those extra files in the root folders as well as the `__mock__` folder are the result of it. 

2. In my test, I added the `data-testid` attribute to the component so I can use it to refer to specific part of the component for testing. And because of that I included the custom `.babelrc` file to customize the default babel from Gatsby. What this file does is to remove the `data-testid` attribute I have added to the component so It won't show on browsers both in dev and prod. To do this I need two packages to be install including *babel-preset-gatsby* (to customize babel in Gatsby) and *babel-plugin-react-remove-properties* (to remove `data-testid` attribute before rendering)

3. I also provided tests for Spinner component as sample test case for you to have an idea how frontend testing works. You can find the file `Spinner.test.js` under `frontend/test` folder

4. Since jest will attempt to cover the front end tests  if we run `npm run test` in root. This would eventually lead to failures in backend test setup. I have added extra ignorePattern for jest in package.json to ignore frontend tests when run tests for backend. Also, I have added a `test-frontend` script in `package.json` to run it separately with the main set up. Now if you run `npm run test` jest will first run just the backend tests then run `test-frontend` to run frontend tests. By doing so, we would have no conflict in set up and we can have the results for both tests in one command.   

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
