### PR TITLE
Fix: issue#1302 - "Malformed input, repository not added" error message while installing Docker on Linux mint

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -224,3 +224,20 @@ This could be an issue with WSL2 in Windows 10. You can resolve it by:
 
 1.  `sudo mkdir /sys/fs/cgroup/systemd`
 2.  `sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd`
+
+### Receive "Malformed input, repository not added" message while installing Docker on Linux Mint
+
+The command below might not work on certain Linux distributions.
+
+```
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+```
+
+If you receive the error message "Malformed input, repository not added" after running this command, please try the below steps instead:
+
+1. run `sudo nano /etc/apt/sources.list.d/addtional-repositories.list`
+2. paste `deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable` to the file, save it, and exit.
+3. run `sudo add-apt-repository deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
The current instructions of Docker installation in `docs/environment-setup.md` might not work on certain Linux distributions. This PR appends a FAQ to solve the issue.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
