### PR TITLE
Allow proxying next's webpack dev server (add unsafe-eval CSP for script-src) via backend

### DIFF
--- a/src/backend/web/app.js
+++ b/src/backend/web/app.js
@@ -29,7 +29,12 @@ app.use(
               frameSrc: ["'self'", '*.youtube.com', '*.vimeo.com'],
               frameAncestors: ["'self'"],
               imgSrc: ["'self'", 'data:', 'https:'],
-              scriptSrc: ["'self'"],
+              scriptSrc: [
+                "'self'",
+                // proxying webpack's dev server requires unsafe-eval, see:
+                // https://github.com/vercel/next.js/issues/7457#issuecomment-497092526
+                "'unsafe-eval'",
+              ],
               styleSrc: ["'self'", 'https:', "'unsafe-inline'"],
               objectSrc: ["'none'"],
               upgradeInsecureRequests: [],


### PR DESCRIPTION
I hit a bug today trying to proxy our next.js frontend via the backend:

```
react-refresh.js?ts=1611939499696:24 Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".

    at Object../node_modules/@next/react-refresh-utils/runtime.js (react-refresh.js?ts=1611939499696:24)
    at __webpack_require__ (webpack.js?ts=1611939499696:873)
    at checkDeferredModules (webpack.js?ts=1611939499696:46)
    at webpackJsonpCallback (webpack.js?ts=1611939499696:33)
    at webpack.js?ts=1611939499696:1015
    at webpack.js?ts=1611939499696:1023
```

This is caused by our CSP settings in dev, which weren't allowing `unsafe-eval` for `script-src` which the webpack dev server requires.

To test this:

1. change `.env` to `PROXY_FRONTEND=1`, `API_URL=http://localhost:3000`
2. `cd src/frontend/next` and start the dev server: `npm run dev`
3. `cd ../../..` (go to root) and start backend `npm start`
4. visit `http://localhost:3000` and you should get the next frontend
3. 