### PR TITLE
refactor(ci): refactored Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Root package.json
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      # Use Eastern Standard Time (UTC -05:00)
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+    # Disable automatic rebasing
+    rebase-strategy: 'disabled'
+
+  # Next Front-End
+  - package-ecosystem: 'npm'
+    directory: '/src/frontend/next'
+    schedule:
+      interval: 'weekly'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: nextjs'
+    rebase-strategy: 'disabled'
+
+  # Auto-deployment Server
+  - package-ecosystem: 'npm'
+    directory: '/tools/autodeployment'
+    schedule:
+      interval: 'weekly'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: autodeployment'
+    rebase-strategy: 'disabled'


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1647 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Refactored Dependabot config file. Number of steps taken to avoid spamming our CI quotas:
- removed Gatsby package file from being monitored. Dependabot will not check for outdated depednencies at `/src/
frontend/gatsby`
- set the `open-pull-requests-limit` to `1` for each of the 3 remaining package files. That would bring us to a maximum of 3 Dependabot PRs open at a time
- disabled automatic rebases: `rebase-strategy: 'disabled'`. This will prevent Dependabot from rebasing each of its PRs whenever it gets outdated. We will rebase manually when we are ready to merge each pr. That would avoid having extra CI runs.
- I and @yuanLeeMidori are taking care of manually updating all of our outdated dependencies in https://github.com/Seneca-CDOT/telescope/issues/1592. Once it is closed, we should have all of our dependencies updated, which would leave Dependabot with nothing to spam our CI with, even if it would want to. 


<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
