### PR TITLE
 Overwrote css while using the search bar

### DIFF
--- a/src/frontend/src/components/Header/DesktopHeader.jsx
+++ b/src/frontend/src/components/Header/DesktopHeader.jsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'primary',
     justifyContent: 'center',
     height: '8.9em',
+    fontSize: '0.875rem',
   },
   toolbar: theme.mixins.toolbar,
   logoIcon: {


### PR DESCRIPTION
## Issue This PR Addresses

USAGE: Fixes #1375

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

The issue can be read up about [here](https://github.com/Seneca-CDOT/telescope/issues/1375).
When hitting the search bar the header would increase in size. This was the result of changing the font size when we clicked the search button. I have created a quick fix to address this issue by overwriting the css changes in DesktopHeader.jsx.

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)