### PR TITLE
Fixes #1261: docker compose up --build doesn't see .env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR "/telescope"
 
 # Copy package.jsons for each service
 COPY package.json .
+COPY .env .
 COPY ./src/frontend/package.json ./src/frontend/package.json
 
 # -------------------------------------
@@ -46,7 +47,6 @@ FROM frontend_dependencies as builder
 
 COPY ./src/frontend ./src/frontend
 COPY ./.git ./.git
-COPY ./.env ./.env
 
 RUN npm run build
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #1261 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This adds the command line `COPY .env .` right after the package.json file is copied for each service, and removes the command line `COPY ./.env ./.env` in the Front-end Builder context. 
It solves the problem that the error "cannot find .env file" being thrown when doing the `docker-compose up --build`. 


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
