### PR TITLE
Fixes #1272: Redis link causing confusion in environment setup (Docs)

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -35,7 +35,7 @@ There are two methods to install Redis on Windows. We strongly recommend the fir
 ##### Option 1: Using [WSL2 (Windows Subsystem Linux)](https://docs.microsoft.com/en-us/windows/wsl/about)
 
 1. Follow Microsoft WSL2 [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to complete the installation
-2. Depending on the distribution you chose for WSL2, install redis using that distro's package manager. For example, if using Ubuntu, run `sudo apt install redis`
+2. Depending on the distribution you chose for WSL2, install redis using that distro's package manager. For example, if using Ubuntu, run `sudo apt-get install redis`
 3. Suggest to install [Windows Terminal](https://docs.microsoft.com/en-us/windows/wsl/install-win10#install-windows-terminal-optional), it facilitates you to switch directories between WSL2 Ubuntu bash and Windows drive
 
 ##### Option 2: Using [Chocolatey package manager](https://chocolatey.org/) to install Redis on Windows

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -35,7 +35,7 @@ There are two methods to install Redis on Windows. We strongly recommend the fir
 ##### Option 1: Using [WSL2 (Windows Subsystem Linux)](https://docs.microsoft.com/en-us/windows/wsl/about)
 
 1. Follow Microsoft WSL2 [installation guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to complete the installation
-2. Follow Redis [installation guide](https://redis.io/topics/quickstart#installing-redis) to install Redis
+2. Depending on the distribution you chose for WSL2, install redis using that distro's package manager. For example, if using Ubuntu, run `sudo apt install redis`
 3. Suggest to install [Windows Terminal](https://docs.microsoft.com/en-us/windows/wsl/install-win10#install-windows-terminal-optional), it facilitates you to switch directories between WSL2 Ubuntu bash and Windows drive
 
 ##### Option 2: Using [Chocolatey package manager](https://chocolatey.org/) to install Redis on Windows

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -5,7 +5,7 @@
 - [Node.js (npm)](https://nodejs.org/en/download/)
 - [Redis](https://redis.io/) (2 methods)
   - Use [Docker and docker-compose](https://docs.docker.com/install/)
-  - Install as a [native application](https://redis.io/topics/quickstart)
+  - Install as a [native application](#Install-Redis-as-a-native-application)
 - [Elasticsearch](https://www.elastic.co/what-is/elasticsearch) (3 methods)
   - Use `MOCK_ELASTIC=1` in your `.env` to use a mock in-memory Elastic (useful for local dev)
   - Use [Docker and docker-compose](https://docs.docker.com/install/)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

 Fixes #1272 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

In the environment setup document file, when setting up redis using WSL2, one of the steps involved the process of compiling and installing redis. The much more simpler method is to use the package manager of the linux distribution you use for installing redis. For example, using "sudo apt-get install redis-server" with an ubuntu distribution. The environment-setup documentation was therefore, updated to reflect this. 

For reference, this was the link with the installation issue [with installing redis](https://redis.io/topics/quickstart#installing-redis)

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
