### PR TITLE
added a new line to start docker daemon

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -209,7 +209,7 @@ Make sure to you have docker running on your machine, you can start docker throu
 2.  Starting the docker application manually
 3.  Restarting your machine.
 
-## I followed all the steps by my browser still can't run telescope locally
+### I followed all the steps by my browser still can't run telescope locally
 
 Try removing the docker images and pulling them again, while you're in the root directory of the project
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -203,11 +203,13 @@ Open `localhost:3000`
 
 ### How do I start Docker daemon?
 
-Make sure to you have docker running on your machine, you can start docker through the following methods
+Make sure to you have (docker)[https://docs.docker.com/engine/reference/commandline/dockerd/] running on your machine, you can start docker through the following methods:
 
 1.  Running the command `sudo dockerd`
 2.  Starting the docker application manually
 3.  Restarting your machine.
+
+You can check out the docker daemon cli through this link (here)[https://docs.docker.com/engine/reference/commandline/dockerd/)
 
 ### I followed all the steps by my browser still can't run telescope locally
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -96,6 +96,8 @@ sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
 sudo chmod g+rwx "$HOME/.docker" -R
 ```
 
+If you encounter the error `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?` then run `sudo dockerd` to start the docker daemon.
+
 10. Now run docker as a service on your machine, on startup:
     1. Enable docker on startup: `sudo systemctl enable docker`
     1. Disable docker on startup: `sudo systemctl disable docker`

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -88,28 +88,32 @@ sudo add-apt-repository \
    1. Create the Docker group: `groupadd docker`
    1. Add your user to the group: `sudo usermod -aG docker $USER`
    1. Log out and log back in (you may have to restart if you are running through a virtual machine)
-9. Make sure to you have docker running in your machine, either by `sudo dockerd` or on startup. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
-   _NOTE: This may cause errors if you have already tried to run docker before. If you get errors then run the following commands to reset it:_
+9. Make sure to you have docker running on your machine, you can start docker through the following methods
+   1. Running the command `sudo dockerd`
+   2. Starting the docker application manually
+   3. Restarting your machine.
+10. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
+    _NOTE: This may cause errors if you have already tried to run docker before. If you get errors then run the following commands to reset it:_
 
 ```
 sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
 sudo chmod g+rwx "$HOME/.docker" -R
 ```
 
-10. Now run docker as a service on your machine, on startup:
+11. Now run docker as a service on your machine, on startup:
     1. Enable docker on startup: `sudo systemctl enable docker`
     1. Disable docker on startup: `sudo systemctl disable docker`
 
 **Install Docker-Compose**
 
-11. Run to download the current stable version of Docker-Compose:
+12. Run to download the current stable version of Docker-Compose:
 
 ```
 sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 ```
 
-12. Apply executable permissions to the downloaded file: `sudo chmod +x /usr/local/bin/docker-compose`
-13. Check installation using: `docker-compose --version`
+13. Apply executable permissions to the downloaded file: `sudo chmod +x /usr/local/bin/docker-compose`
+14. Check installation using: `docker-compose --version`
 
 _NOTE: This will not work on WSL (Windows Subsystem for Linux). Use the approach listed above under WSL._
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -88,12 +88,8 @@ sudo add-apt-repository \
    1. Create the Docker group: `groupadd docker`
    1. Add your user to the group: `sudo usermod -aG docker $USER`
    1. Log out and log back in (you may have to restart if you are running through a virtual machine)
-9. Make sure to you have docker running on your machine, you can start docker through the following methods
-   1. Running the command `sudo dockerd`
-   2. Starting the docker application manually
-   3. Restarting your machine.
-10. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
-    _NOTE: This may cause errors if you have already tried to run docker before. If you get errors then run the following commands to reset it:_
+9. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
+   _NOTE: This may cause errors if you have already tried to run docker before. If you get errors then run the following commands to reset it:_
 
 ```
 sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
@@ -202,3 +198,27 @@ See [staging-production-deployment](staging-production-deployment) for more info
 **Note**: If login function is required, `npm run build` must be used instead of `npm run develop`. For more information on test accounts to log into Telescope for development, please refer to section 5 of our [Login Document](login.md):
 
 Open `localhost:3000`
+
+## Frequently Asked Questions (FAQ)
+
+### How do I start Docker daemon?
+
+Make sure to you have docker running on your machine, you can start docker through the following methods
+
+1.  Running the command `sudo dockerd`
+2.  Starting the docker application manually
+3.  Restarting your machine.
+
+## I followed all the steps by my browser still can't run telescope locally
+
+Try removing the docker images and pulling them again, while you're in the root directory of the project
+
+1.  `docker system prune -af` will delete the containers
+2.  `docker-compose up <services_here>` will pull the containers and start them up
+
+### Cannot find cgroup mount destination
+
+This could be an issue with WSL2 in Windows 10. You can resolve it by:
+
+1.  `sudo mkdir /sys/fs/cgroup/systemd`
+2.  `sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd`

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -88,15 +88,13 @@ sudo add-apt-repository \
    1. Create the Docker group: `groupadd docker`
    1. Add your user to the group: `sudo usermod -aG docker $USER`
    1. Log out and log back in (you may have to restart if you are running through a virtual machine)
-9. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
+9. Make sure to you have docker running in your machine, either by `sudo dockerd` or on startup. Verify your installation by running `docker run hello-world`. This should print a hello world paragraph that includes a confirmation that Docker is working on your system.
    _NOTE: This may cause errors if you have already tried to run docker before. If you get errors then run the following commands to reset it:_
 
 ```
 sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
 sudo chmod g+rwx "$HOME/.docker" -R
 ```
-
-If you encounter the error `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?` then run `sudo dockerd` to start the docker daemon.
 
 10. Now run docker as a service on your machine, on startup:
     1. Enable docker on startup: `sudo systemctl enable docker`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

When users face an error `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running? ` they can simply run `sudo dockerd` to start docker daemon and continue with the setup.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
