### PR TITLE
Added FEED_URL_INTERVAL_MS=200 to coverage script to fix the failing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pretest": "npm run lint",
     "test": "npm run jest",
     "jest": "cross-env LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest --",
-    "coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest --collectCoverage --",
+    "coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest --collectCoverage --",
     "jest-watch": "cross-env MOCK_REDIS=1 jest --watch --",
     "start": "node src/backend",
     "server": "node src/backend/web/server",


### PR DESCRIPTION

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #1239 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR solves the issue of inconsistency when run coverage vs test.

Previously when run coverage, wike-feed-parser.test was failing with error “Async callback was not invoked within the 5000 ms timeout specified by jest.setTimeout”. When run test all the tests were passed.

The issue that causing the problem is the FEED_URL_INTERVAL_MS=200 that was missing in the coverage script.

```js
"test": "npm run jest",
 "jest": "cross-env LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest --",
 "coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 jest --collectCoverage --",
```

After adding FEED_URL_INTERVAL_MS=200 to coverage script as follow:

```js
"coverage": "cross-env LOG_LEVEL=silent MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest --collectCoverage --"
```

Both tests producing the same result.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
