### PR TITLE
linter: remove 'Prefer async/await to callback' rule from .eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,11 +144,6 @@ module.exports = {
      */
     'promise/prefer-await-to-then': 'warn',
 
-    /**
-     * Prefer async/await to the callback pattern
-     */
-    'promise/prefer-await-to-callbacks': 'warn',
-
     'react/jsx-uses-vars': 'error',
 
     /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Closes #1396 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This removes the `Prefer async/await to callback' rule from our `.eslintrc` file. After merging this, we shouldn't see more warnings related to this issue when running tests.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
