### PR TITLE
Fixes #1534, Added Legacy Dependencies Check

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,3 +8,6 @@ unsafe-perm=true
 
 # Set empty tag version prefix
 tag-version-prefix=""
+
+#Set legacy peer dependencies to 'true', (needed for npm7.x compatibility for now)
+legacy-peer-deps=true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
Fixes #1534 
and closed #1617 due to the branch being outdated
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
As of npm7.x, Peer Dependencies has had an overhaul, causing some of our dependencies not properly installing if a user runs `npm install`. This is a band-aid fix to use the legacy Peer Dependencies, until we fix the issue for forwards compatibility. 

This is a final version of #1617, as this PR is rebased.

More Information on the Changes of Peer Dependencies can be found [here](https://github.com/npm/rfcs/blob/latest/implemented/0025-install-peer-deps.md)  
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
