### PR TITLE
Fixes: 1595 - [next] Infinite Scrolling of Posts is broken (All of our infinite scrolls were broken)

### DIFF
--- a/src/frontend/gatsby/src/components/Posts/LoadAutoScroll.jsx
+++ b/src/frontend/gatsby/src/components/Posts/LoadAutoScroll.jsx
@@ -41,7 +41,8 @@ function LoadAutoScroll({ onScroll }) {
     return () => {
       observer.unobserve(buttonRefCopy);
     };
-  }, [onScroll]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Container>

--- a/src/frontend/gatsby/src/components/Posts/LoadAutoScroll.jsx
+++ b/src/frontend/gatsby/src/components/Posts/LoadAutoScroll.jsx
@@ -47,7 +47,7 @@ function LoadAutoScroll({ onScroll }) {
   return (
     <Container>
       <Grid item xs={12} className={classes.content}>
-        <Button ref={$buttonRef}>Load More Posts</Button>
+        <Button ref={$buttonRef}>Loading More Posts</Button>
       </Grid>
     </Container>
   );

--- a/src/frontend/next/src/components/Posts/LoadAutoScroll.tsx
+++ b/src/frontend/next/src/components/Posts/LoadAutoScroll.tsx
@@ -44,7 +44,8 @@ function LoadAutoScroll({ onScroll }: Scroll) {
     return () => {
       observer.unobserve(buttonRefCopy as HTMLButtonElement);
     };
-  }, [$buttonRef, onScroll]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Container>

--- a/src/frontend/next/src/components/Posts/LoadAutoScroll.tsx
+++ b/src/frontend/next/src/components/Posts/LoadAutoScroll.tsx
@@ -50,7 +50,7 @@ function LoadAutoScroll({ onScroll }: Scroll) {
   return (
     <Container>
       <Grid item xs={12} className={classes.content}>
-        <Button ref={$buttonRef}>Load More Posts</Button>
+        <Button ref={$buttonRef}>Loading More Posts</Button>
       </Grid>
     </Container>
   );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1595 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself, and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
 After landed the PR: https://github.com/Seneca-CDOT/telescope/pull/1573 created a bug inside our `LoadAutoScroll`'s useEffect both for our Gatsby and Next. This PR will fix the warning issue and fix all of our infinite scroll problems for Gatsby and Next (homepage and search page).
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
