### PR TITLE
[next] Fixes issue-1541: Ported AuthorSearchInput component to Next.JS

### DIFF
--- a/src/frontend/next/src/components/SearchInput/AuthorSearchInput.tsx
+++ b/src/frontend/next/src/components/SearchInput/AuthorSearchInput.tsx
@@ -1,0 +1,52 @@
+import { ChangeEvent } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+
+type AuthorSearchInputProps = {
+  text: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const useStyles = makeStyles((theme) => ({
+  input: {
+    fontSize: '1.6rem',
+    '&:hover': {
+      border: '1px solid',
+      borderColor: theme.palette.primary.main,
+    },
+    '&:focus': {
+      border: '2px solid',
+      borderColor: theme.palette.primary.main,
+    },
+    '& > *': {
+      fontSize: '1.6rem !important',
+      color: theme.palette.text.primary,
+    },
+    height: '55px',
+    backgroundColor: theme.palette.background.default,
+    paddingLeft: '10px',
+    paddingRight: '60px',
+    border: '1px solid #B3B6B7',
+    borderRadius: '7px',
+    outline: 'none',
+  },
+}));
+
+const AuthorSearchInput = ({ text, onChange }: AuthorSearchInputProps) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <input
+        className={classes.input}
+        list="search-suggestions"
+        placeholder="How to Get Started in Open Source"
+        value={text}
+        onChange={onChange}
+      />
+
+      <datalist aria-label="search telescope" id="search-suggestions" />
+    </>
+  );
+};
+
+export default AuthorSearchInput;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1541

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [x] **Next.JS Port**

## Description
This PR ports over the `AuthorSearchInput` component to Next.JS.

**_However I have a few concerns I'd like to run by everyone before we merge this:_**

- I'm currently getting an ESLint error: `A control must be associated with a text label.eslint(jsx-a11y/control-has-associated-label)` when I remove `/* eslint-disable jsx-a11y/control-has-associated-label */` from the top of the file.
  - FYI: The original Gatsby version of this component also disabled this rule.
  - I've never heard of `<datalist>` before so upon a quick google it seems like we're doing everything right, as `<input>` has a list of `search-suggestions` which matches the `<datalist>`'s `id`, but ESLint is still screaming. 
  - If the input is enclosed by the `datalist` tag, the error goes away (but it doesn't look like this is the correct way of using `datalist`.

Let me know if you guys have any suggestions on this as restricting ESLint makes angels cry, though this case might be an exception.

PS: I added a todo comment for when the parent component `SearchInput` gets implemented. The style used in both `AuthorSearchInput` and `PostSearchInput` can be moved to the parent component.

## How to test:
In `index.tsx`:
- `import AuthorSearchInput from '../components/SearchInput/AuthorSearchInput';`
- `<AuthorSearchInput text="Search Me!" />`

Which should yield:
![firefox_2021-01-20_15-31-53](https://user-images.githubusercontent.com/7242003/105231508-04642b80-5b35-11eb-8fe1-8d596091941b.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)