### PR TITLE
Fixes #Issue 1279: Better errors for failures with Search and ElasticSearch

### DIFF
--- a/src/backend/web/routes/query.js
+++ b/src/backend/web/routes/query.js
@@ -11,7 +11,7 @@ router.get('/', validateQuery(), async (req, res) => {
     const { text, filter, page, perPage } = req.query;
     res.send(await search(text, filter, page, perPage));
   } catch (error) {
-    res.send(`There was an error while executing your query: ${error}`);
+    res.status(500).send(`There was an error while executing your query: ${error}`);
     logger.error({ error }, 'Something went wrong with search indexing');
   }
 });

--- a/src/frontend/src/components/SearchPage/SearchResults.jsx
+++ b/src/frontend/src/components/SearchPage/SearchResults.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { useSWRInfinite } from 'swr';
-import { Container } from '@material-ui/core';
+import { Container, Box, Grid, Typography, ListSubheader } from '@material-ui/core';
 
 import useSiteMetadata from '../../hooks/use-site-metadata';
 import Timeline from '../Posts/Timeline.jsx';
@@ -38,10 +38,18 @@ const SearchResults = ({ text, filter }) => {
   );
 
   if (error) {
-    // TODO: https://github.com/Seneca-CDOT/telescope/issues/1279
     return (
       <Container className={classes.searchResults}>
-        <p>Error loading search results</p>;
+        <Box className={classes.root} boxShadow={2} marginTop={10}>
+          <ListSubheader>
+            <Typography variant="h1" color="secondary" className={classes.title}>
+              <Grid container className={classes.error}>
+                {' '}
+                There was an error while processing your query
+              </Grid>
+            </Typography>
+          </ListSubheader>
+        </Box>
       </Container>
     );
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1279 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

This PR attempts to address the bug involving an incorrect response status being sent in circumstances not already covered, such as when elasticSearch is shut downed. As this fix also affects the UI on the front-end, this PR also attempts to update the front-end UI to put informative message to the user that the post could not be retrieved. 

An example of the correct API response that should be sent:
![PR](https://user-images.githubusercontent.com/16841702/98860795-2f921680-2432-11eb-9db4-3318edb5f7b7.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
