### PR TITLE
Closes #1193: Feature: add synchronized author/post outline in desktop view

### DIFF
--- a/src/frontend/gatsby-browser.js
+++ b/src/frontend/gatsby-browser.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import UserProvider from './src/contexts/User/UserProvider';
+import InViewProvider from './src/contexts/InView/InViewProvider';
 
 // Named export required for useContext
 /* eslint-disable import/prefer-default-export */
 export const wrapRootElement = ({ element }) => {
-  return <UserProvider>{element}</UserProvider>;
+  return (
+    <InViewProvider>
+      <UserProvider>{element}</UserProvider>;
+    </InViewProvider>
+  );
 };

--- a/src/frontend/gatsby-ssr.js
+++ b/src/frontend/gatsby-ssr.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import UserProvider from './src/contexts/User/UserProvider';
+import InViewProvider from './src/contexts/InView/InViewProvider';
 
 // Named export required for useContext
 /* eslint-disable import/prefer-default-export */
 export const wrapRootElement = ({ element }) => {
-  return <UserProvider>{element}</UserProvider>;
+  return (
+    <InViewProvider>
+      <UserProvider>{element}</UserProvider>;
+    </InViewProvider>
+  );
 };

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -30,6 +30,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-helmet": "6.1.0",
+    "react-intersection-observer": "8.30.3",
     "react-material-ui-form-validator": "2.1.1",
     "react-swipeable-views": "0.13.9",
     "react-swipeable-views-utils": "0.13.9",

--- a/src/frontend/src/components/Posts/Outline/Entry.jsx
+++ b/src/frontend/src/components/Posts/Outline/Entry.jsx
@@ -1,0 +1,49 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { ListItem, ListItemText, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import useSWR from 'swr';
+import { InViewStateContext } from '../../../contexts/InView/InViewContext';
+
+const useStyles = makeStyles((theme) => ({
+  text: {
+    color: theme.palette.primary.main,
+    fontSize: '1.6em',
+  },
+  size: {
+    height: theme.spacing(4),
+    width: theme.spacing(4),
+  },
+}));
+
+const PostReference = ({ postUrl }) => {
+  const classes = useStyles();
+  const inViewPost = useContext(InViewStateContext);
+  const { data: post } = useSWR(postUrl, (url) => fetch(url).then((r) => r.json()));
+
+  if (!post) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <ListItem
+      button
+      component="a"
+      href={`#inView${post.id}`}
+      autoFocus={post.id === inViewPost}
+      selected={post.id === inViewPost}
+    >
+      <ListItemText
+        disableTypography
+        primary={<Typography className={classes.text}>{`${post.feed.author}`}</Typography>}
+        secondary={<Typography className={classes.text}>{`- ${post.title}`}</Typography>}
+      />
+    </ListItem>
+  );
+};
+
+PostReference.propTypes = {
+  postUrl: PropTypes.string,
+};
+
+export default PostReference;

--- a/src/frontend/src/components/Posts/Outline/Outline.jsx
+++ b/src/frontend/src/components/Posts/Outline/Outline.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ListSubheader } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import useSiteMetaData from '../../../hooks/use-site-metadata';
+import Entry from './Entry.jsx';
+
+const useStyles = makeStyles((theme) => ({
+  header: {
+    backgroundColor: theme.palette.primary.primary,
+    padding: '2em',
+    overflowY: 'scroll',
+    maxHeight: '500px',
+    top: '62px',
+  },
+}));
+
+const Outline = ({ posts }) => {
+  const classes = useStyles();
+  const { telescopeUrl } = useSiteMetaData();
+
+  if (!posts) return <div>Loading...</div>;
+
+  const postsUrl = posts.map((set) =>
+    set.map(({ id, url }) => <Entry postUrl={`${telescopeUrl}${url}`} key={id} />)
+  );
+
+  return (
+    <ListSubheader className={classes.header} component="nav">
+      {postsUrl && postsUrl.map((post) => post)}
+    </ListSubheader>
+  );
+};
+
+Outline.propTypes = {
+  posts: PropTypes.array,
+};
+
+export default Outline;

--- a/src/frontend/src/components/Posts/Outline/index.js
+++ b/src/frontend/src/components/Posts/Outline/index.js
@@ -1,0 +1,3 @@
+import Outline from './Outline.jsx';
+
+export default Outline;

--- a/src/frontend/src/components/Posts/Posts.jsx
+++ b/src/frontend/src/components/Posts/Posts.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSWRInfinite } from 'swr';
 import { Container, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import SentimentDissatisfiedRoundedIcon from '@material-ui/icons/SentimentDissatisfiedRounded';
 import Timeline from './Timeline.jsx';
 import useSiteMetaData from '../../hooks/use-site-metadata';
+import Outline from './Outline';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -30,6 +31,7 @@ const REFRESH_INTERVAL = 5 * 60 * 1000; /* refresh data every 5 minutes */
 
 const Posts = () => {
   const classes = useStyles();
+  const [isDesktopView, setDesktopView] = useState(true);
   const { telescopeUrl } = useSiteMetaData();
   const { data, size, setSize, error } = useSWRInfinite(
     (index) => `${telescopeUrl}/posts?page=${index + 1}`,
@@ -38,6 +40,16 @@ const Posts = () => {
       refreshInterval: REFRESH_INTERVAL,
     }
   );
+
+  const updateMedia = () => {
+    setDesktopView(window.innerWidth > 1450);
+  };
+
+  useEffect(() => {
+    updateMedia();
+    window.addEventListener('resize', updateMedia);
+    return () => window.removeEventListener('resize', updateMedia);
+  });
 
   // TODO: need proper error handling
   if (error) {
@@ -60,7 +72,16 @@ const Posts = () => {
     );
   }
 
-  return (
+  return isDesktopView ? (
+    <Grid container>
+      <Grid item xs={4}>
+        <Outline posts={data} />
+      </Grid>
+      <Grid item className={classes.root} xs={8}>
+        <Timeline pages={data} nextPage={() => setSize(size + 1)} />
+      </Grid>
+    </Grid>
+  ) : (
     <Container className={classes.root}>
       <Timeline pages={data} nextPage={() => setSize(size + 1)} />
     </Container>

--- a/src/frontend/src/components/Posts/Timeline.jsx
+++ b/src/frontend/src/components/Posts/Timeline.jsx
@@ -12,6 +12,7 @@ import useSiteMetaData from '../../hooks/use-site-metadata';
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: 0,
+    paddingLeft: '1em',
     maxWidth: '785px',
   },
   activeCircle: {

--- a/src/frontend/src/contexts/InView/InViewContext/index.js
+++ b/src/frontend/src/contexts/InView/InViewContext/index.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+export const InViewStateContext = createContext();
+export const InViewDispatchContext = createContext();

--- a/src/frontend/src/contexts/InView/InViewProvider/index.js
+++ b/src/frontend/src/contexts/InView/InViewProvider/index.js
@@ -1,0 +1,21 @@
+import React, { useReducer } from 'react';
+import PropTypes from 'prop-types';
+import { InViewStateContext, InViewDispatchContext } from '../InViewContext';
+import { InViewReducer, initialState } from '../InViewReducer';
+
+const InViewProvider = (props) => {
+  const [state, dispatch] = useReducer(InViewReducer, initialState);
+  return (
+    <InViewStateContext.Provider value={state}>
+      <InViewDispatchContext.Provider value={dispatch}>
+        {props.children}
+      </InViewDispatchContext.Provider>
+    </InViewStateContext.Provider>
+  );
+};
+
+InViewProvider.propTypes = {
+  children: PropTypes.array,
+};
+
+export default InViewProvider;

--- a/src/frontend/src/contexts/InView/InViewReducer/index.js
+++ b/src/frontend/src/contexts/InView/InViewReducer/index.js
@@ -1,0 +1,13 @@
+export const initialState = {
+  selected: '',
+};
+
+export const InViewReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'SELECT_POST': {
+      return action.payload;
+    }
+    default:
+      return state;
+  }
+};

--- a/src/frontend/src/contexts/User/UserProvider/index.js
+++ b/src/frontend/src/contexts/User/UserProvider/index.js
@@ -13,7 +13,7 @@ const UserProvider = (props) => {
 };
 
 UserProvider.propTypes = {
-  children: PropTypes.elementType,
+  children: PropTypes.object,
 };
 
 export default UserProvider;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #1193 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

This adds an author/post outline in the desktop view.

To keep track of posts entering and leaving the viewport, I used [react-intersection-observer](https://www.npmjs.com/package/react-intersection-observer). I saw the solution used in #1332, but I thought this module provides more functionality and [testing tools](https://www.npmjs.com/package/react-intersection-observer#testing).

For communication between the outline and the timeline components, I used [useContext](https://reactjs.org/docs/hooks-reference.html#usecontext).

Originally, keeping track of posts' headers would've been the best approach to know when a post enters or leaves the viewport, but after all the improvements and the way headers behave now, I had to switch to tracking posts' content. This causes weird behaviours sometimes, but I'm working on solving that.

This is a first iteration that mainly focuses on functionality. Styling can be improved in follow-up pull requests (please don't make me do it).

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
