### PR TITLE
Added more node versions to GH actions for testing

### DIFF
--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x]
+        node-version: [12.x, 13.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Added extra node versions (13.x and 14.x) to Github Actions. As the current node LTS is 14.15.4, we should be updating our testing to account for that. I didn't add 15.x because of previous mentions of it being problematic. 

It's actually up in the air to decide if we still want to test for 12.x and 13.x @humphd 

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
