### PR TITLE
[next] Fixes: 1596 - ScrollToTop issues

### DIFF
--- a/src/frontend/next/src/components/BackToTopButton.tsx
+++ b/src/frontend/next/src/components/BackToTopButton.tsx
@@ -1,20 +1,22 @@
 import { Fab, useScrollTrigger, Zoom } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 
 import ScrollAction from './ScrollAction';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    position: 'fixed',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-    zIndex: 1100,
-  },
-  arrowUpIcon: {
-    color: theme.palette.text.primary,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      position: 'fixed',
+      bottom: theme.spacing(2),
+      right: theme.spacing(2),
+      zIndex: 1100,
+    },
+    arrowUpIcon: {
+      color: theme.palette.primary.light,
+    },
+  })
+);
 
 type BackToTopButtonProps = {
   scrollThreshold?: number;

--- a/src/frontend/next/src/theme/lightTheme.ts
+++ b/src/frontend/next/src/theme/lightTheme.ts
@@ -7,6 +7,7 @@ const lightTheme: Theme = createMuiTheme({
     primary: {
       main: '#333E64',
       contrastText: '#E5E5E5',
+      light: '#FFFFFF',
     },
     secondary: {
       main: '#0589D6',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes: #1596
The ~~ScrollToTop~~ `BackToTopButton` control in the posts timeline has a few issues:

1. the colours don't match what Gatsby has (white vs. black)
1. clicking the icon doesn't scroll the page
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
 1. the colours don't match what Gatsby has (white vs. black):
           - Update the color to white.
 1. clicking the icon doesn't scroll the page:
           - No action is needed. `BackToTopButton`needs an anchor to scroll(This anchor will be in the `Banner`). If you add an anchor with the id that the component uses as a target, it will scroll until it. I created a div with the id to reproduce and test it. Please check the image.

![2021-01-23 01 31 33](https://user-images.githubusercontent.com/60857409/105571497-3684b180-5d1e-11eb-929c-0943a704b8de.gif)



<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
