### PR TITLE
Fixes Issue #1307 query param validation for PUT /feeds/:id/flag

### DIFF
--- a/src/backend/web/routes/feeds.js
+++ b/src/backend/web/routes/feeds.js
@@ -53,7 +53,7 @@ feeds.get('/:id', validateFeedsIdParam(), async (req, res) => {
   }
 });
 
-feeds.put('/:id/flag', protectAdmin(), async (req, res) => {
+feeds.put('/:id/flag', protectAdmin(), validateFeedsIdParam(), async (req, res) => {
   const { id } = req.params;
   try {
     const feed = await Feed.byId(id);

--- a/src/backend/web/validation.js
+++ b/src/backend/web/validation.js
@@ -92,7 +92,7 @@ const postsIdParamValidationRules = [
 ];
 
 const feedsIdParamValidationRules = [
-  param('id', 'Id Length is invalid').isLength({ min: 10, max: 10 }),
+  param('id', 'Feeds Id Length is invalid').isLength({ min: 10, max: 10 }),
 ];
 
 module.exports = {

--- a/test/feeds.test.js
+++ b/test/feeds.test.js
@@ -451,7 +451,7 @@ describe('test PUT + DELETE /feeds/:id/flag endpoint', () => {
   it('should respond with a 404 status trying to flag feed that does not exist when logged in as admin user', async () => {
     loginAdmin('Johannes Kepler', 'user1@example.com');
     const res = await request(app)
-      .put(`/feeds/123456/flag`)
+      .put(`/feeds/1234567890/flag`)
       .send()
       .set('Accept', 'application/json');
     expect(res.status).toEqual(404);
@@ -526,5 +526,23 @@ describe('test PUT + DELETE /feeds/:id/flag endpoint', () => {
     // Check updated # of flagged feeds
     const flaggedFeeds = await Feed.flagged();
     expect(flaggedFeeds.length).toEqual(0);
+  });
+
+  it('should respond with a 400 status because id url param is 9 characters but validation expects 10', async () => {
+    loginAdmin('Johannes Kepler', 'user1@example.com');
+    const res = await request(app)
+      .put(`/feeds/123456789/flag`)
+      .send()
+      .set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
+  });
+
+  it('should respond with a 400 status because id url param is 11 characters but validation expects 10', async () => {
+    loginAdmin('Johannes Kepler', 'user1@example.com');
+    const res = await request(app)
+      .put(`/feeds/123456789012/flag`)
+      .send()
+      .set('Accept', 'application/json');
+    expect(res.status).toEqual(400);
   });
 });


### PR DESCRIPTION
    * added express validation for PUT /feeds/:id/flag
	* added test case invalid id param for PUT /feeds/:id/flag

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This pull request address #1307 which I have added express validation to the PUT /feeds/:id/flag. Added a new rule for feed id param validation to validation.js. In the routes/feeds.js the PUT /feeds/:id/flag now used this new validation. Two tests have been added to test the validation of the query param id. One test for character length of 9 and another test for the character length of 11.  Two tests might be redundant since validation only allows for a character length of 10. Did not write a test case for success since there is already a test case for a successful response. It would be redundant to write another test case as it would be the same test case since I cannot test id character query param length in isolation. Other than testing validateFeedsIdParam() but there is no reason to test the express validator.

No screenshots as the code pertaining to a backend fix. 

I do not think there is a need for documentation change for this pull request as it is in regards to a backend route. Please let me know if you want this specified in the documentation somewhere. 

Thank you for your consideration. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
