### PR TITLE
Fixes issue-1355: Display Contributor in Footer of About Page

### DIFF
--- a/src/frontend/src/components/AboutFooter/AboutFooter.jsx
+++ b/src/frontend/src/components/AboutFooter/AboutFooter.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { Box, Divider, Grid, Typography, useMediaQuery } from '@material-ui/core';
 import GitHubIcon from '@material-ui/icons/GitHub';
-
+import GitHubContributorCard from '../GitHubContributorCard/GitHubContributorCard';
 import SlackLogo from '../../images/Slack_Mark_Monochrome_White.svg';
 import LogoIcon from '../LogoIcon';
 
@@ -44,6 +44,9 @@ const useStyles = makeStyles((theme) => ({
   },
   footer: {
     color: theme.palette.text.primary,
+  },
+  card: {
+    marginTop: '2rem',
   },
 }));
 
@@ -188,6 +191,9 @@ const AboutFooter = () => {
             </Grid>
           </Grid>
         )}
+        <Grid item xs={12} sm={12} md={4} className={classes.card}>
+          <GitHubContributorCard />
+        </Grid>
       </Box>
       <Grid item xs={12}>
         <Typography variant="h6" className={classes.footer}>

--- a/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
+++ b/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
@@ -25,43 +25,47 @@ const GitHubContributorCard = () => {
   const theme = useTheme();
   const { contributor, error } = useTelescopeContributor();
 
-  return { contributor } ? (
-    <Card className={classes.root}>
-      <CardContent>
-        <Grid container direction="row" alignItems="center">
-          <Grid item xs={2}>
-            <Avatar alt="Profile Picture" src={contributor?.avatar_url} />
+  if (contributor !== undefined && contributor !== null) {
+    return (
+      <Card className={classes.root}>
+        <CardContent>
+          <Grid container direction="row" alignItems="center">
+            <Grid item xs={2}>
+              <Avatar alt="Profile Picture" src={contributor.avatar_url} />
+            </Grid>
+            <Grid item xs={10} justify="flex-end">
+              <Typography className={classes.typography}>
+                Thank you&nbsp;
+                <a href={contributor.html_url} className={classes.links}>
+                  {contributor.login}
+                </a>
+                , for being a&nbsp;
+                <a
+                  href="https://github.com/Seneca-CDOT/telescope/graphs/contributors"
+                  className={classes.links}
+                >
+                  Telescope project contributor
+                </a>
+                , with your
+                <a
+                  href={
+                    'https://github.com/Seneca-CDOT/telescope/commits?author=' + contributor.login
+                  }
+                  className={classes.links}
+                >
+                  &nbsp;
+                  {contributor.contributions} contribution(s)
+                </a>
+                .
+              </Typography>
+            </Grid>
           </Grid>
-          <Grid item xs={10} justify="flex-end">
-            <Typography className={classes.typography}>
-              Thank you{' '}
-              <a href={contributor?.html_url} className={classes.links}>
-                {contributor?.login}
-              </a>
-              , for being a{' '}
-              <a
-                href="https://github.com/Seneca-CDOT/telescope/graphs/contributors"
-                className={classes.links}
-              >
-                Telescope project contributor
-              </a>
-              , with your
-              <a
-                href={
-                  'https://github.com/Seneca-CDOT/telescope/commits?author=' + contributor?.login
-                }
-                className={classes.links}
-              >
-                {' '}
-                {contributor?.contributions} contribution(s)
-              </a>
-              .
-            </Typography>
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
-  ) : null;
+        </CardContent>
+      </Card>
+    );
+  } else {
+    return null;
+  }
 };
 
 export default GitHubContributorCard;

--- a/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
+++ b/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { Card, CardContent, Typography, Avatar, Grid } from '@material-ui/core';
+import useTelescopeContributor from '../../hooks/use-telescope-contributor';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.primary.light,
+  },
+  typography: {
+    fontSize: 13,
+  },
+  links: {
+    color: theme.palette.text.secondary,
+    textDecorationLine: 'none',
+    '&:hover': {
+      textDecorationLine: 'underline',
+    },
+    alignItems: 'flex-start',
+  },
+}));
+
+const GitHubContributorCard = () => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const { contributor, error } = useTelescopeContributor();
+
+  return { contributor } ? (
+    <Card className={classes.root}>
+      <CardContent>
+        <Grid container direction="row" alignItems="center">
+          <Grid item xs={2}>
+            <Avatar alt="Profile Picture" src={contributor?.avatar_url} />
+          </Grid>
+          <Grid item xs={10} justify="flex-end">
+            <Typography className={classes.typography}>
+              Thank you{' '}
+              <a href={contributor?.html_url} className={classes.links}>
+                {contributor?.login}
+              </a>
+              , for being a{' '}
+              <a
+                href="https://github.com/Seneca-CDOT/telescope/graphs/contributors"
+                className={classes.links}
+              >
+                Telescope project contributor
+              </a>
+              , with your
+              <a
+                href={
+                  'https://github.com/Seneca-CDOT/telescope/commits?author=' + contributor?.login
+                }
+                className={classes.links}
+              >
+                {' '}
+                {contributor?.contributions} contribution(s)
+              </a>
+              .
+            </Typography>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  ) : null;
+};
+
+export default GitHubContributorCard;

--- a/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
+++ b/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
@@ -3,6 +3,10 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { Card, CardContent, Typography, Avatar, Grid } from '@material-ui/core';
 import useTelescopeContributor from '../../hooks/use-telescope-contributor';
 
+function Contributions({ contributions }) {
+  return contributions < 3 ? 'contributions.' : `${contributions} contributions.`;
+}
+
 const useStyles = makeStyles((theme) => ({
   root: {
     backgroundColor: theme.palette.primary.light,
@@ -25,7 +29,7 @@ const GitHubContributorCard = () => {
   const theme = useTheme();
   const { contributor, error } = useTelescopeContributor();
 
-  if (!contributor) {
+  if (error || !contributor) {
     return null;
   }
 
@@ -57,11 +61,8 @@ const GitHubContributorCard = () => {
                 className={classes.link}
               >
                 &nbsp;
-                {contributor.contributions > 2
-                  ? contributor.contributions + ' contributions'
-                  : 'contributions'}
+                <Contributions contributions={contributor.contributions} />
               </a>
-              .
             </Typography>
           </Grid>
         </Grid>

--- a/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
+++ b/src/frontend/src/components/GitHubContributorCard/GitHubContributorCard.jsx
@@ -8,9 +8,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.primary.light,
   },
   typography: {
-    fontSize: 13,
+    fontSize: '13px',
   },
-  links: {
+  link: {
     color: theme.palette.text.secondary,
     textDecorationLine: 'none',
     '&:hover': {
@@ -25,47 +25,49 @@ const GitHubContributorCard = () => {
   const theme = useTheme();
   const { contributor, error } = useTelescopeContributor();
 
-  if (contributor !== undefined && contributor !== null) {
-    return (
-      <Card className={classes.root}>
-        <CardContent>
-          <Grid container direction="row" alignItems="center">
-            <Grid item xs={2}>
-              <Avatar alt="Profile Picture" src={contributor.avatar_url} />
-            </Grid>
-            <Grid item xs={10} justify="flex-end">
-              <Typography className={classes.typography}>
-                Thank you&nbsp;
-                <a href={contributor.html_url} className={classes.links}>
-                  {contributor.login}
-                </a>
-                , for being a&nbsp;
-                <a
-                  href="https://github.com/Seneca-CDOT/telescope/graphs/contributors"
-                  className={classes.links}
-                >
-                  Telescope project contributor
-                </a>
-                , with your
-                <a
-                  href={
-                    'https://github.com/Seneca-CDOT/telescope/commits?author=' + contributor.login
-                  }
-                  className={classes.links}
-                >
-                  &nbsp;
-                  {contributor.contributions} contribution(s)
-                </a>
-                .
-              </Typography>
-            </Grid>
-          </Grid>
-        </CardContent>
-      </Card>
-    );
-  } else {
+  if (!contributor) {
     return null;
   }
+
+  return (
+    <Card className={classes.root}>
+      <CardContent>
+        <Grid container direction="row" alignItems="center">
+          <Grid item xs={2}>
+            <Avatar alt="Profile Picture" src={contributor.avatar_url} />
+          </Grid>
+          <Grid item xs={10} justify="flex-end">
+            <Typography className={classes.typography}>
+              Thank you&nbsp;
+              <a href={contributor.html_url} className={classes.link}>
+                {contributor.login}
+              </a>
+              , for being a&nbsp;
+              <a
+                href="https://github.com/Seneca-CDOT/telescope/graphs/contributors"
+                className={classes.link}
+              >
+                Telescope project contributor
+              </a>
+              , with your
+              <a
+                href={
+                  'https://github.com/Seneca-CDOT/telescope/commits?author=' + contributor.login
+                }
+                className={classes.link}
+              >
+                &nbsp;
+                {contributor.contributions > 2
+                  ? contributor.contributions + ' contributions'
+                  : 'contributions'}
+              </a>
+              .
+            </Typography>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
 };
 
 export default GitHubContributorCard;

--- a/src/frontend/src/hooks/use-telescope-contributor.js
+++ b/src/frontend/src/hooks/use-telescope-contributor.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 const pickRandomContributor = (contributors) => {
-  return contributors[Math.floor(Math.random() * contributors.length) + 1];
+  return contributors[Math.floor(Math.random() * contributors.length)];
 };
 
 const useTelescopeContributor = () => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1355 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
I have went ahead and added a new component for the GitHub Contributors using the custom hook from #1330. I was given an example from the Node.js site and took some ideas from it, and made changes to make the Card to better fit into the telescope project visually. I am not sure if we're planning to add more elements to the footer, but in case if we plan to do that in the future, I have decided to have the card positioned on the left for now and leave the center/right empty (unless it's on a small screen device).

View on mobile:
<img width="335" alt="mobile" src="https://user-images.githubusercontent.com/54863160/99483376-10145580-292c-11eb-9e35-98b154dd9d66.PNG">

View on PC:
<img width="1128" alt="PC" src="https://user-images.githubusercontent.com/54863160/99483400-1c98ae00-292c-11eb-961b-766dabdf5772.PNG">

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
