### PR TITLE
Allow searching for exact phrases

### DIFF
--- a/src/backend/utils/indexer.js
+++ b/src/backend/utils/indexer.js
@@ -51,14 +51,13 @@ const deletePost = async (postId) => {
  * @return all the results matching the passed text
  */
 const search = async (textToSearch) => {
+  console.log(textToSearch);
   const query = {
     query: {
-      match: {
-        text: {
-          query: textToSearch,
-          operator: 'AND',
-          fuzziness: 'auto',
-        },
+      simple_query_string: {
+        query: textToSearch,
+        default_operator: 'and',
+        fields: ['text'],
       },
     },
   };

--- a/src/backend/utils/indexer.js
+++ b/src/backend/utils/indexer.js
@@ -52,7 +52,6 @@ const deletePost = async (postId) => {
  */
 const search = async (textToSearch) => {
   const query = {
-    _source: ['id'],
     query: {
       simple_query_string: {
         query: textToSearch,

--- a/src/backend/utils/indexer.js
+++ b/src/backend/utils/indexer.js
@@ -51,8 +51,8 @@ const deletePost = async (postId) => {
  * @return all the results matching the passed text
  */
 const search = async (textToSearch) => {
-  console.log(textToSearch);
   const query = {
+    _source: ['id'],
     query: {
       simple_query_string: {
         query: textToSearch,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1259 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Reduces the amount results returned by full-text searching by removing fuzziness. Also allowing users to search by exact phrases.

Adding tests after people give feedback on this.

To test:
`curl http://localhost:3000/query?search="<searchTermHere>"` with a running local backend
feel free to pipe it to a file for verification by appending `> <fileName>.txt` to the end of the above command
or use PostMan
or run local backend + build frontend and use the search Posts function

`searchTermHere` should now support the following:
![image](https://user-images.githubusercontent.com/18711727/97951377-fab5fd80-1d67-11eb-83bf-42cc07081660.png)

For example if I want to check posts containing the keyword `pandas` OR `c3ho`. I would use:
`curl http://localhost:3000/query?search="pandas+|+c3ho"`

to Test Exact Phrasing:
Linux
`curl http://localhost:3000/query?search='pandas+|+%22c3ho+for+carefully%22'` 

**`%22` = escaped double quotes and `+` = spaces**

Running local back-end + front-end
![image](https://user-images.githubusercontent.com/18711727/97952791-8e89c880-1d6c-11eb-88d1-7effec635338.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
