### PR TITLE
Fixes #1223: Merge our two "sticky headers" on scroll

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -119,7 +119,7 @@ export default function Banner() {
         justify="center"
         className={classes.container}
       >
-        <Grid id="back-to-top-anchor" item xs={8}>
+        <Grid id="back-to-top-anchor-mobile" item xs={8}>
           <div className={classes.icon}>
             <ScrollAction>
               <Fab color="secondary" aria-label="scroll-down">
@@ -129,6 +129,7 @@ export default function Banner() {
           </div>
         </Grid>
       </Grid>
+      <div id="back-to-top-anchor"></div>
     </>
   );
 }

--- a/src/frontend/src/components/Header/DesktopHeader.jsx
+++ b/src/frontend/src/components/Header/DesktopHeader.jsx
@@ -11,6 +11,8 @@ const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
     backgroundColor: 'primary',
+    justifyContent: 'center',
+    height: '8.9em',
   },
   toolbar: theme.mixins.toolbar,
   logoIcon: {
@@ -38,7 +40,6 @@ const useStyles = makeStyles((theme) => ({
 
 export default function DesktopHeader() {
   const classes = useStyles();
-
   return (
     <>
       <AppBar position="sticky" className={classes.root}>

--- a/src/frontend/src/components/Header/Header.jsx
+++ b/src/frontend/src/components/Header/Header.jsx
@@ -7,7 +7,7 @@ import DesktopHeader from './DesktopHeader.jsx';
 
 function Header() {
   const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.down(1400));
+  const matches = useMediaQuery(theme.breakpoints.down(1440));
 
   return <>{matches ? <MobileHeader /> : <DesktopHeader />}</>;
 }

--- a/src/frontend/src/components/Header/Header.jsx
+++ b/src/frontend/src/components/Header/Header.jsx
@@ -7,7 +7,7 @@ import DesktopHeader from './DesktopHeader.jsx';
 
 function Header() {
   const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.down('sm'));
+  const matches = useMediaQuery(theme.breakpoints.down(1350));
 
   return <>{matches ? <MobileHeader /> : <DesktopHeader />}</>;
 }

--- a/src/frontend/src/components/Header/Header.jsx
+++ b/src/frontend/src/components/Header/Header.jsx
@@ -7,7 +7,7 @@ import DesktopHeader from './DesktopHeader.jsx';
 
 function Header() {
   const theme = useTheme();
-  const matches = useMediaQuery(theme.breakpoints.down(1350));
+  const matches = useMediaQuery(theme.breakpoints.down(1400));
 
   return <>{matches ? <MobileHeader /> : <DesktopHeader />}</>;
 }

--- a/src/frontend/src/components/Header/MobileHeader.jsx
+++ b/src/frontend/src/components/Header/MobileHeader.jsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'primary',
     justifyContent: 'center',
     height: '8em',
+    [theme.breakpoints.down(1020)]: {
+      height: '6.5em',
+    },
   },
   toolbar: theme.mixins.toolbar,
   logoIcon: {

--- a/src/frontend/src/components/Header/MobileHeader.jsx
+++ b/src/frontend/src/components/Header/MobileHeader.jsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'primary',
     justifyContent: 'center',
     height: '8em',
-    [theme.breakpoints.down(1020)]: {
+    [theme.breakpoints.down(1065)]: {
       height: '6.5em',
     },
   },

--- a/src/frontend/src/components/Header/MobileHeader.jsx
+++ b/src/frontend/src/components/Header/MobileHeader.jsx
@@ -13,6 +13,8 @@ const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
     backgroundColor: 'primary',
+    justifyContent: 'center',
+    height: '8em',
   },
   toolbar: theme.mixins.toolbar,
   logoIcon: {

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -21,10 +21,10 @@ const useStyles = makeStyles((theme) => ({
     padding: '1.4em',
     lineHeight: '1.3',
     zIndex: 1500,
-    [theme.breakpoints.down(1400)]: {
+    [theme.breakpoints.down(1440)]: {
       padding: '.7em',
     },
-    [theme.breakpoints.down(1020)]: {
+    [theme.breakpoints.down(1065)]: {
       position: 'static',
     },
   },

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -18,12 +18,13 @@ const useStyles = makeStyles((theme) => ({
   header: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.text.secondary,
-    padding: '3em',
+    padding: '1.4em',
     lineHeight: '1.3',
-    top: '62px',
-    [theme.breakpoints.between('xs', 'sm')]: {
-      paddingTop: '2em',
-      paddingBottom: '2em',
+    zIndex: 1500,
+    [theme.breakpoints.down(1350)]: {
+      padding: '.7em',
+    },
+    [theme.breakpoints.down(985)]: {
       position: 'static',
     },
   },
@@ -79,15 +80,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function formatPublishedDate(dateString) {
+const formatPublishedDate = (dateString) => {
   const date = new Date(dateString);
   const options = { month: 'long', day: 'numeric', year: 'numeric' };
   const formatted = new Intl.DateTimeFormat('en-CA', options).format(date);
   return `Last Updated ${formatted}`;
-}
+};
 
 const Post = ({ postUrl }) => {
-  // id, html, author, url, title, date, link
   const classes = useStyles();
   // We need a ref to our post content, which we inject into a <section> below.
   const sectionEl = useRef(null);
@@ -143,7 +143,8 @@ const Post = ({ postUrl }) => {
         <Typography variant="h1" title={post.title} id={post.id} className={classes.title}>
           {post.title}
         </Typography>
-        <Typography variant="h3" className={classes.author}>
+        <Typography variant={'p'} className={classes.author}>
+          {' '}
           By{' '}
           <a className={classes.link} href={post.feed.link}>
             {post.feed.author}
@@ -151,7 +152,7 @@ const Post = ({ postUrl }) => {
         </Typography>
         <a href={post.url} rel="bookmark" className={classes.published}>
           <time className={classes.time} dateTime={post.updated}>
-            {formatPublishedDate(post.updated)}
+            {` ${formatPublishedDate(post.updated)}`}
           </time>
         </a>
       </ListSubheader>

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -21,10 +21,10 @@ const useStyles = makeStyles((theme) => ({
     padding: '1.4em',
     lineHeight: '1.3',
     zIndex: 1500,
-    [theme.breakpoints.down(1350)]: {
+    [theme.breakpoints.down(1400)]: {
       padding: '.7em',
     },
-    [theme.breakpoints.down(985)]: {
+    [theme.breakpoints.down(1020)]: {
       position: 'static',
     },
   },
@@ -144,8 +144,7 @@ const Post = ({ postUrl }) => {
           {post.title}
         </Typography>
         <Typography variant={'p'} className={classes.author}>
-          {' '}
-          By{' '}
+          &nbsp;By&nbsp;
           <a className={classes.link} href={post.feed.link}>
             {post.feed.author}
           </a>

--- a/src/frontend/src/components/Posts/Posts.jsx
+++ b/src/frontend/src/components/Posts/Posts.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSWRInfinite } from 'swr';
-
 import { Container, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import SentimentDissatisfiedRoundedIcon from '@material-ui/icons/SentimentDissatisfiedRounded';

--- a/src/frontend/src/components/ScrollAction/ScrollAction.jsx
+++ b/src/frontend/src/components/ScrollAction/ScrollAction.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const ScrollAction = ({ children }) => {
   const handleClick = (event) => {
-    const mobile = window.innerWidth <= 1020;
+    const mobile = window.innerWidth <= 1065;
     const anchor = mobile
       ? (event.target.ownerDocument || document).querySelector('#back-to-top-anchor-mobile')
       : (event.target.ownerDocument || document).querySelector('#back-to-top-anchor');

--- a/src/frontend/src/components/ScrollAction/ScrollAction.jsx
+++ b/src/frontend/src/components/ScrollAction/ScrollAction.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 
 const ScrollAction = ({ children }) => {
   const handleClick = (event) => {
-    const anchor = (event.target.ownerDocument || document).querySelector('#back-to-top-anchor');
+    const mobile = window.innerWidth <= 1400;
+    const anchor = mobile
+      ? (event.target.ownerDocument || document).querySelector('#back-to-top-anchor-mobile')
+      : (event.target.ownerDocument || document).querySelector('#back-to-top-anchor');
+
     if (anchor) {
       anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }

--- a/src/frontend/src/components/ScrollAction/ScrollAction.jsx
+++ b/src/frontend/src/components/ScrollAction/ScrollAction.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const ScrollAction = ({ children }) => {
   const handleClick = (event) => {
-    const mobile = window.innerWidth <= 1400;
+    const mobile = window.innerWidth <= 1020;
     const anchor = mobile
       ? (event.target.ownerDocument || document).querySelector('#back-to-top-anchor-mobile')
       : (event.target.ownerDocument || document).querySelector('#back-to-top-anchor');


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes: #1223

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
Fixes: 1223
      *ScrollTop and ScrollDown becomes: ScrollAction (We had repeated code for up and down, now we have only one component)
      *BackToTop becomes: BackToTopButton - No more coupling with ScrollTop
      *Also updated to ES6 the code that I worked on. 
      *Merge our two "sticky headers" on scroll (#1223)
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
