### PR TITLE
Add check for empty descriptions to avoid empty blog posts

### DIFF
--- a/src/backend/utils/html/index.js
+++ b/src/backend/utils/html/index.js
@@ -1,9 +1,12 @@
+const jsdom = require('jsdom');
 const sanitize = require('./sanitize');
 const fixIFrameWidth = require('./fix-iframe-width');
 const lazyLoad = require('./lazy-load');
 const syntaxHighlight = require('./syntax-highlight');
 const replaceCodeEntities = require('./replace-entities');
 const toDOM = require('./dom');
+
+const { JSDOM } = jsdom;
 
 /**
  * Takes a String of HTML and sanitizes, syntax highlights, and
@@ -18,6 +21,12 @@ module.exports = function process(html) {
 
   // Sanitize the HTML to remove unwanted elements and attributes
   const clean = sanitize(html);
+
+  // Checks if the context of the sanitized html contains whitespace only.
+  const fragment = JSDOM.fragment(clean);
+  if (fragment.textContent.replace(/\s/gim, '').length <= 0) {
+    throw new Error('post is empty');
+  }
 
   // Create a document we can process
   const dom = toDOM(clean);

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -100,6 +100,16 @@ const getValidHtmlBody = () =>
   </html>
   `;
 
+const getInvalidDescription = () =>
+  `
+  <p>     </p>
+  <p>   <br><br><br><br><br></p>
+  <p>    </p>
+  <p>     </p>
+  <p>      </p>
+  <p></p>
+  `;
+
 /**
  * Generic network nock request, used below to define all our mock requests.
  *
@@ -123,6 +133,7 @@ exports.getRssUri = getRssUri;
 exports.getHtmlUri = getHtmlUri;
 exports.getRealWorldRssUri = getRealWorldRssUri;
 exports.stripProtocol = stripProtocol;
+exports.getInvalidDescription = getInvalidDescription;
 
 exports.getValidFeedBody = getValidFeedBody;
 exports.getEmptyFeedBody = getEmptyFeedBody;

--- a/test/post.test.js
+++ b/test/post.test.js
@@ -1,6 +1,10 @@
 const { parse } = require('feedparser-promised');
 
-const { nockRealWorldRssResponse, getRealWorldRssUri } = require('./fixtures');
+const {
+  nockRealWorldRssResponse,
+  getRealWorldRssUri,
+  getInvalidDescription,
+} = require('./fixtures');
 const Post = require('../src/backend/data/post');
 const Feed = require('../src/backend/data/feed');
 const hash = require('../src/backend/data/hash');
@@ -234,6 +238,12 @@ describe('Post data class tests', () => {
       const id = await Post.createFromArticle(article, feed);
       const post = await Post.byId(id);
       expect(post.title).toEqual('Untitled');
+    });
+
+    test('Post.createFromArticle() with whitespace only in description should throw', async () => {
+      const article = articles[0];
+      article.description = getInvalidDescription();
+      await expect(Post.createFromArticle(article, feed)).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #1249 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The `description` of an article from an RSS feed holds the raw html for blog posts which can contain just whitespace in it's context(s) which should be invalid. This uses `jsdom` to turn the `description` into a fragment of html and checks if the context contains only whitespace.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
