### PR TITLE
Fix #1476: Add internal padding on searchInput to solve overlap problem

### DIFF
--- a/src/frontend/gatsby/src/components/SearchInput/SearchInput.jsx
+++ b/src/frontend/gatsby/src/components/SearchInput/SearchInput.jsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles((theme) => ({
     height: '55px',
     backgroundColor: theme.palette.background.default,
     paddingLeft: '10px',
+    paddingRight: '65px',
     border: '1px solid #B3B6B7',
     borderRadius: '7px',
     outline: 'none',

--- a/src/frontend/gatsby/src/components/SearchInput/SearchInput.jsx
+++ b/src/frontend/gatsby/src/components/SearchInput/SearchInput.jsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     height: '55px',
     backgroundColor: theme.palette.background.default,
     paddingLeft: '10px',
-    paddingRight: '65px',
+    paddingRight: '60px',
     border: '1px solid #B3B6B7',
     borderRadius: '7px',
     outline: 'none',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
This pr adds internal padding on search input area to stop the text from going beyond the area covered by the adornment.

![issue1476](https://user-images.githubusercontent.com/46911810/103828503-a588b780-5048-11eb-9a72-73c1e4e8b863.gif)


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
