### PR TITLE
Add Kibana to Telescope

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:7.9.3
     ports:
-      - ${KIBANA_PORT}:${KIBANA_POR}
+      - ${KIBANA_PORT}:${KIBANA_PORT}
     environment:
       ELASTICSEARCH_HOSTS: ${ELASTIC_URL}:${ELASTIC_PORT}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - REDIS_URL=redis://redis:${REDIS_PORT}
       # variables for elasticsearch
       - ES_HOST=elasticsearch
-      - ELASTIC_URL=http://elasticsearch
+      - ELASTIC_URL=http://elasticsearch:${ELASTIC_PORT}
     depends_on:
       - redis
       - login
@@ -46,7 +46,7 @@ services:
     ports:
       - ${KIBANA_PORT}:${KIBANA_PORT}
     environment:
-      ELASTICSEARCH_HOSTS: ${ELASTIC_URL}:${ELASTIC_PORT}
+      ELASTICSEARCH_HOSTS: http://elasticsearch:${ELASTIC_PORT}
 
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:7.9.3
     ports:
-      - ${KIBANA_PORT}:${KIBANA_PORT}
+      - ${KIBANA_PORT}:${KIBANA_POR}
     environment:
       ELASTICSEARCH_HOSTS: ${ELASTIC_URL}:${ELASTIC_PORT}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,13 +33,18 @@ services:
       - ./redis-data:/data
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
     environment:
       - bootstrap.memory_lock=true
       - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
       - discovery.type=single-node
     ports:
       - ${ELASTIC_PORT}:${ELASTIC_PORT}
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.9.3
+    ports:
+      - ${KIBANA_PORT}:${KIBANA_PORT}
 
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     image: docker.elastic.co/kibana/kibana:7.9.3
     ports:
       - ${KIBANA_PORT}:${KIBANA_PORT}
+    environment:
+      - ELASTICSEARCH_HOSTS: ${ELASTIC_URL}:${ELASTIC_PORT}
 
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     ports:
       - ${KIBANA_PORT}:${KIBANA_PORT}
     environment:
-      - ELASTICSEARCH_HOSTS: ${ELASTIC_URL}:${ELASTIC_PORT}
+      ELASTICSEARCH_HOSTS: ${ELASTIC_URL}:${ELASTIC_PORT}
 
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,10 @@ services:
     ports:
       - ${KIBANA_PORT}:${KIBANA_PORT}
     environment:
+      # Other configurations are available at https://www.elastic.co/guide/en/kibana/7.10/settings.html
       ELASTICSEARCH_HOSTS: http://elasticsearch:${ELASTIC_PORT}
+      SERVER_HOST: ${KIBANA_HOST}
+      SERVER_PORT: ${KIBANA_PORT}
 
   # SSO Identity Provider test service, https://simplesamlphp.org
   # Access to the authentication page via http://localhost:8080/simplesaml or https://localhost:8443/simplesaml

--- a/env.example
+++ b/env.example
@@ -59,6 +59,10 @@ ELASTIC_MAX_RESULTS=50
 # Delay to check connectivity with Elasticsearch in ms
 ELASTIC_DELAY_MS=10000
 
+# Kibana info
+KIBANA_URL=http://127.0.0.1
+KIBANA_PORT=5601
+
 # https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9 - is used for this current portion of code
 
 # The Single Sign On (SSO) login service URL

--- a/env.example
+++ b/env.example
@@ -60,7 +60,6 @@ ELASTIC_MAX_RESULTS=50
 ELASTIC_DELAY_MS=10000
 
 # Kibana info
-KIBANA_URL=http://127.0.0.1
 KIBANA_PORT=5601
 
 # https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9 - is used for this current portion of code

--- a/env.example
+++ b/env.example
@@ -60,7 +60,10 @@ ELASTIC_MAX_RESULTS=50
 ELASTIC_DELAY_MS=10000
 
 # Kibana info
+# Default port # is 5601, change this if using another port #
 KIBANA_PORT=5601
+# If starting Kibana with Docker, default host is localhost, change this if using another host
+KIBANA_HOST=localhost
 
 # https://medium.com/disney-streaming/setup-a-single-sign-on-saml-test-environment-with-docker-and-nodejs-c53fc1a984c9 - is used for this current portion of code
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Part of #1269
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Submitting a new PR because previous one was reverted. When the previous one was merged, staging was failing to build due to #1261 I think. `docker-compose` command was failing because the env var for Kibana port could not be found.

I was thinking of Kibana ever since we added ElasticSearch, great to finally have it added. I had to also update our ElasticSearch image to 7.9.3 so it is compatible with the current version of Kibana.

To test:

1. make sure the extra lines from `env.example` are copied into your `.env` file
2. `docker-compose up redis elasticsearch kibana`
3. navigate to `http://localhost:5601`

You should see something like this afterwards

![image](https://user-images.githubusercontent.com/18711727/98143475-25eb3a80-1e97-11eb-8893-819cda3d03d0.png)

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
