### PR TITLE
[next] Fixes #1539: Porting DeleteFeedDialogButton to Next

### DIFF
--- a/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
+++ b/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
@@ -28,9 +28,9 @@ const DeleteFeedDialogButton = ({ feed, deletionCallback }: DeleteFeedDialogButt
   const { id, url } = feed;
   const classes = useStyles();
   const { telescopeUrl } = useSiteMetadata();
-  const [open, setOpen] = useState<boolean>(false);
+  const [open, setOpen] = useState(false);
 
-  const deleteBtnRef = useRef<HTMLButtonElement>(null);
+  const deleteBtnRef = useRef<HTMLButtonElement | null>(null);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -49,7 +49,7 @@ const DeleteFeedDialogButton = ({ feed, deletionCallback }: DeleteFeedDialogButt
   const removeFeed = async () => {
     console.log(`Removing feed hosted at URL ${url}...`);
     try {
-      const response = await fetch(`${telescopeUrl}/feeds/${id}`, { method: 'DELETE ' });
+      const response = await fetch(`${telescopeUrl}/feeds/${id}`, { method: 'DELETE' });
 
       if (!response.ok) {
         throw new Error(response.statusText);

--- a/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
+++ b/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef } from 'react';
-import { Feed } from '../interfaces';
 import {
   Button,
   Dialog,
@@ -11,6 +10,7 @@ import {
 } from '@material-ui/core';
 import { Delete } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
+import { Feed } from '../interfaces';
 import useSiteMetadata from '../hooks/use-site-metadata';
 
 type DeleteFeedDialogButtonProps = {

--- a/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
+++ b/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
@@ -1,0 +1,111 @@
+import { useState, useRef } from 'react';
+import { Feed } from '../interfaces';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+} from '@material-ui/core';
+import { Delete } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+import useSiteMetadata from '../hooks/use-site-metadata';
+
+type DeleteFeedDialogButtonProps = {
+  feed: Feed;
+  deleteionCallback: (id: number) => void;
+};
+
+const useStyles = makeStyles(() => ({
+  button: {
+    padding: '3px 0 3px 0',
+  },
+}));
+
+const DeleteFeedDialogButton = ({ feed, deleteionCallback }: DeleteFeedDialogButtonProps) => {
+  const { id, url } = feed;
+  const classes = useStyles();
+  const { telescopeUrl } = useSiteMetadata();
+  const [open, setOpen] = useState<boolean>(false);
+
+  const deleteBtnRef = useRef<HTMLButtonElement>(null);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const disableBtn = () => {
+    if (deleteBtnRef.current !== null) {
+      deleteBtnRef.current.setAttribute('disabled', 'disabled');
+    }
+  };
+
+  const removeFeed = async () => {
+    console.log(`Removing feed hosted at URL ${url}...`);
+    try {
+      const response = await fetch(`${telescopeUrl}/feeds/${id}`, { method: 'DELETE ' });
+
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+
+      deleteionCallback(id);
+
+      console.log(`Feed was successfully removed`);
+    } catch (error) {
+      console.error(`Error removing feed with ID ${id}`, error);
+      throw error;
+    }
+  };
+
+  return (
+    <div>
+      <IconButton classes={{ root: classes.button }} onClick={handleClickOpen}>
+        <Delete color="secondary" />
+      </IconButton>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{`Remove feed hosted at ${url}?`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Telescope will no longer display blog posts from this feed.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            ref={deleteBtnRef}
+            onClick={handleClose}
+            color="secondary"
+            variant="outlined"
+            autoFocus
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              disableBtn();
+              handleClose();
+              removeFeed();
+            }}
+            color="primary"
+            variant="contained"
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default DeleteFeedDialogButton;

--- a/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
+++ b/src/frontend/next/src/components/DeleteFeedDialogButton.tsx
@@ -15,7 +15,7 @@ import useSiteMetadata from '../hooks/use-site-metadata';
 
 type DeleteFeedDialogButtonProps = {
   feed: Feed;
-  deleteionCallback: (id: number) => void;
+  deletionCallback: (id: number) => void;
 };
 
 const useStyles = makeStyles(() => ({
@@ -24,7 +24,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const DeleteFeedDialogButton = ({ feed, deleteionCallback }: DeleteFeedDialogButtonProps) => {
+const DeleteFeedDialogButton = ({ feed, deletionCallback }: DeleteFeedDialogButtonProps) => {
   const { id, url } = feed;
   const classes = useStyles();
   const { telescopeUrl } = useSiteMetadata();
@@ -55,7 +55,7 @@ const DeleteFeedDialogButton = ({ feed, deleteionCallback }: DeleteFeedDialogBut
         throw new Error(response.statusText);
       }
 
-      deleteionCallback(id);
+      deletionCallback(id);
 
       console.log(`Feed was successfully removed`);
     } catch (error) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1539 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR address #1539, which is the porting of the DeleteFeedDialogIcon button to next from gatsby. It is part of #1316 which is the transitioning of the telescope frontend. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
