### PR TITLE
Fix #1589 - make sure that NEXT_PUBLIC_API_URL is set locally and in Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@
   publish = "out"
   command = "npm run build"
 
-
 [build.environment]
+  # Expose the API_URL to the back-end
   API_URL="https://dev.telescope.cdot.systems"
-
-
+  # We need to expose the API_URL to the front-end too
+  NEXT_PUBLIC_API_URL="https://dev.telescope.cdot.systems"

--- a/src/frontend/next/next.config.js
+++ b/src/frontend/next/next.config.js
@@ -4,7 +4,7 @@ const dotenv = require('dotenv');
 // Forward the API_URL value from the root env to NEXT_PUBLIC_API_URL
 const envPath = path.join(process.cwd(), '../../..', '.env');
 if (dotenv.config({ path: envPath }).error) {
-  console.warn('Unable to read root Telescope .env file');
+  console.warn('Unable to read root Telescope .env file.');
 } else {
   const apiUrl = process.env.API_URL;
 
@@ -17,6 +17,7 @@ if (dotenv.config({ path: envPath }).error) {
     process.env.NEXT_PUBLIC_API_URL = `http://localhost:${port}`;
   }
 }
+console.info(`Using NEXT_PUBLIC_API_URL=${process.env.NEXT_PUBLIC_API_URL}`);
 
 module.exports = {
   poweredByHeader: false,


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #1589

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

We need to set the NEXT_PUBLIC_API_URL in Netlify as well as locally.  This sets it in the netlify.toml file.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
