### PR TITLE
Closes #1439: Fix eslint warnings from Gatsby build

### DIFF
--- a/src/frontend/gatsby/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
+++ b/src/frontend/gatsby/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
@@ -75,13 +75,7 @@ function DeleteFeedDialogButton({ feed, deletionCallback }) {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button
-            ref={deleteBtnRef}
-            onClick={handleClose}
-            color="secondary"
-            variant="outlined"
-            autoFocus
-          >
+          <Button ref={deleteBtnRef} onClick={handleClose} color="secondary" variant="outlined">
             Cancel
           </Button>
           <Button


### PR DESCRIPTION

## Issue This PR Addresses

Closes #1439 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This removes `autofocus` from [DeleteFeedDialogButton](https://github.com/Seneca-CDOT/telescope/blob/master/src/frontend/gatsby/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx) to deal with:

```sh
warning ESLintError: 
telescope/src/frontend/gatsby/src/components/MyFeedsPage/DeleteFeedDialogButton.jsx
  83:13  warning  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus 
```

All the other warnings in #1439 have been fixed.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
