### PR TITLE
Fixes #1252, Added Comments for Logger Discussion

### DIFF
--- a/src/backend/feed/processor.js
+++ b/src/backend/feed/processor.js
@@ -207,7 +207,7 @@ module.exports = async function processor(job) {
         }`
       );
     } else {
-      logger.error({ error }, `Unable to process feed ${feed.url}`);
+      logger.debug({ error }, `Unable to process feed ${feed.url}`);
       throw error;
     }
   }

--- a/src/backend/feed/worker.js
+++ b/src/backend/feed/worker.js
@@ -31,9 +31,10 @@ exports.start = async function () {
   try {
     await waitOnReady();
     logger.info('Connected to elasticsearch!');
-
     const concurrency = getFeedWorkersCount();
-    logger.info(`Starting ${concurrency} instance${concurrency > 1 ? 's' : ''} of feed processor.`);
+    logger.debug(
+      `Starting ${concurrency} instance${concurrency > 1 ? 's' : ''} of feed processor.`
+    );
     feedQueue.process(concurrency, path.resolve(__dirname, 'processor.js'));
     return feedQueue;
   } catch (error) {

--- a/src/backend/lib/shutdown.js
+++ b/src/backend/lib/shutdown.js
@@ -11,7 +11,7 @@ async function stopQueue() {
     await feedQueue.close();
     logger.info('Feed queue shut down.');
   } catch (error) {
-    logger.error({ error }, 'Unable to close feed queue gracefully');
+    logger.debug({ error }, 'Unable to close feed queue gracefully');
   }
 }
 
@@ -24,7 +24,7 @@ async function stopWebServer() {
     await serverClose();
     logger.info('Web server shut down.');
   } catch (error) {
-    logger.error({ error }, 'Unable to close web server gracefully');
+    logger.debug({ error }, 'Unable to close web server gracefully');
   }
 }
 
@@ -33,7 +33,7 @@ async function cleanShutdown() {
     await Promise.all([stopQueue(), stopWebServer()]);
     logger.info('Completing shut down.');
   } catch (error) {
-    logger.error({ error }, 'Failed to perform clean shutdown');
+    logger.debug({ error }, 'Failed to perform clean shutdown');
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1252 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
So, I wanted to make this PR to discuss what needs to be changed for the Backend's logger. 
I've done an audit and added comments to the code on what I personally think needs to be changed, and why. 
I would really like some feedback/discussions so that what we change will be useful, and won't omit any data when debugging Telescope.

* `shutdown.js`
[There ](https://github.com/Seneca-CDOT/telescope/blob/c7a532038950ea2d039a8de8682046300b30db10/src/backend/lib/shutdown.js#L18)seems to be a lot of `error` functions being invoked when the service is shutdown. We parse the error into the logger, and mention that the shutdown was not graceful & dirty. Is it possible to move this into debug? 

* `processor.js`
-[Inside](https://github.com/Seneca-CDOT/telescope/blob/c7a532038950ea2d039a8de8682046300b30db10/src/backend/feed/processor.js#L145), we have a lot of warnings being sent to the logger. I think that the `info` calls are appropriate, but should we change the warnings into debug, and return a generic message for production? 

- [On Line 135](https://github.com/Seneca-CDOT/telescope/blob/c7a532038950ea2d039a8de8682046300b30db10/src/backend/feed/processor.js#L135), we send some data into `info` mentioning that a certain feed as been skipped. It might be redundant to print this all the time, as the larger the ignored feed list grows, the more messages this will output. Should we change this into debug?

- [Line 110](https://github.com/Seneca-CDOT/telescope/blob/c7a532038950ea2d039a8de8682046300b30db10/src/backend/feed/processor.js#L110), we only check for an instance of `ArticleError`, to let out service continue. Should we add a debug call to this, for developers to see what type of error is thrown?

These were the log calls that I think should be changed, I'm a little bit iffy on changing any calls within `backend/web`, as they're appropriate (in terms of logging any errors that occur).

I would love to get feedback on what needs to be changed.



## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
