### PR TITLE
Fixed logging format

### DIFF
--- a/src/backend/utils/logger.js
+++ b/src/backend/utils/logger.js
@@ -58,7 +58,11 @@ const streamToElastic = pinoElastic({
   'flush-bytes': FLUSH_BYTES || 1000,
 });
 
-const logger = pino(options, LOG_ELASTIC ? streamToElastic : destination);
+// Unable to use options as argument in both cases because pino-elastic does not like prettyPrint
+const logger = pino(
+  LOG_ELASTIC ? { level: logLevel } : options,
+  LOG_ELASTIC ? streamToElastic : destination
+);
 
 const expressLogger = expressPino({ logger });
 

--- a/src/backend/utils/logger.js
+++ b/src/backend/utils/logger.js
@@ -51,7 +51,7 @@ const streamToElastic = pinoElastic({
   // Consistency of the write, valid values: 'one', 'quorum', 'all'
   consistency: (CONSISTENCY || 'one').toLowerCase(),
   // URL of Elasticsearch
-  node: parseUrl(ELASTIC_URL, ELASTIC_PORT),
+  node: parseUrl(ELASTIC_URL, ELASTIC_PORT) || 'http://127.0.0.1:9200',
   // Elasticsearch version
   'es-version': ELASTIC_VERSION || 7,
   // The number of bytes for each bulk insert

--- a/src/backend/utils/logger.js
+++ b/src/backend/utils/logger.js
@@ -39,14 +39,14 @@ const streamToElastic = pinoElastic({
   // Consistency of the write, valid values: 'one', 'quorum', 'all'
   consistency: (process.env.CONSISTENCY || 'one').toLowerCase(),
   // URL of Elasticsearch
-  node: `http://${process.env.ELASTIC_URL}:${process.env.ELASTIC_PORT}`,
+  node: `${process.env.ELASTIC_URL}:${process.env.ELASTIC_PORT}`,
   // Elasticsearch version
   'es-version': process.env.ELASTIC_VERSION || 7,
   // The number of bytes for each bulk insert
   'flush-bytes': process.env.FLUSH_BYTES || 1000,
 });
 
-const logger = pino({ options }, process.env.LOG_ELASTIC ? streamToElastic : destination);
+const logger = pino(options, process.env.LOG_ELASTIC ? streamToElastic : destination);
 
 const expressLogger = expressPino({ logger });
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1448 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Now when logging to console, the log messages will look pretty again.

Could someone also test the pino-elastic logging as well for this and make sure it is also working? I tested it, but it was inconclusive for me.

Steps to test fix:
1. in the `.env` file set `LOG_LEVEL` to `info`
1. `docker-compose up redis elasticsearch`
1. `npm start`

Check info messages in terminal tab. They should look pretty now (just like before)

To regression test:
1. in the `.env` file set `LOG_LEVEL` to `info` and set `LOG_ELASTIC` to 1
1. `docker-compose up redis elasticsearch`
1. `npm start`, there should be no logging appearing in terminal tab anymore as they're directed to elasticsearch now
1. navigate to `http://localhost:9200/_cat/indices?v` You should see two rows and under the `indexes` column there should be 2 indexes  `logs` and `posts`
1. Remember to set `LOG_ELASTIC` to blank again in your `.env` file after testing.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
