### PR TITLE
Fix #1629: improve next.js auth handling

### DIFF
--- a/src/frontend/next/src/components/AdminButtons.tsx
+++ b/src/frontend/next/src/components/AdminButtons.tsx
@@ -2,7 +2,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { IconButton } from '@material-ui/core';
 import FlagIcon from '@material-ui/icons/Flag';
 import DeleteIcon from '@material-ui/icons/Delete';
-import { useUser } from './UserProvider';
+import { useAdminUser } from './UserProvider';
 
 const useStyles = makeStyles(() => ({
   iconDiv: {
@@ -16,11 +16,12 @@ const useStyles = makeStyles(() => ({
 
 function AdminButtons() {
   const classes = useStyles();
-  const user = useUser();
+  const admin = useAdminUser();
 
-  if (!user.isAdmin) {
+  if (!admin) {
     return null;
   }
+
   return (
     <div className={classes.iconDiv}>
       <span className={classes.iconSpan}>

--- a/src/frontend/next/src/components/Login/LoggedIn.tsx
+++ b/src/frontend/next/src/components/Login/LoggedIn.tsx
@@ -2,7 +2,7 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { Button, Divider, Grid, useMediaQuery } from '@material-ui/core';
 import Link from 'next/link';
 
-import { useUser } from '../UserProvider';
+import { useAuthenticatedUser } from '../UserProvider';
 import config from '../../config';
 
 const useStyles = makeStyles((theme) => ({
@@ -37,11 +37,17 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const LoggedIn = () => {
-  const logoutUrl = `${config.telescopeUrl}/auth/logout`;
   const classes = useStyles();
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down('sm'));
-  const { name } = useUser();
+  const user = useAuthenticatedUser();
+  const { logoutUrl } = config;
+
+  if (!user) {
+    return null;
+  }
+
+  const { name } = user;
 
   return (
     <div>

--- a/src/frontend/next/src/components/Login/LoggedOut.tsx
+++ b/src/frontend/next/src/components/Login/LoggedOut.tsx
@@ -17,8 +17,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const LoggedOut = () => {
-  const loginUrl = `${config.telescopeUrl}/auth/login`;
   const classes = useStyles();
+  const { loginUrl } = config;
 
   return (
     <Button className={classes.button} href={loginUrl}>

--- a/src/frontend/next/src/components/Login/index.tsx
+++ b/src/frontend/next/src/components/Login/index.tsx
@@ -25,23 +25,25 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type LoginProps = {
-  isMobile: boolean | undefined;
+  isMobile?: boolean;
 };
 
 const Login = ({ isMobile = false }: LoginProps) => {
-  const { isLoggedIn } = useUser();
+  const user = useUser();
   const classes = useStyles();
+  const { logoutUrl, loginUrl } = config;
+
   if (isMobile) {
-    return isLoggedIn ? (
+    return user?.isLoggedIn ? (
       // This is How you make NextJS Link works with ListItem
       // Reference: https://dev.to/ivandotv/using-next-js-link-component-with-material-ui-buttons-and-menu-items-3m6a
-      <Link href={`${config.telescopeUrl}/auth/logout`} passHref>
+      <Link href={logoutUrl} passHref>
         <ListItem button component="a" className={classes.item}>
           <LoggedIn />
         </ListItem>
       </Link>
     ) : (
-      <Link href={`${config.telescopeUrl}/auth/login`} passHref>
+      <Link href={loginUrl} passHref>
         <ListItem button component="a" className={classes.item}>
           <LoggedOut />
         </ListItem>
@@ -49,7 +51,7 @@ const Login = ({ isMobile = false }: LoginProps) => {
     );
   }
 
-  return isLoggedIn ? <LoggedIn /> : <LoggedOut />;
+  return user?.isLoggedIn ? <LoggedIn /> : <LoggedOut />;
 };
 
 export default Login;

--- a/src/frontend/next/src/components/MyFeeds.tsx
+++ b/src/frontend/next/src/components/MyFeeds.tsx
@@ -1,0 +1,188 @@
+import { useState, useEffect, FormEvent } from 'react';
+import { Box, Card, Container, Grid, IconButton, Typography } from '@material-ui/core';
+import { AccountCircle, AddCircle, RssFeed } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+import { ValidatorForm, TextValidator } from 'react-material-ui-form-validator';
+import { isWebUri } from 'valid-url';
+
+import config from '../config';
+import ExistingFeedList from './ExistingFeedList';
+import HelpPopoverButton from './HelpPopoverButton';
+import CustomizedSnackBar from './SnackBar';
+import { AuthenticatedUser, Feed, FeedHash } from '../interfaces';
+
+const useStyles = makeStyles((theme) => ({
+  margin: {
+    margin: theme.spacing(2),
+  },
+  button: {
+    padding: '3px 0 3px 0',
+  },
+}));
+
+type MyFeedsProps = {
+  user: AuthenticatedUser;
+};
+
+const MyFeeds = ({ user }: MyFeedsProps) => {
+  const classes = useStyles();
+  const [newFeedAuthor, setNewFeedAuthor] = useState(user.name);
+  const [newFeedUrl, setNewFeedUrl] = useState('');
+  const [submitStatus, setSubmitStatus] = useState({ message: '', isError: false });
+  const [feedHashObject, updateFeedHashObject] = useState({});
+  const [alert, setAlert] = useState(false);
+
+  const { userFeedsUrl, feedsUrl } = config;
+
+  useEffect(() => {
+    setNewFeedAuthor(user.name);
+    ValidatorForm.addValidationRule('isUrl', (value: string) => !!isWebUri(value));
+    return function () {
+      ValidatorForm.removeValidationRule.bind('isUrl');
+    };
+  }, [user.name]);
+
+  useEffect(() => {
+    setAlert(true);
+    (async function hashUserFeeds() {
+      try {
+        const response = await fetch(userFeedsUrl);
+
+        if (!response.ok) {
+          throw new Error(response.statusText);
+        }
+
+        const userFeeds = await response.json();
+
+        const userFeedHash = userFeeds.reduce((hash: FeedHash, feed: Feed) => {
+          hash[feed.id] = { author: feed.author, url: feed.url };
+          return hash;
+        }, {});
+
+        updateFeedHashObject(userFeedHash);
+      } catch (error) {
+        console.error('Error hashing user feeds', error);
+      }
+    })();
+  }, [userFeedsUrl, alert]);
+
+  async function addFeed() {
+    try {
+      const response = await fetch(feedsUrl, {
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          user: user.id,
+          author: newFeedAuthor,
+          url: newFeedUrl,
+        }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        setSubmitStatus({ message: data.message, isError: false });
+        setNewFeedUrl('');
+        updateFeedHashObject({
+          [data.id]: { author: newFeedAuthor, url: newFeedUrl },
+          ...feedHashObject,
+        } as FeedHash);
+      } else {
+        throw new Error(data.message);
+      }
+    } catch (error) {
+      setSubmitStatus({ message: error.message, isError: true });
+      console.error('Error adding feed', error);
+    }
+    setAlert(false);
+  }
+
+  function handleChange(event: FormEvent<HTMLInputElement>) {
+    const { name, value } = event.target as HTMLInputElement;
+    if (name === 'author') {
+      setNewFeedAuthor(value);
+    } else {
+      setNewFeedUrl(value);
+    }
+  }
+
+  function deletionCallback(id: string) {
+    const updatedHash: FeedHash = { ...feedHashObject };
+    delete updatedHash[id];
+    setSubmitStatus({ message: 'Feed removed successfully', isError: false });
+    setAlert(false);
+    updateFeedHashObject(updatedHash);
+  }
+
+  return (
+    <div className={classes.margin}>
+      <ValidatorForm onSubmit={() => addFeed()} instantValidate={false}>
+        <Container maxWidth="md">
+          <Card>
+            <Box px={2} py={1}>
+              <Typography variant="h3" component="h3" align="center">
+                My Feeds
+              </Typography>
+              <Grid container spacing={5}>
+                <Grid item xs={5} sm={4} md={3}>
+                  <Grid container spacing={1} alignItems="flex-end">
+                    <Grid item xs="auto">
+                      <AccountCircle />
+                    </Grid>
+                    <Grid item xs={8} sm={10}>
+                      <TextValidator
+                        label="Blog feed author"
+                        name="author"
+                        value={newFeedAuthor}
+                        onChange={handleChange}
+                        type="string"
+                        validators={['required', 'trim']}
+                        errorMessages={"Please enter the blog's author."}
+                        fullWidth
+                      />
+                    </Grid>
+                  </Grid>
+                </Grid>
+                <Grid item xs={7} sm={8} md={9}>
+                  <Grid container spacing={1} alignItems="flex-end">
+                    <Grid item xs="auto">
+                      <RssFeed />
+                    </Grid>
+                    <Grid item xs={8} sm={10} md={11}>
+                      <TextValidator
+                        label="Blog feed URL"
+                        name="url"
+                        value={newFeedUrl}
+                        onChange={handleChange}
+                        type="url"
+                        validators={['required', 'isUrl']}
+                        errorMessages={"Please enter the blog's feed URL."}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs="auto">
+                      <HelpPopoverButton />
+                    </Grid>
+                  </Grid>
+                  <Grid container spacing={2}>
+                    <Grid item>
+                      <IconButton classes={{ root: classes.button }} type="submit">
+                        <AddCircle color="secondary" />
+                      </IconButton>
+                      {alert === true && submitStatus.message !== '' && (
+                        <CustomizedSnackBar message={submitStatus.message} isOpen={alert} />
+                      )}
+                    </Grid>
+                  </Grid>
+                </Grid>
+              </Grid>
+              <ExistingFeedList feedHash={feedHashObject} deletionCallback={deletionCallback} />
+            </Box>
+          </Card>
+        </Container>
+      </ValidatorForm>
+    </div>
+  );
+};
+
+export default MyFeeds;

--- a/src/frontend/next/src/components/UserProvider.tsx
+++ b/src/frontend/next/src/components/UserProvider.tsx
@@ -1,9 +1,11 @@
 import { createContext, ReactNode, useContext } from 'react';
 
-import { User } from '../interfaces';
+import { User, AuthenticatedUser, AdminUser } from '../interfaces';
 import useAuthorization from '../hooks/use-authorization';
+import config from '../config';
 
-const UserContext = createContext<User>({ isLoggedIn: false });
+const { loginUrl } = config;
+const UserContext = createContext<null | User | AuthenticatedUser | AdminUser>(null);
 
 type Props = {
   children: ReactNode;
@@ -16,4 +18,63 @@ const UserProvider = ({ children }: Props) => {
 
 export default UserProvider;
 
-export const useUser = () => useContext(UserContext);
+/**
+ * User Hooks
+ * ----------
+ *
+ * We provide three different user hooks, which work in a similar way,
+ * but are meant to be used in different circumstances.
+ *
+ * useUser() - when all you care about is if the user is logged in or not.
+ *
+ * useAuthenticatedUser(shouldRedirect) - when you need an authenticated user.
+ * You will get null or an AuthenticatedUser in response.  If shouldRedirect
+ * is true, it will redirect to the Telescope login page.
+ *
+ * useAdminUser(shouldRedirect) - when you need an authenticated admin user.
+ * You will get null or an AdminUser in response.  If shouldRedirect
+ * is true, it will redirect to the Telescope login page.
+ */
+export const useUser = (): null | User => useContext(UserContext);
+
+export const useAuthenticatedUser = (shouldRedirect = false): null | AuthenticatedUser => {
+  const user = useUser();
+
+  // Wait until we have user info from the server
+  if (!user) {
+    return null;
+  }
+
+  if (!user.isLoggedIn) {
+    if (shouldRedirect) {
+      window.location.href = loginUrl;
+    }
+    // Caller wants an authenticated user, which we don't have,
+    // so return nothing.
+    return null;
+  }
+
+  // User's authentication status is known, return that
+  return user as AuthenticatedUser;
+};
+
+export const useAdminUser = (shouldRedirect = false): null | AdminUser => {
+  const user = useAuthenticatedUser();
+
+  // Wait until we have user info from the server
+  if (!user) {
+    return null;
+  }
+
+  if (!user.isAdmin) {
+    if (shouldRedirect) {
+      window.location.href = loginUrl;
+    }
+    // Caller wants an admin user, which we don't have,
+    // so return nothing.
+    return null;
+  }
+
+  // User's authentication status is known, return that
+  return user as AdminUser;
+};

--- a/src/frontend/next/src/config.ts
+++ b/src/frontend/next/src/config.ts
@@ -1,9 +1,15 @@
+// This comes via the top level .env and its API_URL value,
+// and gets set in next.config.js at build time.
+const telescopeUrl = process.env.NEXT_PUBLIC_API_URL;
+
 export default {
   title: `Telescope`,
   description: `A tool for tracking blogs in orbit around Seneca's open source involvement`,
   author: `SDDS Students and professors`,
-  // This comes via the top level .env and its API_URL value,
-  // and gets set in next.config.js at build time.
-  telescopeUrl: process.env.NEXT_PUBLIC_API_URL,
+  telescopeUrl,
+  loginUrl: `${telescopeUrl}/auth/login`,
+  logoutUrl: `${telescopeUrl}/auth/logout`,
+  userFeedsUrl: `${telescopeUrl}/user/feeds`,
+  feedsUrl: `${telescopeUrl}/feeds`,
   keywords: 'blogfeeds, canada, opensourced',
 };

--- a/src/frontend/next/src/hooks/use-authorization.ts
+++ b/src/frontend/next/src/hooks/use-authorization.ts
@@ -3,7 +3,8 @@ import useSWR from 'swr';
 import config from '../config';
 import { User } from '../interfaces';
 
-export default function useAuthorization(): User {
+export default function useAuthorization(): User | null {
+  const userInfoUrl = `${config.telescopeUrl}/user/info`;
   const loggedOutUser: User = { isLoggedIn: false };
 
   // Assuming fetch() works, our fetcher function will always
@@ -30,7 +31,7 @@ export default function useAuthorization(): User {
     };
   };
 
-  const { data, error } = useSWR<User>(`${config.telescopeUrl}/user/info`, fetcher);
+  const { data: user, error } = useSWR<User>(userInfoUrl, fetcher);
 
   // In the error case (backend is down?) we have no idea, so logged out.
   if (error) {
@@ -38,12 +39,8 @@ export default function useAuthorization(): User {
     return loggedOutUser;
   }
 
-  // If we have user data from the backend, use that
-  if (data) {
-    return data;
-  }
-
-  // In all other cases (e.g., on startup before we hear back from the
-  // server, or some other unknown condition), assume logged out.
-  return loggedOutUser;
+  // If we have user data from the backend, use that. In all other cases
+  // (e.g., on startup before we hear back from the server, or some other
+  // unknown condition), return nothing to indicate that we're still waiting.
+  return user || null;
 }

--- a/src/frontend/next/src/interfaces/index.ts
+++ b/src/frontend/next/src/interfaces/index.ts
@@ -1,10 +1,18 @@
-export type User = {
-  name?: string;
-  email?: string;
-  id?: string;
-  isAdmin?: boolean;
+export interface User {
   isLoggedIn: boolean;
-};
+}
+
+export interface AuthenticatedUser extends User {
+  name: string;
+  email: string;
+  id: string;
+  isAdmin: boolean;
+  isLoggedIn: true;
+}
+
+export interface AdminUser extends AuthenticatedUser {
+  isAdmin: true;
+}
 
 export type Feed = {
   id: string;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #1629

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This follows the suggestions of the next.js docs on doing statically rendered site authentication.  I've also extended it a bit to add the concept of a user vs. an admin.

First, we have 4 types that a "user" can be at runtime:

- `null` - we either don't know anything about them, or don't have the info (yet)
- `User` - we know whether they are logged in or not, nothing more (e.g., we don't have their user info yet)
- `AuthenticatedUser` - we know that they are logged in for sure, and their name, email, id
- `AdminUser` - we know that they are authenticated AND that they are an admin

In components/pages, you decide which one you want to use, based on your needs.  So if you only care about whether or not the user is logged in, you use `useUser()`:

```
const user = useUser();

// User might be null
if(!user) { 
  return null;
}

return user.isLoggedIn ? 'Logged In' : 'Not Logged In';
```

If you need to use their username or email, then you need `useAuthenticatedUser()` instead:

```
const authenticated = useAuthenticatedUser();

// User might be null
if(!authenticated) { 
  return null;
}

return authenticated.name;
```

Same idea for admin with `useAdminUser()`.

For `useAuthenticatedUser()` and useAdminUser()` you can also pass `true` to them to have the app redirect on failure to the login page.  This is useful for pages that need to have an authenticated user or admin user.

I've re-written the `/myfeeds` page to use this logic, and only render it once we have an Authenticated user.  To allow for passing the authenticated user down, I've refactored it a bit to move the body of the page into its own component that receives the user on props.
