### PR TITLE
ReOpen: Fix#Issue 1311 - validate GET /posts/:id route using Express Validator

### DIFF
--- a/src/backend/web/routes/posts.js
+++ b/src/backend/web/routes/posts.js
@@ -3,7 +3,7 @@ const express = require('express');
 const Post = require('../../data/post');
 const { getPosts, getPostsCount } = require('../../utils/storage');
 const { logger } = require('../../utils/logger');
-const { validatePostsQuery } = require('../validation');
+const { validatePostsQuery, validatePostsIdParam } = require('../validation');
 
 const posts = express.Router();
 
@@ -73,7 +73,7 @@ posts.get('/', validatePostsQuery(), async (req, res) => {
   );
 });
 
-posts.get('/:id', async (req, res) => {
+posts.get('/:id', validatePostsIdParam(), async (req, res) => {
   const { id } = req.params;
 
   try {

--- a/src/backend/web/validation.js
+++ b/src/backend/web/validation.js
@@ -1,6 +1,6 @@
 const Ajv = require('ajv');
 
-const { check, query, validationResult } = require('express-validator');
+const { check, query, param, validationResult } = require('express-validator');
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -98,8 +98,13 @@ const queryValidationRules = [
     .bail(),
 ];
 
+const postsIdParamValidationRules = [
+  param('id', 'Id Length is invalid').isLength({ min: 10, max: 10 }),
+];
+
 module.exports = {
   validateNewFeed,
   validateQuery: () => validate(queryValidationRules),
   validatePostsQuery: () => validate(postsQueryValidationRules),
+  validatePostsIdParam: () => validate(postsIdParamValidationRules),
 };

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -195,4 +195,20 @@ describe('test /posts/:id responses', () => {
     expect(res.get('Content-type')).toContain('application/json');
     expect(res.body).toEqual(JSON.parse(JSON.stringify(receivedPost1)));
   });
+
+  test('requests ID with 6 characters Test', async () => {
+    const res = await request(app).get(`/posts/123456`).set('Accept', 'text/html');
+    expect(res.status).toEqual(400);
+  });
+
+  test('requests ID with 14 characters Test', async () => {
+    const res = await request(app).get(`/posts/12345678901234`).set('Accept', 'text/html');
+    expect(res.status).toEqual(400);
+  });
+
+  test('requests ID with valid length but not exist Test', async () => {
+    const res = await request(app).get(`/posts/1234567890`).set('Accept', 'text/html');
+    expect(res.status).toEqual(404);
+    expect(res.get('Content-length')).toEqual('46');
+  });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
Fixes #1311 
https://github.com/Seneca-CDOT/telescope/issues/1311

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
 
<!-- Please add a detailed description of what this PR does and why it is needed -->

The validation will check the length of the parameter 'Id' in posts. In this issue, I only applied it to GET /posts/:id but it could be applied to any posts url with id param.  Normal id length is 10 and the reason why I used the length check is the id value is encoded by hash algorithms and sliced to 10 characters. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
