### PR TITLE
fix(linter): remove 'Prefer await to then()' rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,15 +135,10 @@ module.exports = {
      * https://eslint.org/docs/rules/func-names
      */
     'linebreak-style': 'off',
-    /**
-     * The following are eslint rules from the promise-plugin
-     * https://github.com/xjamundx/eslint-plugin-promise
-     */
-    /**
-     * Prefer wait to then() for reading Promise values
-     */
-    'promise/prefer-await-to-then': 'warn',
 
+    /**
+     * Prevent variables used in JSX to be incorrectly marked as unused
+     */
     'react/jsx-uses-vars': 'error',
 
     /**


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This removes the `Prefer await to then()` rule from our `.eslintrc.js`.
Also, a description for `'react/jsx-uses-vars': 'error'` was added (there wasn't any before).

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
