### PR TITLE
[next] Fixes #1547: Ported HelpPopoverButton from Gatsby to Next.js

### DIFF
--- a/src/frontend/next/package.json
+++ b/src/frontend/next/package.json
@@ -11,6 +11,7 @@
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
     "dotenv": "^8.2.0",
+    "material-ui-popup-state": "^1.7.1",
     "next": "^10.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/frontend/next/src/components/HelpPopoverButton.tsx
+++ b/src/frontend/next/src/components/HelpPopoverButton.tsx
@@ -1,0 +1,54 @@
+import { Box, IconButton, Popover, Typography } from '@material-ui/core';
+import { HelpOutline } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+
+const useStyles = makeStyles(() => ({
+  button: {
+    padding: '3px 0 3px 0',
+  },
+}));
+
+const HelpPopoverButton = () => {
+  const classes = useStyles();
+
+  return (
+    <PopupState variant="popover" popupId="help-popover">
+      {(popupState) => (
+        <div>
+          <IconButton
+            color="secondary"
+            classes={{ root: classes.button }}
+            {...bindTrigger(popupState)}
+          >
+            <HelpOutline />
+          </IconButton>
+          <Popover
+            {...bindPopover(popupState)}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <Box p={2}>
+              <Typography align="center">
+                Please enter the web address of your blog&apos;s RSS or Atom feed.
+              </Typography>
+              <Typography align="center">
+                <em>
+                  (<a href="https://rss.com/blog/find-rss-feed/">Not sure how to find that?</a>)
+                </em>
+              </Typography>
+            </Box>
+          </Popover>
+        </div>
+      )}
+    </PopupState>
+  );
+};
+
+export default HelpPopoverButton;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses 
Closes #1547 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [x] **Porting NextJS**

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Porting HelpPopoverButton from Gatsby to NextJS. Process was pretty straight forward. To test, I also rendered this on `index.tsx`.

Steps to test:
1) Open src/frontend/next/index.tsx
2) Add this to import statements: `import HelpPopoverButton from '../components/MyFeedsPage/HelpPopoverButton';`
3) Render component `<HelpPopoverButton />` in `index.tsx`

`package-lock.json` was modified as I had to run `npm install --save material-ui-popup-state`.

<img width="634" alt="image" src="https://user-images.githubusercontent.com/43390970/105220871-52bdfe00-5b26-11eb-9ba7-e5a19c1bba3d.png">

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
