### PR TITLE
chore: bump @types/react from 16.9.51 to 17.0.2 in src/frontend/next

### DIFF
--- a/src/frontend/next/package.json
+++ b/src/frontend/next/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.14.28",
-    "@types/react": "^16.9.51",
+    "@types/react": "^17.0.2",
     "@types/react-material-ui-form-validator": "^2.1.0",
     "@types/valid-url": "^1.0.3",
     "typescript": "^4.1.2"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
Related to #1592 
## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR bumps @types/react to 16.14.4.
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
