### PR TITLE
Fixes #1386: set up Theme src/frontend/src/theme.js in Next

### DIFF
--- a/src/frontend/next/src/theme/theme.ts
+++ b/src/frontend/next/src/theme/theme.ts
@@ -1,0 +1,48 @@
+import { red } from '@material-ui/core/colors';
+import createMuiTheme, { Theme } from '@material-ui/core/styles/createMuiTheme';
+
+export const lightTheme: Theme = createMuiTheme({
+  palette: {
+    type: 'light',
+    primary: {
+      main: '#333E64',
+      contrastText: '#E5E5E5',
+    },
+    secondary: {
+      main: '#0589D6',
+    },
+    error: {
+      main: red.A400,
+    },
+    background: {
+      default: '#E5E5E5',
+    },
+    text: {
+      primary: '#181818',
+      secondary: '#8BC2EB',
+    },
+  },
+});
+
+export const darkTheme: Theme = createMuiTheme({
+  palette: {
+    type: 'dark',
+    primary: {
+      main: '#303030',
+      contrastText: '',
+    },
+    secondary: {
+      main: '',
+    },
+    error: {
+      main: '',
+    },
+    background: {
+      default: '',
+    },
+    text: {
+      primary: '',
+      secondary: '',
+    },
+  },
+});


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixed #1386 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [x] **Porting**: Gatsby to Next
## Description
I simply added the `theme.ts` file with consideration for darkmode to be implemented in the future. At the moment, the file looks similar to the `theme.js` in Gatsby because initially we wanted to follow MUI default theme structure (more detail can be found in #1390). However, there was some concern from @humphd before about the meaning of some theme attributes that might not be as clean as we want and in PR #1414 , @abhaseen actually made custom theme files. At the moment, the PR has not been merged so I was following the previous design. If later on, we set on a structure then we can adjust it. 

<!-- bug fix, feature, documentation, UI, etc. -->

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
