### PR TITLE
Fix issue-1271 : Add BackToTopButton in searchPage

### DIFF
--- a/src/frontend/src/components/SearchPage/SearchPage.jsx
+++ b/src/frontend/src/components/SearchPage/SearchPage.jsx
@@ -1,10 +1,20 @@
 import React, { useState } from 'react';
 import { useQueryParam, StringParam } from 'use-query-params';
+import { makeStyles } from '@material-ui/core/styles';
 
 import SearchBar from '../SearchBar';
 import SearchResults from './SearchResults.jsx';
+import BackToTopButton from '../BackToTopButton';
+
+const useStyles = makeStyles(() => ({
+  anchor: {
+    position: 'absolute',
+    top: 0,
+  },
+}));
 
 const SearchPage = () => {
+  const classes = useStyles();
   // We synchronize the `text` and `filter` values to the URL's query string
   // via `textParam` and `filterParam`. The <SearchBar> UI uses our internal
   // state values, and the <SearchResults> only update on page load or when
@@ -26,6 +36,7 @@ const SearchPage = () => {
 
   return (
     <div>
+      <div className={classes.anchor} id="back-to-top-anchor"></div>
       <SearchBar
         text={text}
         onTextChange={(value) => setText(value)}
@@ -35,6 +46,7 @@ const SearchPage = () => {
       />
       <br />
       <SearchResults text={textParam} filter={filterParam} />
+      <BackToTopButton />
     </div>
   );
 };


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
fix #1271 


<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Added Back to Top Button on the search page. A Back To Top button now shows up when you have a long search result on the search page. 
Added the css to move Back To Top Buttle to the top of the webpage. Please advise the position if you think that is better than move to the top. 
Thanks for your consideration!

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
