### PR TITLE
[next] Fixes #1542 - Porting PostSearchInput to Next

### DIFF
--- a/src/frontend/next/src/components/SearchInput/PostSearchInput.tsx
+++ b/src/frontend/next/src/components/SearchInput/PostSearchInput.tsx
@@ -1,0 +1,49 @@
+import { ChangeEvent } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+
+type PostSearchInputProps = {
+  text: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const useStyles = makeStyles((theme) => ({
+  input: {
+    fontSize: '1.6rem',
+    '&:hover': {
+      border: '1px solid',
+      borderColor: theme.palette.primary.main,
+    },
+    '&:focus': {
+      border: '2px solid',
+      borderColor: theme.palette.primary.main,
+    },
+    '& > *': {
+      fontSize: '1.6rem !important',
+      color: theme.palette.text.primary,
+    },
+    height: '55px',
+    backgroundColor: theme.palette.background.default,
+    paddingLeft: '10px',
+    paddingRight: '60px',
+    border: '1px solid #B3B6B7',
+    borderRadius: '7px',
+    outline: 'none',
+  },
+}));
+
+const PostSearchInput = ({ text, onChange }: PostSearchInputProps) => {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <input
+        className={classes.input}
+        placeholder="How to Get Started in Open Source"
+        value={text}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+export default PostSearchInput;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR fixes #1542 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

This PR is created to address the porting of the Telescope Front-end from Gatsby to NextJS. As part of that transition, this PR handles the porting of the PostSearchInput component, as per #1542 
![Initial Look](https://user-images.githubusercontent.com/16841702/104984167-3746dc00-59dc-11eb-92cd-223853542aa5.png)
![WithTextValue](https://user-images.githubusercontent.com/16841702/104984203-44fc6180-59dc-11eb-8837-6e9e149c2e09.png)



## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
