### PR TITLE
Add hook for getting Telescope contributors from GitHub

### DIFF
--- a/src/frontend/src/hooks/use-telescope-contributor.js
+++ b/src/frontend/src/hooks/use-telescope-contributor.js
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+const pickRandomContributor = (contributors) => {
+  return contributors[Math.floor(Math.random() * contributors.length) + 1];
+};
+
+const useTelescopeContributor = () => {
+  const [contributor, setContributor] = useState(null);
+  const [error, setError] = useState();
+  const telescopeGitHubContributorsUrl =
+    'https://api.github.com/repos/Seneca-CDOT/telescope/contributors';
+
+  useEffect(() => {
+    const fetchContributors = async () => {
+      try {
+        const response = await fetch(telescopeGitHubContributorsUrl);
+        if (!response.ok) {
+          throw new Error('GitHub API response not OK');
+        }
+
+        const contributors = await response.json();
+        setContributor(pickRandomContributor(contributors));
+      } catch (err) {
+        setError(err);
+      }
+    };
+    fetchContributors();
+  }, []);
+
+  return { contributor, error };
+};
+
+export default useTelescopeContributor;


### PR DESCRIPTION
## Issue This PR Addresses

Part of #1232

Should this PR get merged I will create a couple more issues related to this issue as [discussed here](https://seneca-open-source.slack.com/archives/CS5DGCAE5/p1605108742117300). 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds a React hook to the application that fetches a random Telescope contributor once on load in the about page. Once this PR is merged I will create one issue to get someone to display the information in the AboutFooter. and another issue to create some tests for the hook. 


## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
