### PR TITLE
Fix: issue 1588 - Update bull board and highlight.js dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@wordpress/wordcount": "2.14.1",
     "body-parser": "1.19.0",
     "bull": "3.20.1",
-    "bull-board": "0.9.0",
+    "bull-board": "1.3.1",
     "connect-redis": "5.1.0",
     "cors": "2.8.5",
     "date-fns": "2.17.0",

--- a/src/backend/feed/queue.js
+++ b/src/backend/feed/queue.js
@@ -1,4 +1,4 @@
-const { setQueues } = require('bull-board');
+const { setQueues, BullAdapter } = require('bull-board');
 
 require('../lib/config');
 const { logger } = require('../utils/logger');
@@ -8,7 +8,7 @@ const { createQueue } = require('../lib/queue');
 const queue = createQueue('feed-queue');
 
 // For visualizing queues using bull board
-setQueues(queue);
+setQueues([new BullAdapter(queue)]);
 
 /**
  * Provide a helper for adding a feed with our desired default options.

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -1,6 +1,6 @@
 require('../../lib/config');
 const express = require('express');
-const { UI } = require('bull-board');
+const { router: bullBoardRouter } = require('bull-board');
 const { createProxyMiddleware } = require('http-proxy-middleware');
 const fs = require('fs');
 
@@ -10,7 +10,7 @@ const { logger } = require('../../utils/logger');
 const router = express.Router();
 
 // Only authenticated admins can use these routes
-router.use('/queues', protectAdmin(true), UI);
+router.use('/queues', protectAdmin(true), bullBoardRouter);
 
 // Only authenticated admin users can see this route
 router.get('/log', protectAdmin(true), (req, res) => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes: #1588 
Related: #1592 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

bull-board 0.9.0 has highlight version 9 dependency. To fix issue #1588, we need to update bull-board.

![image](https://user-images.githubusercontent.com/50813726/108256911-1208d300-712c-11eb-99d0-36b44a6d6744.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
