### PR TITLE
Fixes #1468: Port error page from Gatsby to Nextjs

### DIFF
--- a/src/frontend/next/src/pages/error.tsx
+++ b/src/frontend/next/src/pages/error.tsx
@@ -1,0 +1,194 @@
+import { useRouter } from 'next/router';
+import { Card, CardActions, CardContent, Fab, Grid, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ArrowBack from '@material-ui/icons/ArrowBack';
+import config from '../config';
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    position: 'absolute',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      top: '0',
+    },
+    top: '45vh',
+  },
+  root: {
+    fontFamily: 'Roboto',
+    zIndex: 100,
+    padding: theme.spacing(2, 4, 2, 4),
+    position: 'relative',
+    margin: 'auto',
+    backgroundColor: theme.palette.primary.main,
+    overflow: 'visible',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      top: theme.spacing(24),
+    },
+  },
+  h1: {
+    fontWeight: 'bold',
+    opacity: 0.85,
+    color: theme.palette.grey[100],
+    fontSize: '12rem',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      fontSize: '4rem',
+    },
+    [theme.breakpoints.between('md', 'lg')]: {
+      fontSize: '8rem',
+    },
+    [theme.breakpoints.up('xl')]: {
+      fontSize: '12rem',
+    },
+  },
+  h2: {
+    fontSize: '2rem',
+    color: theme.palette.grey[200],
+    marginTop: '1.75rem',
+    lineHeight: 'inherit',
+    letterSpacing: 'inherit',
+    transition: 'all linear 350ms',
+    [theme.breakpoints.between('xs', 'sm')]: {
+      fontSize: '2rem',
+    },
+    [theme.breakpoints.between('md', 'lg')]: {
+      fontSize: '4rem',
+    },
+    [theme.breakpoints.up('xl')]: {
+      fontSize: '8rem',
+    },
+  },
+  h3: {
+    fontFamily: 'monospace',
+    fontSize: '2rem',
+    padding: theme.spacing(4),
+    color: theme.palette.grey[300],
+    borderRadius: theme.spacing(1),
+  },
+  link: {
+    color: 'white',
+    fontFamily: 'Roboto, sans-serif',
+    textDecoration: 'none',
+    fontSize: '1.5rem',
+    margin: '0 0.5rem 0 0.5rem',
+  },
+  fab: {
+    position: 'relative',
+    fontSize: '1.5rem',
+    color: theme.palette.text.primary,
+    bottom: -45,
+    zIndex: 200,
+    backgroundColor: theme.palette.secondary.light,
+    transition: 'all linear 250ms',
+    '&:hover': {
+      backgroundColor: theme.palette.secondary.dark,
+    },
+    [theme.breakpoints.between('xs', 'sm')]: {
+      right: '-2rem',
+    },
+  },
+  buttonText: {
+    fontSize: '1.5rem',
+    paddingLeft: theme.spacing(1),
+    [theme.breakpoints.between('xs', 'sm')]: {
+      display: 'none',
+    },
+  },
+}));
+
+type ErrorProps = {
+  message: string | null;
+  status: number | null;
+};
+
+function InnerErrorContent({ message, status }: ErrorProps) {
+  const classes = useStyles();
+
+  let errorMessage;
+
+  switch (status) {
+    case 400:
+      errorMessage = 'We did not understand the request!';
+      break;
+    case 401:
+      errorMessage = 'You are not authorized to view this page!';
+      break;
+    case 403:
+      errorMessage = 'Access is not allowed for the requested page!';
+      break;
+    case 404:
+      errorMessage = 'We could not find what you were looking for!';
+      break;
+    case 405:
+      errorMessage = 'Method is not allowed!';
+      break;
+    default:
+      errorMessage = 'Something went wrong!';
+  }
+
+  // If server doesn't send us a custom message, use ones defined above.
+  if (!message) {
+    return (
+      <Typography variant="body1" className={classes.h2}>
+        {errorMessage}
+      </Typography>
+    );
+  }
+  return (
+    <Typography variant="body1" className={classes.h3}>
+      {message}
+    </Typography>
+  );
+}
+
+const ErrorPage = () => {
+  const classes = useStyles();
+  const router = useRouter();
+
+  const { telescopeUrl } = config;
+  const location = new URL(router.asPath, telescopeUrl);
+  const params = new URLSearchParams(location.search);
+
+  const status = params.get('status') ? Number(params.get('status')) : null;
+  const message = params.get('message');
+
+  return (
+    <>
+      <Grid
+        container
+        spacing={0}
+        direction="column"
+        alignItems="center"
+        justify="center"
+        className={classes.container}
+      >
+        <Grid item xs={8}>
+          <Card className={classes.root} elevation={6}>
+            <CardContent>
+              <Typography variant="h1" className={classes.h1}>
+                {status}
+              </Typography>
+
+              <InnerErrorContent status={status} message={message} />
+            </CardContent>
+
+            <CardActions
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                transition: 'all linear 350ms',
+              }}
+            >
+              <Fab variant="extended" href="/" className={classes.fab}>
+                <ArrowBack />
+                <Typography variant="body2" className={classes.buttonText}>
+                  Let&apos;s Go Back
+                </Typography>
+              </Fab>
+            </CardActions>
+          </Card>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default ErrorPage;


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #1468 
Closes #1506 (Old PR for same issue)

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR takes over and continues the work of #1506 to port the error page from Gatsby to Next.js. 

### HOW TO TEST:
Set your URL to `/error`. 
**For example,** if I am running Telescope on `localhost:8000`, then my full URL will look like `http://localhost:8000/error`.  

To see default status code messages (400-405), add `?status=CODE` to `http://localhost:8000/error` where `CODE` is a number from 400-405. 
**For example:**  `http://localhost:8000/error?status=404` will result in displaying status code 404 and message 'We could not find what you were looking for!'
Note, codes out of this range will still be displayed and also it will default to message 'Something went wrong!'. 

To see custom messages, add `&message=MESSAGE` to `http://localhost:8000/error?status=CODE` where `CODE` is any number, and `MESSAGE` is a string.
**For example:** `http://localhost:8000/error?status=999&message=Server blew up!`

### NOTE
`PageBase` component was removed, the `_app.tsx` replaces its purpose.  

Next.js on the left, Gatsby on the right.
![image](https://user-images.githubusercontent.com/48869737/108137744-825f1800-708a-11eb-9058-abc43a5e486c.png)
As you can see, without the `PageBase` component everything is still there (*minus the DynamicImage, I removed it for now as it caused mobile styling issues*)

## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

## Screenshots
Test with status 400
![image](https://user-images.githubusercontent.com/48869737/108133770-1331f580-7083-11eb-9d76-23b4997f66f5.png)
---
Test with no search parameters
![image](https://user-images.githubusercontent.com/48869737/108133810-2a70e300-7083-11eb-9930-c2947739aea8.png)
---
Test with status 405 and custom message
![image](https://user-images.githubusercontent.com/48869737/108133957-660bad00-7083-11eb-86ec-6883d90bfaec.png)
---
Test with status 404 on mobile
![image](https://user-images.githubusercontent.com/48869737/108134002-7ae84080-7083-11eb-8ce1-2b250ba01ef1.png)


