### PR TITLE
Connect Pino logger to ElasticSearch

### DIFF
--- a/env.example
+++ b/env.example
@@ -35,6 +35,19 @@ LOG_LEVEL=debug
 # LOG_FILE is used to set a destination path to write logs. Works in production mode only.
 LOG_FILE=
 
+# Used to set if Pino should log are indexed to ElasticSearch, LOG_ELASTIC=1 to enable, if LOG_FILE and LOG_ELASTIC is set,
+# LOG_ELASTIC will take priority
+LOG_ELASTIC=
+# Following are used to set up Pino-Elastic
+# Index name for logs to be stored under
+INDEX_NAME=logs
+# Determines consistency of the write, valid values are: one, quorum or all
+CONSISTENCY=one
+# Elasticsearch Version
+ELASTIC_VERSION=7
+# The number of bytes for each bulk insert
+FLUSH_BYTES=1000
+
 # FEED_URL url used to access feed list
 FEED_URL=https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
 # Milliseconds to wait after attempting to fetch the feed list when the server is not available

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "passport": "0.4.1",
     "passport-saml": "1.3.5",
     "pino": "6.6.1",
+    "pino-elasticsearch": "5.3.0",
     "pino-pretty": "4.2.1",
     "sanitize-html": "1.27.4",
     "set-interval-async": "1.0.33",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1268 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Connecting our logger to elastic so we can index logs too and have them show up in `localhost:<elasticPort>`. Your console/terminal should not be spammed anymore by the logging if this is enabled, it should all be redirected to ElasticSearch now.

I should be able to remove the need to put `elasticStream` inside `destination = pino.destination()` and just use it directly
according to the response https://github.com/pinojs/pino/issues/845

To test:
1. Set `PINO_ELASTIC=1` in `.env` or add the variable to your `.env`
2. `npm install`
3. `npm start`
4. navigate to `http://localhost:9200/_cat/indices?v`

You should now see a new index called `logs`

This was from an earlier version I was playing with:
![image](https://user-images.githubusercontent.com/18711727/98071184-dffb8b80-1e30-11eb-9dd6-d8b57b20c9d2.png)

There's a new index called `an-index`

Visualization will come in my next PR.
## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
