### PR TITLE
refactor(next): Fixed #1446 - Migrated headers to Next.js and TS

### DIFF
--- a/src/frontend/next/src/components/Header/DesktopHeader.tsx
+++ b/src/frontend/next/src/components/Header/DesktopHeader.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { makeStyles } from '@material-ui/core/styles';
+import { AppBar, Toolbar, Button, IconButton } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
+
+import Logo from '../Logo';
+import Login from '../Login';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: 1,
+    backgroundColor: 'primary',
+    justifyContent: 'center',
+    height: '8.9em',
+  },
+  toolbar: theme.mixins.toolbar,
+
+  grow: {
+    flexGrow: 1,
+  },
+  searchIcon: {
+    fontSize: '2.5rem',
+    color: theme.palette.primary.contrastText,
+  },
+  button: {
+    float: 'right',
+    margin: '0 0.5rem 0 0.5rem',
+  },
+  links: {
+    color: theme.palette.primary.contrastText,
+    fontFamily: 'Roboto, sans-serif',
+    textDecoration: 'none',
+    fontSize: '1.5rem',
+    margin: '0 0.5rem 0 0.5rem',
+  },
+}));
+
+export default function DesktopHeader() {
+  const classes = useStyles();
+  return (
+    <>
+      <AppBar position="sticky" className={classes.root}>
+        <Toolbar>
+          <Link href="/">
+            <Logo height={45} width={45} />
+          </Link>
+          <div className={classes.grow} />
+          <IconButton color="inherit" className={classes.button} aria-label="search">
+            <Link href="/search">
+              <SearchIcon className={classes.searchIcon} />
+            </Link>
+          </IconButton>
+
+          <Button color="inherit" size="medium" className={classes.button}>
+            <Link href="/">
+              <a className={classes.links}>Home</a>
+            </Link>
+          </Button>
+          <Button color="inherit" size="medium" className={classes.button}>
+            <Link href="/about">
+              <a className={classes.links}>About</a>
+            </Link>
+          </Button>
+          <Login />
+        </Toolbar>
+      </AppBar>
+    </>
+  );
+}

--- a/src/frontend/next/src/components/Header/MobileHeader.tsx
+++ b/src/frontend/next/src/components/Header/MobileHeader.tsx
@@ -1,0 +1,142 @@
+import { useState, KeyboardEvent, SyntheticEvent } from 'react';
+import Link from 'next/link';
+import { makeStyles } from '@material-ui/core/styles';
+import { AppBar, Toolbar, IconButton, List, ListItem, Drawer, Divider } from '@material-ui/core';
+import MenuIcon from '@material-ui/icons/Menu';
+import SearchIcon from '@material-ui/icons/Search';
+
+import Logo from '../Logo';
+import Login from '../Login';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: 1,
+    backgroundColor: 'primary',
+    justifyContent: 'center',
+    height: '8em',
+    [theme.breakpoints.down(1065)]: {
+      height: '6.5em',
+    },
+  },
+  toolbar: theme.mixins.toolbar,
+  Logo: {
+    margin: '0 0.5rem 0 0.5rem',
+  },
+  grow: {
+    flexGrow: 1,
+  },
+  searchIcon: {
+    fontSize: '2.5rem',
+    color: theme.palette.background.default,
+  },
+  menuIcon: {
+    fontSize: '2.5rem',
+  },
+  links: {
+    color: theme.palette.background.default,
+    fontFamily: 'Roboto, sans-serif',
+    textDecoration: 'none',
+    fontSize: '1.5rem',
+    margin: '0 0.5rem 0 0.5rem',
+  },
+  button: {
+    float: 'right',
+    margin: '0 0.5rem 0 0.5rem',
+  },
+  list: {
+    width: 250,
+  },
+  paper: {
+    backgroundColor: theme.palette.primary.main,
+  },
+  line: {
+    backgroundColor: theme.palette.background.default,
+  },
+  item: {
+    color: theme.palette.background.default,
+    fontFamily: 'Roboto, sans-serif',
+    textDecoration: 'none',
+    fontSize: '1.5rem',
+    justifyContent: 'center',
+    fontWeight: 500,
+    lineHeight: 1.75,
+  },
+}));
+
+export default function MobileHeader() {
+  const classes = useStyles();
+  const [state, setState] = useState({
+    right: false,
+  });
+
+  const toggleDrawer = (side: string, open: boolean) => (event: SyntheticEvent) => {
+    if (event.type === 'keydown') {
+      const keyboardEvent = event as KeyboardEvent;
+      if (keyboardEvent.key === 'Tab' || keyboardEvent.key === 'Shift') {
+        return;
+      }
+    }
+    setState({ ...state, [side]: open });
+  };
+
+  const sideList = (side: string) => (
+    <div
+      className={classes.list}
+      role="presentation"
+      onClick={toggleDrawer(side, false)}
+      onKeyDown={toggleDrawer(side, false)}
+    >
+      <List className={classes.item}>
+        <ListItem button className={classes.item}>
+          <Link href="/">
+            <a className={classes.links}>Home</a>
+          </Link>
+        </ListItem>
+        <Divider className={classes.line} />
+        <ListItem button className={classes.item}>
+          <Link href="/about">
+            <a className={classes.links}>About</a>
+          </Link>
+        </ListItem>
+        <Divider className={classes.line} />
+        <Login isMobile />
+        <Divider className={classes.line} />
+      </List>
+    </div>
+  );
+
+  return (
+    <>
+      <AppBar position="sticky" className={classes.root}>
+        <Toolbar>
+          <Link href="/">
+            <Logo height={45} width={45} />
+          </Link>
+          <div className={classes.grow} />
+          <IconButton color="inherit" className={classes.button} aria-label="search">
+            <Link href="/search">
+              <SearchIcon className={classes.searchIcon} />
+            </Link>
+          </IconButton>
+          <IconButton
+            onClick={toggleDrawer('right', true)}
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            className={classes.button}
+          >
+            <MenuIcon className={classes.menuIcon} />
+          </IconButton>
+          <Drawer
+            classes={{ paper: classes.paper }}
+            anchor="right"
+            open={state.right}
+            onClose={toggleDrawer('right', false)}
+          >
+            {sideList('right')}
+          </Drawer>
+        </Toolbar>
+      </AppBar>
+    </>
+  );
+}

--- a/src/frontend/next/src/components/Header/index.tsx
+++ b/src/frontend/next/src/components/Header/index.tsx
@@ -1,0 +1,14 @@
+import { useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+
+import MobileHeader from './MobileHeader';
+import DesktopHeader from './DesktopHeader';
+
+function Header() {
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.down(1440));
+
+  return <>{matches ? <MobileHeader /> : <DesktopHeader />}</>;
+}
+
+export default Header;

--- a/src/frontend/next/src/pages/_app.tsx
+++ b/src/frontend/next/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { AppProps } from 'next/app';
 import { ThemeProvider } from '@material-ui/core/styles';
+import Header from '../components/Header';
 import UserProvider from '../components/UserProvider';
 
 import '../styles/globals.css';
@@ -30,6 +31,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   return (
     <ThemeProvider theme={theme}>
       <UserProvider>
+        <Header />
         <Component {...pageProps} theme={theme} toggleTheme={toggleTheme} />
       </UserProvider>
     </ThemeProvider>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #1446. It is a rework of the #1516 PR.

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Translated DesktopHeader.js, MobileHeader.js and Header.js to TS. 

You can check how it works if you go to the `frontend/next` and run `npm run dev`. This will build the Next version of the frontend - and here you can check out how the banner works by trying to click "Home" and "About" and "Search" buttons in Desktop and Mobile versions (For Mobile press F12 in Chrome). 

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
