### PR TITLE
Ported SnackBar component

### DIFF
--- a/src/frontend/next/package.json
+++ b/src/frontend/next/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.11.2",
+    "@material-ui/icons": "^4.11.2",
     "next": "^10.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/src/frontend/next/src/components/SnackBar/SnackBar.tsx
+++ b/src/frontend/next/src/components/SnackBar/SnackBar.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import Snackbar from '@material-ui/core/Snackbar';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+
+type SnackbarProps = {
+  message: string;
+};
+
+const SimpleSnackbar = ({ message }: SnackbarProps) => {
+  const [open, setOpen] = useState<boolean>(true);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        open={open}
+        autoHideDuration={6000}
+        message={message}
+        action={
+          <>
+            <IconButton size="small" aria-label="close" color="inherit" onClick={handleClose}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </>
+        }
+      />
+    </div>
+  );
+};
+
+export default SimpleSnackbar;


### PR DESCRIPTION
## Issue This PR Addresses
Fixed #1538 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
I have modified the SnackBar component to be written in TS. I made some changes to the component to accompany using `handleClose` in the close button. The `onClose` property is not required because it is simply prevent us to close snackbar when we clickaway. Simply remove `onClose` does the same thing.

For reference, you can try what I mentioned above in this playground.
https://codesandbox.io/s/material-demo-forked-qe0kl?file=/demo.js

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
