### PR TITLE
netlify: force rebuild with every merge to avoid 'failed' message in badge

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,11 @@
   publish = "out"
   command = "npm run build"
 
+  # Netlify cancels builds when it detects that no changes were made to the next frontend,
+  # and this cancellation is reported as "fail" in our netlify badge.
+  # To avoid this, we use the ignore setting to force a build even when no changes have been made to the next frontend.
+  ignore = "/bin/false"
+
 [build.environment]
   # Expose the API_URL to the back-end
   API_URL="https://dev.telescope.cdot.systems"


### PR DESCRIPTION

## Description

Whenever a PR is merged and no changes were made to `next`, our badge reports a `failed` build. This happens because `netlify` detects that no changes were made to the `next` front-end and cancels the build, and for some reason it considers this a failed attempt.
This bug [has been reported](https://community.netlify.com/t/status-badge-incorrectly-shows-failing-when-deploy-is-auto-cancelled/7316/3), and it seems that the solution to avoid this behavior (for now) is to force a build even when no changes were made to the `next` front-end.

This PR makes the necessary changes to our `netlify.toml` to force the `next` build.
