### PR TITLE
Fixes issue-1371: Make the picture sticky in About page

### DIFF
--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -9,7 +9,6 @@ import { graphql } from 'gatsby';
 
 import PageBase from '../pages/PageBase';
 import AboutFooter from '../components/AboutFooter';
-import { yellow } from '@material-ui/core/colors';
 
 const AutoPlaySwipeableViews = autoPlay(SwipeableViews);
 

--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -37,7 +37,7 @@ const tutorialSteps = [
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    flexGrow: 1,
+    // flexGrow: 1,
   },
   markdownBody: {
     padding: '2rem',
@@ -45,13 +45,11 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: '785px',
     color: theme.palette.text.default,
   },
-  sticky: {
-    position: 'sticky',
-    top: '80px',
-  },
   carousel: {
     paddingTop: '8rem',
     padding: '4rem',
+    position: 'fixed',
+    top: 'center',
   },
   img: {
     display: 'block',
@@ -103,61 +101,59 @@ export default function Template({
     <PageBase title={frontmatter.title}>
       <Grid container className={classes.root}>
         <Grid container>
-          <Grid item xs={12} md={6} className={classes.carousel}>
-            <div className={classes.sticky}>
-              <AutoPlaySwipeableViews
-                axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
-                index={activeStep}
-                onChangeIndex={handleStepChange}
-                enableMouseEvents
-              >
-                {tutorialSteps.map((step, index) => (
-                  <div key={step.label}>
-                    {Math.abs(activeStep - index) <= 2 ? (
-                      <img className={classes.img} src={step.imgPath} alt={step.label} />
-                    ) : null}
-                  </div>
-                ))}
-              </AutoPlaySwipeableViews>
-              <MobileStepper
-                steps={maxSteps}
-                position="static"
-                variant="dots"
-                className={classes.footer}
-                activeStep={activeStep}
-                nextButton={
-                  <Button
-                    size="large"
-                    className={classes.footerButton}
-                    onClick={handleNext}
-                    disabled={activeStep === maxSteps - 1}
-                  >
-                    {theme.direction === 'rtl' ? (
-                      <KeyboardArrowLeft fontSize="large" />
-                    ) : (
-                      <KeyboardArrowRight fontSize="large" />
-                    )}
-                  </Button>
-                }
-                backButton={
-                  <Button
-                    size="large"
-                    className={classes.footerButton}
-                    onClick={handleBack}
-                    disabled={activeStep === 0}
-                  >
-                    {theme.direction === 'rtl' ? (
-                      <KeyboardArrowRight fontSize="large" />
-                    ) : (
-                      <KeyboardArrowLeft fontSize="large" />
-                    )}
-                  </Button>
-                }
-              />
-            </div>
+          <Grid item xs={6} className={classes.carousel}>
+            <AutoPlaySwipeableViews
+              axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
+              index={activeStep}
+              onChangeIndex={handleStepChange}
+              enableMouseEvents
+            >
+              {tutorialSteps.map((step, index) => (
+                <div key={step.label}>
+                  {Math.abs(activeStep - index) <= 2 ? (
+                    <img className={classes.img} src={step.imgPath} alt={step.label} />
+                  ) : null}
+                </div>
+              ))}
+            </AutoPlaySwipeableViews>
+            <MobileStepper
+              steps={maxSteps}
+              position="static"
+              variant="dots"
+              className={classes.footer}
+              activeStep={activeStep}
+              nextButton={
+                <Button
+                  size="large"
+                  className={classes.footerButton}
+                  onClick={handleNext}
+                  disabled={activeStep === maxSteps - 1}
+                >
+                  {theme.direction === 'rtl' ? (
+                    <KeyboardArrowLeft fontSize="large" />
+                  ) : (
+                    <KeyboardArrowRight fontSize="large" />
+                  )}
+                </Button>
+              }
+              backButton={
+                <Button
+                  size="large"
+                  className={classes.footerButton}
+                  onClick={handleBack}
+                  disabled={activeStep === 0}
+                >
+                  {theme.direction === 'rtl' ? (
+                    <KeyboardArrowRight fontSize="large" />
+                  ) : (
+                    <KeyboardArrowLeft fontSize="large" />
+                  )}
+                </Button>
+              }
+            />
           </Grid>
-
-          <Grid item xs={12} md={6}>
+          <Grid item xs={6}></Grid>
+          <Grid item xs={6}>
             <div className={classes.markdownBody}>
               <h1>{frontmatter.title}</h1>
               <div dangerouslySetInnerHTML={{ __html: html }} />

--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -45,12 +45,13 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: '785px',
     color: theme.palette.text.default,
   },
+  sticky: {
+    position: 'sticky',
+    top: '20%',
+  },
   carousel: {
     paddingTop: '8rem',
     padding: '4rem',
-    position: 'fixed',
-    top: '3%',
-    marginLeft: '3%',
   },
   img: {
     display: 'block',
@@ -62,14 +63,10 @@ const useStyles = makeStyles((theme) => ({
   stepper: {
     iconColor: theme.palette.text.primary,
   },
-  picture: {
-    width: '100%',
-  },
   footer: {
     display: 'flex',
     alignItems: 'center',
     height: 40,
-    width: '100%',
     backgroundColor: theme.palette.secondary.main,
     boxShadow:
       'rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px',
@@ -106,60 +103,60 @@ export default function Template({
     <PageBase title={frontmatter.title}>
       <Grid container className={classes.root}>
         <Grid container>
-          <Grid item xs={5} className={classes.carousel}>
-            <AutoPlaySwipeableViews
-              className={classes.picture}
-              axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
-              index={activeStep}
-              onChangeIndex={handleStepChange}
-              enableMouseEvents
-            >
-              {tutorialSteps.map((step, index) => (
-                <div key={step.label}>
-                  {Math.abs(activeStep - index) <= 2 ? (
-                    <img className={classes.img} src={step.imgPath} alt={step.label} />
-                  ) : null}
-                </div>
-              ))}
-            </AutoPlaySwipeableViews>
-            <MobileStepper
-              steps={maxSteps}
-              position="static"
-              variant="dots"
-              className={classes.footer}
-              activeStep={activeStep}
-              nextButton={
-                <Button
-                  size="large"
-                  className={classes.footerButton}
-                  onClick={handleNext}
-                  disabled={activeStep === maxSteps - 1}
-                >
-                  {theme.direction === 'rtl' ? (
-                    <KeyboardArrowLeft fontSize="large" />
-                  ) : (
-                    <KeyboardArrowRight fontSize="large" />
-                  )}
-                </Button>
-              }
-              backButton={
-                <Button
-                  size="large"
-                  className={classes.footerButton}
-                  onClick={handleBack}
-                  disabled={activeStep === 0}
-                >
-                  {theme.direction === 'rtl' ? (
-                    <KeyboardArrowRight fontSize="large" />
-                  ) : (
-                    <KeyboardArrowLeft fontSize="large" />
-                  )}
-                </Button>
-              }
-            />
+          <Grid item xs={12} md={6} className={classes.carousel}>
+            <div className={classes.sticky}>
+              <AutoPlaySwipeableViews
+                axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
+                index={activeStep}
+                onChangeIndex={handleStepChange}
+                enableMouseEvents
+              >
+                {tutorialSteps.map((step, index) => (
+                  <div key={step.label}>
+                    {Math.abs(activeStep - index) <= 2 ? (
+                      <img className={classes.img} src={step.imgPath} alt={step.label} />
+                    ) : null}
+                  </div>
+                ))}
+              </AutoPlaySwipeableViews>
+              <MobileStepper
+                steps={maxSteps}
+                position="static"
+                variant="dots"
+                className={classes.footer}
+                activeStep={activeStep}
+                nextButton={
+                  <Button
+                    size="large"
+                    className={classes.footerButton}
+                    onClick={handleNext}
+                    disabled={activeStep === maxSteps - 1}
+                  >
+                    {theme.direction === 'rtl' ? (
+                      <KeyboardArrowLeft fontSize="large" />
+                    ) : (
+                      <KeyboardArrowRight fontSize="large" />
+                    )}
+                  </Button>
+                }
+                backButton={
+                  <Button
+                    size="large"
+                    className={classes.footerButton}
+                    onClick={handleBack}
+                    disabled={activeStep === 0}
+                  >
+                    {theme.direction === 'rtl' ? (
+                      <KeyboardArrowRight fontSize="large" />
+                    ) : (
+                      <KeyboardArrowLeft fontSize="large" />
+                    )}
+                  </Button>
+                }
+              />
+            </div>
           </Grid>
-          <Grid item xs={6} md={6}></Grid>
-          <Grid item xs={6} md={6}>
+          <Grid item xs={12} md={6}>
             <div className={classes.markdownBody}>
               <h1>{frontmatter.title}</h1>
               <div dangerouslySetInnerHTML={{ __html: html }} />

--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -9,6 +9,7 @@ import { graphql } from 'gatsby';
 
 import PageBase from '../pages/PageBase';
 import AboutFooter from '../components/AboutFooter';
+import { yellow } from '@material-ui/core/colors';
 
 const AutoPlaySwipeableViews = autoPlay(SwipeableViews);
 
@@ -44,6 +45,10 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '16px',
     maxWidth: '785px',
     color: theme.palette.text.default,
+  },
+  sticky: {
+    position: 'sticky',
+    top: '0',
   },
   carousel: {
     paddingTop: '8rem',
@@ -100,56 +105,59 @@ export default function Template({
       <Grid container className={classes.root}>
         <Grid container>
           <Grid item xs={12} md={6} className={classes.carousel}>
-            <AutoPlaySwipeableViews
-              axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
-              index={activeStep}
-              onChangeIndex={handleStepChange}
-              enableMouseEvents
-            >
-              {tutorialSteps.map((step, index) => (
-                <div key={step.label}>
-                  {Math.abs(activeStep - index) <= 2 ? (
-                    <img className={classes.img} src={step.imgPath} alt={step.label} />
-                  ) : null}
-                </div>
-              ))}
-            </AutoPlaySwipeableViews>
-            <MobileStepper
-              steps={maxSteps}
-              position="static"
-              variant="dots"
-              className={classes.footer}
-              activeStep={activeStep}
-              nextButton={
-                <Button
-                  size="large"
-                  className={classes.footerButton}
-                  onClick={handleNext}
-                  disabled={activeStep === maxSteps - 1}
-                >
-                  {theme.direction === 'rtl' ? (
-                    <KeyboardArrowLeft fontSize="large" />
-                  ) : (
-                    <KeyboardArrowRight fontSize="large" />
-                  )}
-                </Button>
-              }
-              backButton={
-                <Button
-                  size="large"
-                  className={classes.footerButton}
-                  onClick={handleBack}
-                  disabled={activeStep === 0}
-                >
-                  {theme.direction === 'rtl' ? (
-                    <KeyboardArrowRight fontSize="large" />
-                  ) : (
-                    <KeyboardArrowLeft fontSize="large" />
-                  )}
-                </Button>
-              }
-            />
+            <div className={classes.sticky}>
+              <AutoPlaySwipeableViews
+                axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
+                index={activeStep}
+                onChangeIndex={handleStepChange}
+                enableMouseEvents
+              >
+                {tutorialSteps.map((step, index) => (
+                  <div key={step.label}>
+                    {Math.abs(activeStep - index) <= 2 ? (
+                      <img className={classes.img} src={step.imgPath} alt={step.label} />
+                    ) : null}
+                  </div>
+                ))}
+              </AutoPlaySwipeableViews>
+              <MobileStepper
+                steps={maxSteps}
+                position="static"
+                variant="dots"
+                className={classes.footer}
+                activeStep={activeStep}
+                nextButton={
+                  <Button
+                    size="large"
+                    className={classes.footerButton}
+                    onClick={handleNext}
+                    disabled={activeStep === maxSteps - 1}
+                  >
+                    {theme.direction === 'rtl' ? (
+                      <KeyboardArrowLeft fontSize="large" />
+                    ) : (
+                      <KeyboardArrowRight fontSize="large" />
+                    )}
+                  </Button>
+                }
+                backButton={
+                  <Button
+                    size="large"
+                    className={classes.footerButton}
+                    onClick={handleBack}
+                    disabled={activeStep === 0}
+                  >
+                    {theme.direction === 'rtl' ? (
+                      <KeyboardArrowRight fontSize="large" />
+                    ) : (
+                      <KeyboardArrowLeft fontSize="large" />
+                    )}
+                  </Button>
+                }
+              />
+            </div>
           </Grid>
+
           <Grid item xs={12} md={6}>
             <div className={classes.markdownBody}>
               <h1>{frontmatter.title}</h1>

--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
   },
   sticky: {
     position: 'sticky',
-    top: '0',
+    top: '80px',
   },
   carousel: {
     paddingTop: '8rem',

--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -37,7 +37,7 @@ const tutorialSteps = [
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    // flexGrow: 1,
+    flexGrow: 1,
   },
   markdownBody: {
     padding: '2rem',

--- a/src/frontend/src/templates/template.js
+++ b/src/frontend/src/templates/template.js
@@ -49,7 +49,8 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: '8rem',
     padding: '4rem',
     position: 'fixed',
-    top: 'center',
+    top: '3%',
+    marginLeft: '3%',
   },
   img: {
     display: 'block',
@@ -61,10 +62,14 @@ const useStyles = makeStyles((theme) => ({
   stepper: {
     iconColor: theme.palette.text.primary,
   },
+  picture: {
+    width: '100%',
+  },
   footer: {
     display: 'flex',
     alignItems: 'center',
-    height: 50,
+    height: 40,
+    width: '100%',
     backgroundColor: theme.palette.secondary.main,
     boxShadow:
       'rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px',
@@ -101,8 +106,9 @@ export default function Template({
     <PageBase title={frontmatter.title}>
       <Grid container className={classes.root}>
         <Grid container>
-          <Grid item xs={6} className={classes.carousel}>
+          <Grid item xs={5} className={classes.carousel}>
             <AutoPlaySwipeableViews
+              className={classes.picture}
               axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
               index={activeStep}
               onChangeIndex={handleStepChange}
@@ -152,8 +158,8 @@ export default function Template({
               }
             />
           </Grid>
-          <Grid item xs={6}></Grid>
-          <Grid item xs={6}>
+          <Grid item xs={6} md={6}></Grid>
+          <Grid item xs={6} md={6}>
             <div className={classes.markdownBody}>
               <h1>{frontmatter.title}</h1>
               <div dangerouslySetInnerHTML={{ __html: html }} />


### PR DESCRIPTION
## Issue This PR Addresses
Fix #1371 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

In About page, when we scroll down, half of the page will be blank now. It looks weird. So, I want to make the pictures sticky.

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
