### PR TITLE
Removed box shadow for alignment of post content and post header

### DIFF
--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -145,7 +145,7 @@ const Post = ({ postUrl }) => {
   }
 
   return (
-    <Box className={classes.root} boxShadow={2}>
+    <Box className={classes.root}>
       <ListSubheader className={classes.header}>
         <AdminButtons />
         <Typography variant="h1" title={post.title} id={post.id} className={classes.title}>

--- a/src/frontend/src/components/Post/Post.jsx
+++ b/src/frontend/src/components/Post/Post.jsx
@@ -5,8 +5,8 @@ import 'highlight.js/styles/github.css';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Grid, Typography, ListSubheader } from '@material-ui/core';
 import './telescope-post-content.css';
-import Spinner from '../Spinner/Spinner.jsx';
 import ErrorRoundedIcon from '@material-ui/icons/ErrorRounded';
+import Spinner from '../Spinner/Spinner.jsx';
 import AdminButtons from '../AdminButtons';
 
 const useStyles = makeStyles((theme) => ({
@@ -105,7 +105,7 @@ const Post = ({ postUrl }) => {
   if (error) {
     console.error(`Error loading post at ${postUrl}`, error);
     return (
-      <Box className={classes.root} boxShadow={2}>
+      <Box className={classes.root}>
         <ListSubheader className={classes.header}>
           <AdminButtons />
           <Typography variant="h1" className={classes.title}>
@@ -123,7 +123,7 @@ const Post = ({ postUrl }) => {
 
   if (!post) {
     return (
-      <Box className={classes.root} boxShadow={2}>
+      <Box className={classes.root}>
         <ListSubheader className={classes.header}>
           <AdminButtons />
           <Typography variant="h1" className={classes.title}>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

Fixes #1188 and #1401 
The box shadow property applied to post content as well as header, but because of the post header background colour, the shadow wasn't very visible which gave an appearance of both not aligned. The best way to fix this was to remove box shadow property itself. 

![Screen Shot 2020-11-18 at 4 52 21 PM](https://user-images.githubusercontent.com/48449650/99592735-94afb400-29be-11eb-82c0-f115885b0c5f.png)
