### PR TITLE
[next] Fixes #1546: Ported SearchResults to NextJS and fixed styling on search error

### DIFF
--- a/src/frontend/next/src/components/SearchResults.tsx
+++ b/src/frontend/next/src/components/SearchResults.tsx
@@ -1,0 +1,104 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { useSWRInfinite } from 'swr';
+import { Container, Box } from '@material-ui/core';
+
+import useSiteMetadata from '../hooks/use-site-metadata';
+import Timeline from './Posts/Timeline';
+import Spinner from './Spinner';
+
+const useStyles = makeStyles(() => ({
+  spinner: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  searchResults: {
+    padding: 0,
+    width: '100%',
+    justifyContent: 'center',
+  },
+  errorBackground: {
+    position: 'relative',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: '10px',
+    background: '#353F61',
+    boxShadow: '0 15px 30px rgba(0,0,0,.5)',
+    lineHeight: '1rem',
+  },
+  errorTitle: {
+    textAlign: 'center',
+    fontSize: '5rem',
+    color: '#fff',
+  },
+  errorMessage: {
+    lineHeight: '2rem',
+    fontSize: '2rem',
+    textAlign: 'center',
+    margin: '2rem',
+    color: '#96C1E7',
+  },
+}));
+
+type SearchResultProps = {
+  text: string;
+  filter: 'post' | 'author';
+};
+
+const SearchResults = ({ text, filter }: SearchResultProps) => {
+  const classes = useStyles();
+  const { telescopeUrl } = useSiteMetadata();
+  const prepareUrl = (index: number) =>
+    `${telescopeUrl}/query?text=${encodeURIComponent(text)}&filter=${filter}&page=${index}`;
+
+  // We only bother doing the request if we have something to search for.
+  const shouldFetch = () => text.length > 0;
+  const { data, size, setSize, error } = useSWRInfinite(
+    (index) => (shouldFetch() ? prepareUrl(index) : null),
+    async (u) => {
+      const res = await fetch(u);
+      const results = await res.json();
+      return results.values;
+    }
+  );
+  const loading = !data && !error;
+
+  if (error) {
+    return (
+      <Container className={classes.searchResults}>
+        <Box boxShadow={2} marginTop={10}>
+          <div className={classes.errorBackground}>
+            <div>
+              <p className={classes.errorTitle}>Search Error</p>
+              <p className={classes.errorMessage}>
+                There was a server error while processing your query
+              </p>
+            </div>
+          </div>
+        </Box>
+      </Container>
+    );
+  }
+
+  if (text.length && loading) {
+    return (
+      <Container className={classes.searchResults}>
+        <h1 className={classes.spinner}>
+          <Spinner />
+        </h1>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className={classes.searchResults}>
+      {data && data.length ? (
+        <Timeline pages={data} nextPage={() => setSize(size + 1)} />
+      ) : (
+        <h1>No search results</h1>
+      )}
+    </Container>
+  );
+};
+
+export default SearchResults;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1546 (Port SearchResults to NextJS)
Fixes #1458 (Update error styling for failed search)
Closes #1512 (The original 1458 issue was worked on by @sonechca and his resulting PR's work was essentially merged into this one and updated)
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI
- [x] **Next.JS Port** 

## Description
This PR ports SearchResults component from Gatsby to NextJS. This PR also includes an update on the search error styling.

Notable changes are the removal of the `loading` variable from `const { data, size, loading, setSize, error } = useSWRInfinite(//...)`  
`loading` is now declared as `const loading = !data && !error;`

`className={classes.root}` attribute was removed from `<Box className={classes.root} boxShadow={2} marginTop={10}>` since `classes.root` doesn't exist (*Typescript complained whereas in the original JSX file this was not an issue*). 

CSS styling additions of `errorBackground`, `errorTitle`, and `errorMessage` were added to update the error styling.

#### How to Test
Import the SearchResults component into a NextJS page (I used the index.tsx to test):
`import SearchResults from '../components/SearchResults'`  

Now create a SearchResults component and pass in some data:
e.g. it might look like this ` <SearchResults text={"Search for me"} filter={"I am a filter"}/>`

Save the code and then refresh the page, you should see something similar to this:
![image](https://user-images.githubusercontent.com/48869737/106329438-6c122900-624f-11eb-8e32-daeb3ae58e04.png)

To check the responsiveness, inspect the page (right-click the page -> inspect) and toggle device toolbar. For resulting example, see below:

Styling was taken from PR #1512 and updated to be responsive, see below:
| Before | After |
| :---: | :---: |
| ![image](https://user-images.githubusercontent.com/48869737/105510019-2926e300-5c9c-11eb-85cd-6c1aa7a6994b.png) | ![image](https://user-images.githubusercontent.com/48869737/106326711-e8563d80-624a-11eb-86ea-430bdbeaf956.png)

## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)