### PR TITLE
Fix #1597: [next] post banner has incorrect style

### DIFF
--- a/src/frontend/next/src/components/Posts/Post.tsx
+++ b/src/frontend/next/src/components/Posts/Post.tsx
@@ -161,7 +161,7 @@ const PostComponent = ({ postUrl }: Props) => {
             {post.title}
           </span>
         </Typography>
-        <Typography className={classes.author}>
+        <Typography variant="caption" className={classes.author}>
           &nbsp;By&nbsp;
           <a className={classes.link} href={post.feed.url}>
             {post.feed.author}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes: #1597 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
After porting post component to next, the `variant-"p"` in the element of author name was missing. Which cause the issue of incorrect css style (see the picture below)

![before](https://user-images.githubusercontent.com/50813726/105614440-83589e80-5d97-11eb-83ec-4046c457a82a.png)

However, when I tried to add this `variant="p"` back to the author element, I got a typescript error saying that this is overloaded and is not a match.
```
	"owner": "typescript",
	"code": "2769",
	"severity": 8,
	"message": "No overload matches this call.\n  Overload 1 of 2, '(props: { component: ElementType<any>; } & { align?: \"left\" | \"right\" | \"inherit\" | \"center\" | \"justify\" | undefined; children?: ReactNode; color?: \"inherit\" | \"initial\" | ... 5 more ... | undefined; ... 5 more ...; variantMapping?: Partial<...> | undefined; } & CommonProps<...> & Pick<...>): Element', gave the following error.\n    Type '\"p\"' is not assignable to type '\"inherit\" | \"button\" | \"overline\" | \"caption\" | \"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"subtitle1\" | \"subtitle2\" | \"body1\" | \"body2\" | \"srOnly\" | undefined'.\n  Overload 2 of 2, '(props: DefaultComponentProps<TypographyTypeMap<{}, \"span\">>): Element', gave the following error.\n    Type '\"p\"' is not assignable to type '\"inherit\" | \"button\" | \"overline\" | \"caption\" | \"h1\" | \"h2\" | \"h3\" | \"h4\" | \"h5\" | \"h6\" | \"subtitle1\" | \"subtitle2\" | \"body1\" | \"body2\" | \"srOnly\" | undefined'.",

```

Therefore, I change it to `variant="caption"` to avoid this error. Below is the post banner with `variant="caption"`.

![captionVariant](https://user-images.githubusercontent.com/50813726/105614444-881d5280-5d97-11eb-971a-190772fb2458.png)

However, this is still *slightly* different from the `variant="p"`. The below picture is the post component with `variant="p"`.

![pVariant](https://user-images.githubusercontent.com/50813726/105614449-8eabca00-5d97-11eb-8bb3-084bc4b8d8ca.png)

You may try in your local machine with these 2 variant setting in the author element in post component, it'll be easier to compare.

Feel free to leave a comment of your thought. Thanks!
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
