### PR TITLE
Fixed#1776: Fixed inconsistent render of the toggle theme icone when dark mode is chosen on client.

### DIFF
--- a/src/frontend/next/src/components/Header/DesktopHeader.tsx
+++ b/src/frontend/next/src/components/Header/DesktopHeader.tsx
@@ -2,10 +2,18 @@ import Link from 'next/link';
 import { makeStyles } from '@material-ui/core/styles';
 import { AppBar, Toolbar, Button, IconButton } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
+import dynamic from 'next/dynamic';
 
 import Logo from '../Logo';
 import Login from '../Login';
-import ThemeToggleButton from '../ThemeToggleButton';
+
+/**  This will solve the problem of incorrect rendering of theme icon when theme preference is dark
+ * This ensures that the version displayed to user is the client view which ties to the client's preference theme.
+ * This is only an issue on DesktopHeader since on MobileHeader there is a listener triggering rerendering.
+ * */
+const DynamicThemeToggleButton = dynamic(() => import('../ThemeToggleButton'), {
+  ssr: false,
+});
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -73,7 +81,7 @@ export default function DesktopHeader() {
             </Button>
           </Link>
           <Login />
-          <ThemeToggleButton />
+          <DynamicThemeToggleButton />
         </Toolbar>
       </AppBar>
     </>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixed #1776 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Toggle theme icons rendered correctly now especially with dark mode preffered. Try to choose dark mode then refresh the page. Before it would show the `moon` icon, now it correctly show the `sun` icon
![image](https://user-images.githubusercontent.com/55034244/108377956-8e55f180-71d2-11eb-912c-3b35ab067809.png)

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
