### PR TITLE
Fixed #1549: Modified _app and _document to ensure matching styling between client and server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,9 @@ module.exports = {
     {
       files: ['src/frontend/next/**/*.ts', 'src/frontend/next/**/*.tsx'],
       plugins: ['@typescript-eslint'],
+      env: {
+        browser: true,
+      },
       rules: {
         'react/prop-types': 'off',
         'react/react-in-jsx-scope': 'off',

--- a/src/frontend/next/src/pages/_app.tsx
+++ b/src/frontend/next/src/pages/_app.tsx
@@ -1,7 +1,17 @@
+import { useEffect } from 'react';
 import { AppProps } from 'next/app';
 import '../styles/globals.css';
 
+// Reference: https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_app.js
 const App = ({ Component, pageProps }: AppProps) => {
+  // This hook is for ensuring the styling is sync between client and server
+  useEffect(() => {
+    // Remove the server-side injected CSS.
+    const jssStyles = document.querySelector('#jss-server-side');
+    if (jssStyles) {
+      jssStyles.parentElement?.removeChild(jssStyles);
+    }
+  }, []);
   return <Component {...pageProps} />;
 };
 

--- a/src/frontend/next/src/pages/_document.tsx
+++ b/src/frontend/next/src/pages/_document.tsx
@@ -1,0 +1,44 @@
+import { Children } from 'react';
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import { ServerStyleSheets } from '@material-ui/core/styles';
+
+// Reference: https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_document.js
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+MyDocument.getInitialProps = async (ctx) => {
+  // Render app and page and get the context of the page with collected side effects.
+  const sheets = new ServerStyleSheets();
+  const originalRenderPage = ctx.renderPage;
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
+    });
+
+  const initialProps = await Document.getInitialProps(ctx);
+
+  return {
+    ...initialProps,
+    // Styles fragment is rendered after the app and page rendering finish.
+    styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()],
+  };
+};
+
+export default MyDocument;


### PR DESCRIPTION
## Issue This PR Addresses
Fixed #1549 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
For those JSS that generating class names at run time like MUI, Next renders different class names on server vs client. In this PR, I have modified the _app.tsx and _document.tsx following the recommended example on MUI's website as well as how to do it with Next. More information can be found below.
References:
https://material-ui.com/guides/server-rendering/
https://github.com/mui-org/material-ui/tree/master/examples/nextjs

## Checklist
<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
