### PR TITLE
Fix #1496: Port GitHub Contributor Card to NextJS

### DIFF
--- a/src/frontend/next/src/components/GitHubContributorCard/GitHubContributorCard.tsx
+++ b/src/frontend/next/src/components/GitHubContributorCard/GitHubContributorCard.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Card, CardContent, Typography, Avatar, Grid } from '@material-ui/core';
+import useTelescopeContributor from '../../hooks/use-telescope-contributor';
+
+function Contributions({ contributions }) {
+  return contributions < 3 ? 'contributions.' : `${contributions} contributions.`;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: theme.palette.primary.light,
+  },
+  typography: {
+    color: theme.palette.primary.contrastText,
+    fontSize: '13px',
+  },
+  link: {
+    color: theme.palette.primary.contrastText,
+    textDecorationLine: 'underline',
+    alignItems: 'flex-start',
+  },
+}));
+
+const GitHubContributorCard = () => {
+  const classes = useStyles();
+  const { contributor, error } = useTelescopeContributor();
+
+  if (error || !contributor) {
+    return null;
+  }
+
+  return (
+    <Card className={classes.root}>
+      <CardContent>
+        <Grid container direction="row" alignItems="center">
+          <Grid item xs={2}>
+            <Avatar alt="Profile Picture" src={contributor.avatar_url} />
+          </Grid>
+          <Grid item xs={10} justify="flex-end">
+            <Typography className={classes.typography}>
+              Thank you&nbsp;
+              <a href={contributor.html_url} className={classes.link}>
+                {contributor.login}
+              </a>
+              , for being a&nbsp;
+              <a
+                href="https://github.com/Seneca-CDOT/telescope/graphs/contributors"
+                className={classes.link}
+              >
+                Telescope project contributor
+              </a>
+              , with your
+              <a
+                href={`https://github.com/Seneca-CDOT/telescope/commits?author=${contributor.login}`}
+                className={classes.link}
+              >
+                &nbsp;
+                <Contributions contributions={contributor.contributions} />
+              </a>
+            </Typography>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default GitHubContributorCard;

--- a/src/frontend/next/src/components/GitHubContributorCard/GitHubContributorCard.tsx
+++ b/src/frontend/next/src/components/GitHubContributorCard/GitHubContributorCard.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import { FC } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Card, CardContent, Typography, Avatar, Grid } from '@material-ui/core';
 import useTelescopeContributor from '../../hooks/use-telescope-contributor';
 
-function Contributions({ contributions }) {
-  return contributions < 3 ? 'contributions.' : `${contributions} contributions.`;
+type ContributionProps = {
+  contributions: number;
+};
+
+function Contributions({ contributions }: ContributionProps) {
+  return <span> {contributions < 3 ? 'contributions.' : `${contributions} contributions.`} </span>;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -22,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const GitHubContributorCard = () => {
+const GitHubContributorCard: FC = () => {
   const classes = useStyles();
   const { contributor, error } = useTelescopeContributor();
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #1496  

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [x] **Next**: Porting to NextJS

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Ports GithubContributorCard Component from Gatsby to Next

Note: This Component is dependent on the hooks/use-telescope-contributor.js file (#1502)

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
