### PR TITLE
Fix Scroll To Top button doesn't move to correct position

### DIFF
--- a/src/frontend/src/components/Banner/Banner.jsx
+++ b/src/frontend/src/components/Banner/Banner.jsx
@@ -68,6 +68,10 @@ const useStyles = makeStyles((theme) => ({
       bottom: theme.spacing(18),
     },
   },
+  anchor: {
+    position: 'relative',
+    top: '1rem',
+  },
 }));
 
 export default function Banner() {
@@ -129,7 +133,7 @@ export default function Banner() {
           </div>
         </Grid>
       </Grid>
-      <div id="back-to-top-anchor"></div>
+      <div className={classes.anchor} id="back-to-top-anchor"></div>
     </>
   );
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fix #1426 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Add a CSS to the div with id "back-to-top-anchor". Back To Top Button now move to the proper position.
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
