### PR TITLE
fixes issue-1180 fixes the post padding for mobile devices found in timeline.jsx

### DIFF
--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -6,7 +6,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Box, Grid, Typography, ListSubheader } from '@material-ui/core';
 import './telescope-post-content.css';
 import AdminButtons from '../AdminButtons';
-import { autoDetection } from 'highlight.js';
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -6,6 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Box, Grid, Typography, ListSubheader } from '@material-ui/core';
 import './telescope-post-content.css';
 import AdminButtons from '../AdminButtons';
+import { autoDetection } from 'highlight.js';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -52,6 +53,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   content: {
+    overflow: 'auto',
     padding: '2em',
     color: theme.palette.text.default,
   },

--- a/src/frontend/src/components/Posts/Timeline.jsx
+++ b/src/frontend/src/components/Posts/Timeline.jsx
@@ -9,6 +9,10 @@ import LoadMoreButton from './LoadMoreButton.jsx';
 import useSiteMetaData from '../../hooks/use-site-metadata';
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: 0,
+    maxWidth: '785px',
+  },
   activeCircle: {
     borderRadius: '4rem',
     transition: 'all linear 250ms',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1180 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
I traced how the padding was being applied through Chrome developer tools. I saw that the default root `padding` was being applied meaning the posts have `padding` to the left and right and were not being overridden as expected. From the previous fix that was made I saw that root style was being overridden with a `padding` of 0 in posts.jsx but since the change in #1217 , timeline.jsx was created and that is where the issue stemmed from. I saw that the Timeline function was returning the wrapped array in a container that had the `className={classes.root}`. However custom overriding of the root style was not being called in "useStyles". 

### Before
![without fix](https://user-images.githubusercontent.com/55108855/98273270-1257d680-1f60-11eb-9a51-70c3d7465132.JPG)

### After
![with fix](https://user-images.githubusercontent.com/55108855/98273318-1e439880-1f60-11eb-8ff1-8aec37d7e7ad.JPG)

<br /><br />
EDIT:
I believe this also fixed #1226 
![fixed search](https://user-images.githubusercontent.com/55108855/98275188-5e0b7f80-1f62-11eb-991c-8473288134b1.JPG)



I also ran `npm run test` and everything passed. Everything looks alright on my end.

Let me know what you think and if this is what we are after in #1180 , my JS is terrible and I probably spent far longer than needed for something like this. I hope it is what we are after.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
