### PR TITLE
Fix issue 1464:  Scroll To Top button on the search page does not work on mobile version

### DIFF
--- a/src/frontend/gatsby/src/components/SearchPage/SearchPage.jsx
+++ b/src/frontend/gatsby/src/components/SearchPage/SearchPage.jsx
@@ -11,6 +11,10 @@ const useStyles = makeStyles(() => ({
     position: 'absolute',
     top: 0,
   },
+  anchorMobile: {
+    position: 'relative',
+    bottom: '71px',
+  },
 }));
 
 const SearchPage = () => {
@@ -37,6 +41,7 @@ const SearchPage = () => {
   return (
     <div>
       <div className={classes.anchor} id="back-to-top-anchor" />
+      <div className={classes.anchorMobile} id="back-to-top-anchor-mobile" />
       <SearchBar
         text={text}
         onTextChange={(value) => setText(value)}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fix #1464 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Scroll To Top button on the search page now work properly on mobile version. 
To check this, Open telescopes in mobile version, click on the search icon to navigate to the search page.
Scroll the page down until the button shows, and then click the button.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
