### PR TITLE
Fixed #1277: Validate input on POST /feeds with Ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@elastic/elasticsearch": "7.9.0",
     "@elastic/elasticsearch-mock": "0.3.0",
     "@wordpress/wordcount": "2.11.0",
+    "ajv": "6.12.6",
     "body-parser": "1.19.0",
     "bull": "3.18.0",
     "bull-board": "0.9.0",

--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -4,6 +4,7 @@ const { getFeeds } = require('../../utils/storage');
 const { logger } = require('../../utils/logger');
 const { protect } = require('../authentication');
 const { protectAdmin } = require('../authentication');
+const { validateNewFeed } = require('../validation');
 
 const feeds = express.Router();
 
@@ -73,7 +74,7 @@ feeds.put('/:id/flag', protectAdmin(), async (req, res) => {
   }
 });
 
-feeds.post('/', protect(), async (req, res) => {
+feeds.post('/', protect(), validateNewFeed(), async (req, res) => {
   const feedData = req.body;
   const { user } = req;
   feedData.user = user.id;

--- a/src/backend/web/validation.js
+++ b/src/backend/web/validation.js
@@ -1,0 +1,53 @@
+const Ajv = require('ajv');
+
+const ajv = new Ajv({ allErrors: true });
+
+// Expect only URI starting with http:// or https://
+const validateHttpSchemes = function (schema, uri) {
+  return typeof uri === 'string' && uri.search(/https?:\/\//i) === 0;
+};
+
+// Expect input fields not empty
+const validateNotEmpty = function (schema, data) {
+  return typeof data === 'string' && data.trim() !== '';
+};
+
+// Not Empty validation
+ajv.addKeyword('isNotEmpty', {
+  validate: validateNotEmpty,
+  errors: false,
+});
+
+// Http schemes validation
+ajv.addKeyword('httpSchemes', {
+  validate: validateHttpSchemes,
+  errors: false,
+});
+
+const feedSchema = {
+  type: 'object',
+  properties: {
+    user: { type: 'string', isNotEmpty: true },
+    url: {
+      type: 'string',
+      format: 'uri',
+      httpSchemes: true,
+    },
+    author: { type: 'string', isNotEmpty: true },
+  },
+};
+
+function validateNewFeed() {
+  return function (req, res, next) {
+    const feedData = req.body;
+    const valid = ajv.validate(feedSchema, feedData);
+
+    if (!valid) {
+      res.status(400).send();
+    } else {
+      next();
+    }
+  };
+}
+
+module.exports.validateNewFeed = validateNewFeed;

--- a/test/feeds.test.js
+++ b/test/feeds.test.js
@@ -101,9 +101,24 @@ describe('test POST /feeds endpoint', () => {
     expect(feed.url).toEqual(feedData.url);
   });
 
-  it('no author being sent', async () => {
+  it('returns 400 if no author being sent (ie: author is null or empty string)', async () => {
     const feedData = {
-      author: null,
+      user: 'user',
+      url: 'http://telescope200.cdot.systems',
+    };
+
+    feedData.author = null;
+    let res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+
+    feedData.author = '';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+  });
+
+  it('returns 400 if author provided is a number instead of string', async () => {
+    const feedData = {
+      author: 100,
       user: 'user',
       url: 'http://telescope200.cdot.systems',
     };
@@ -111,14 +126,88 @@ describe('test POST /feeds endpoint', () => {
     expect(res.status).toEqual(400);
   });
 
-  it('no url being sent', async () => {
+  it('returns 400 if no url being sent (ie: url is null or empty string)', async () => {
     const feedData = {
       author: 'foo',
       user: 'user',
-      url: null,
     };
+
+    feedData.url = null;
+    let res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+
+    feedData.url = '';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+  });
+
+  it('returns 400 if url provided is a number instead of a string', async () => {
+    const feedData = {
+      author: 'foo',
+      user: 'user',
+      url: 100,
+    };
+
     const res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
     expect(res.status).toEqual(400);
+  });
+
+  it('returns 400 if url is invalid', async () => {
+    const feedData = {
+      author: 'foo',
+      user: 'user',
+    };
+
+    feedData.url = 'www.invalidURL.com';
+    let res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+
+    feedData.url = 'chrome://www.google.com';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+  });
+
+  it(`returns 201 if url is valid`, async () => {
+    const feedData = {
+      author: 'foo',
+      user: 'user',
+    };
+
+    /** The sample links were common patterns from the valid feed list
+     *  https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List#Feeds
+     * */
+
+    feedData.url = 'http://joy3van.blogspot.com/feeds/posts/default/-/Open-Source?alt=rss';
+    let res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'https://dev.to/feed/henryzerocool/';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'https://medium.com/feed/@random4900';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'https://badalsarkar.ca/blog-opensource/feed.xml';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'https://medium.com/feed/programmer-and-a-scholar/tagged/opensource';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'http://www.hodgin.ca/?feed=rss2&cat=4';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'http://blog.auios.com/feed.php';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
+
+    feedData.url = 'http://dailypackage.fedorabook.com/index.php?/feeds/index.rss2';
+    res = await request(app).post('/feeds').send(feedData).set('Accept', 'application/json');
+    expect(res.status).toEqual(201);
   });
 
   it('url already in the feed list', async () => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
Fixes #1277 
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
In this PR, I have added the Ajv package to validate JSON input for REST API routes.  The particular route I have worked with was POST /feeds.
The JSON received by this route has the form
``` 
{
      "user" : "...",
      "author" : "...",
      "url" : "..."
}
``` 
My logic to validate this is that all properties need to be string type and cannot be empty. Also, for url property, it needs to be a valid URL as well. 
I have also modify feeds.test.js on some tests to correspond with the new middleware added

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
