### PR TITLE
Fix: specify gatsby in the path to the front-end's public folder

### DIFF
--- a/src/backend/web/routes/index.js
+++ b/src/backend/web/routes/index.js
@@ -47,7 +47,7 @@ if (process.env.NODE_ENV === 'development') {
     router.use('/', createProxyMiddleware({ target: 'http://localhost:8000', changeOrigin: true }));
   } else {
     // Or serve the static files in the Gatsby build directory
-    router.use(express.static(path.join(__dirname, '../../../frontend/public')));
+    router.use(express.static(path.join(__dirname, '../../../frontend/gatsby/public')));
   }
 }
 


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This fixes the path the `public` folder when served by the backend (locally, it doesn't affect `dev` or `prod`),
This only shows up when running telescope only using `docker`, or when trying to access the front-end using port 3000 instead of 8000.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
