### PR TITLE
Fixes #1266: modifies sanitize.js to allow Telescope to parse img tags with data uris

### DIFF
--- a/src/backend/utils/html/sanitize.js
+++ b/src/backend/utils/html/sanitize.js
@@ -41,10 +41,12 @@ module.exports = function (dirty) {
       'tr',
       'ul',
     ],
+    allowedSchemesByTag: { img: ['http', 'https', 'data'] },
     allowedAttributes: {
       iframe: ['src'],
       img: ['src'],
       a: ['href'],
+      blockquote: ['cite'],
     },
     allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com', 'giphy.com'],
   });

--- a/src/backend/utils/html/sanitize.js
+++ b/src/backend/utils/html/sanitize.js
@@ -46,7 +46,6 @@ module.exports = function (dirty) {
       iframe: ['src'],
       img: ['src'],
       a: ['href'],
-      blockquote: ['cite'],
     },
     allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com', 'giphy.com'],
   });

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -30,6 +30,11 @@ describe('Sanitize HTML', () => {
     expect(data).toBe('<p><a><img src="http://www.telescope.com/http_image.jpg" /></a></p>');
   });
 
+  test('protocoless urls should be accepted (i.e. not sanitized)', () => {
+    const data = sanitizeHTML('<img src="//www.telescope.com/image.jpg" />');
+    expect(data).toBe('<img src="//www.telescope.com/image.jpg" />');
+  });
+
   test('<a><img> should work, but inline js should not', () => {
     const data = sanitizeHTML(
       '<a href="https://www.telescope.com"><img border="0" alt="W3Schools" src="logo.gif" width="100" height="100"></a>'
@@ -91,15 +96,6 @@ describe('Sanitize HTML', () => {
     );
     expect(data).toBe(
       '<table><tbody><tr><td><a href="www.senecacollege.ca"><img src="https://1.bp.blogspot.com/11.JPG" /></a></td></tr><tr><td>The Final Product</td></tr></tbody></table>'
-    );
-  });
-
-  test('<blockquote> should return properly and retain its citation', () => {
-    const data = sanitizeHTML(
-      '<blockquote cite="http://www.worldwildlife.org/who/index.html"> For 50 years, WWF has been protecting the future of nature from Stone Cold Steve Austin. </blockquote>'
-    );
-    expect(data).toBe(
-      '<blockquote cite="http://www.worldwildlife.org/who/index.html"> For 50 years, WWF has been protecting the future of nature from Stone Cold Steve Austin. </blockquote>'
     );
   });
 });

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -23,6 +23,7 @@ describe('Sanitize HTML', () => {
     expect(data).toBe('<p><a><img src="https://www.telescope.com/https_image.jpg" /></a></p>');
   });
 
+  // this test might break everything in the future as Chrome moves towards blocking mixed content. see: https://web.dev/what-is-mixed-content/
   test('img links over http should be accepted (i.e. not sanitized)', () => {
     const data = sanitizeHTML(
       '<p><a><img src="http://www.telescope.com/http_image.jpg" /></a></p>'

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -6,6 +6,30 @@ describe('Sanitize HTML', () => {
     expect(data).toBe('<img src="x" />');
   });
 
+  // note: any sort of image type is accepted using a data URI (.png, .gif, .jpg, etc.)
+  test('<img src="data:..."/> URI links (gif based) should be accepted (i.e. not sanitized)', () => {
+    const data = sanitizeHTML(
+      '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />'
+    );
+    expect(data).toBe(
+      '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />'
+    );
+  });
+
+  test('img links over https should be accepted (i.e. not sanitized)', () => {
+    const data = sanitizeHTML(
+      '<p><a><img src="https://www.telescope.com/https_image.jpg" /></a></p>'
+    );
+    expect(data).toBe('<p><a><img src="https://www.telescope.com/https_image.jpg" /></a></p>');
+  });
+
+  test('img links over http should be accepted (i.e. not sanitized)', () => {
+    const data = sanitizeHTML(
+      '<p><a><img src="http://www.telescope.com/http_image.jpg" /></a></p>'
+    );
+    expect(data).toBe('<p><a><img src="http://www.telescope.com/http_image.jpg" /></a></p>');
+  });
+
   test('<a><img> should work, but inline js should not', () => {
     const data = sanitizeHTML(
       '<a href="https://www.telescope.com"><img border="0" alt="W3Schools" src="logo.gif" width="100" height="100"></a>'
@@ -67,6 +91,15 @@ describe('Sanitize HTML', () => {
     );
     expect(data).toBe(
       '<table><tbody><tr><td><a href="www.senecacollege.ca"><img src="https://1.bp.blogspot.com/11.JPG" /></a></td></tr><tr><td>The Final Product</td></tr></tbody></table>'
+    );
+  });
+
+  test('<blockquote> should return properly and retain its citation', () => {
+    const data = sanitizeHTML(
+      '<blockquote cite="http://www.worldwildlife.org/who/index.html"> For 50 years, WWF has been protecting the future of nature from Stone Cold Steve Austin. </blockquote>'
+    );
+    expect(data).toBe(
+      '<blockquote cite="http://www.worldwildlife.org/who/index.html"> For 50 years, WWF has been protecting the future of nature from Stone Cold Steve Austin. </blockquote>'
     );
   });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
## Issue This PR Addresses
Fixes #1266 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
  * Modified `sanitize.js` to allow for `img` tags to use `data` uris as `src` so they can be successfully parsed and indexed by Telescope.
  * Adds a test to ensure `data` uris are sanitized properly.
  * Adds two more `http` and `https` schema tests for `img` tag with a data uri `src`.
  * Adds `blockquote` `test` and `cite` sanitation.

Hey everyone!

As per issue #1266, this PR allows images which have a `src` `data` uri type to be properly indexed. It passes all the tests on my end thus showing that data uris are being allowed by Telescope.

I tried to ensure that this works as expected by purging my redis db via `docker exec -it telescope_redis_1 redis-cli flushall` but it seems that once a post is indexed, it is how it is and forever shall be the way it was initially indexed. So instead of going back in time I disallowed all html attributes and waited for a post to come in. Once one arrived I noticed that it had no tags at all, just plaintext, so I reverted back to normal and allowed `img`s with a data uri.

While this isn't exactly a perfect sign that everything works as expected, given that `npm test sanitize-html` runs and returns that all tests pass, and specifically: `<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />` returned as expected, I feel that Telescope should now properly parse `img`s with a data uri.

Let me know, thanks!

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
