### PR TITLE
Fixes #1173: Change Telescope theme to a light theme

### DIFF
--- a/src/frontend/src/pages/error.jsx
+++ b/src/frontend/src/pages/error.jsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles((theme) => ({
   fab: {
     position: 'relative',
     fontSize: '1.5rem',
-    color: 'white',
+    color: '#D3D3D3',
     bottom: -45,
     zIndex: 200,
     backgroundColor: theme.palette.secondary.light,

--- a/src/frontend/src/pages/error.jsx
+++ b/src/frontend/src/pages/error.jsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles((theme) => ({
   fab: {
     position: 'relative',
     fontSize: '1.5rem',
-    color: '#D3D3D3',
+    color: theme.palette.text.default,
     bottom: -45,
     zIndex: 200,
     backgroundColor: theme.palette.secondary.light,

--- a/src/frontend/src/theme.js
+++ b/src/frontend/src/theme.js
@@ -14,10 +14,10 @@ const theme = createMuiTheme({
       main: red.A400,
     },
     background: {
-      default: '#E5E5E5',
+      default: '#FCFCFC',
     },
     text: {
-      primary: '#E5E5E5',
+      primary: '#FCFCFC',
       secondary: '#8BC2EB',
       default: '#181818',
     },

--- a/src/frontend/src/theme.js
+++ b/src/frontend/src/theme.js
@@ -14,10 +14,10 @@ const theme = createMuiTheme({
       main: red.A400,
     },
     background: {
-      default: '#FCFCFC',
+      default: '#E5E5E5',
     },
     text: {
-      primary: '#FCFCFC',
+      primary: '#E5E5E5',
       secondary: '#8BC2EB',
       default: '#181818',
     },


### PR DESCRIPTION
## Issue This PR Addresses

#1173. Change Telescope Theme to a light theme

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

Homepage
![image](https://user-images.githubusercontent.com/45149474/98846121-a7eddd00-241c-11eb-9d33-4078dfae8467.png)

About page
![image](https://user-images.githubusercontent.com/45149474/98846163-b2a87200-241c-11eb-98b1-3c5e928e11cd.png)

My feed page
![image](https://user-images.githubusercontent.com/45149474/98846207-c0f68e00-241c-11eb-8ee8-d40d29d0703b.png)

404 page
![image](https://user-images.githubusercontent.com/45149474/98846472-0adf7400-241d-11eb-9363-b9e34944aa8d.png)

While I'am working on lighten the 404 page, I've found the homepage, about page, and my feed page also got lighter theme following my change. I've changed background and primary colour on 'theme.js' file. Please have a look at this colour change is whether what you or not and let me know if you want another colour theme.

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
