### PR TITLE
chore: bump highlight.js from 10.4.1 to 10.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "feedparser-promised": "2.0.1",
     "git-repo-info": "2.1.1",
     "helmet": "4.4.1",
-    "highlight.js": "10.4.1",
+    "highlight.js": "10.6.0",
     "http-proxy-middleware": "1.0.6",
     "ioredis": "4.22.0",
     "ioredis-mock": "5.2.2",

--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -55,7 +55,7 @@ describe('syntax-highlight tests', () => {
       '<pre><code>import React, { Component } from "react"; function main() { console.log("hi"); }</code></pre>';
     const result = syntaxHighlighter(original);
     const expected =
-      '<pre class="hljs javascript"><code><span class="hljs-keyword">import</span> React, { Component } <span class="hljs-keyword">from</span> <span class="hljs-string">"react"</span>; <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">main</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"hi"</span>); }</code></pre>';
+      '<pre class="hljs typescript"><code><span class="hljs-keyword">import</span> React, { Component } <span class="hljs-keyword">from</span> <span class="hljs-string">"react"</span>; <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">main</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"hi"</span>); }</code></pre>';
     expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
Related to #1592 
## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR bumps version of `highlight.js` from 10.4.1 to 10.6.0 in the root package file and updates the test.
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
