### PR TITLE
adds: initial service architecture for Elastic search service port  

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -84,6 +84,15 @@ IMAGE_PORT=4444
 # Image Service URL
 IMAGE_URL=http://localhost/v1/image
 
+################################################################################
+# Search Service
+################################################################################
+
+# Search Service Port (default is 4445)
+SEARCH_PORT=4445
+
+# Search Service URL
+SEARCH_URL=http://api.telescope.localhost/v1/search
 
 ################################################################################
 # Posts Service

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,34 @@ services:
       - 'traefik.http.middlewares.strip_auth_prefix.stripprefix.forceSlash=true'
       - 'traefik.http.routers.auth.middlewares=strip_auth_prefix'
 
+  search:
+    container_name: 'search'
+    build:
+      context: ../src/api/search
+      dockerfile: Dockerfile
+    environment:
+      - ELASTIC_APM_SERVICE_NAME=search
+      - SEARCH_PORT
+
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTIC_APM_SERVER_URL=http://apm:8200
+    depends_on:
+      - elasticsearch
+      - traefik
+    ports:
+      - ${SEARCH_PORT}
+    labels:
+      # Enable Traefik
+      - 'traefik.enable=true'
+      # Traefik routing for the search service at /v1/search
+      - 'traefik.http.routers.search.rule=PathPrefix(`/${API_VERSION}/search`)'
+      # Specify the search service port
+      - 'traefik.http.services.search.loadbalancer.server.port=${SEARCH_PORT}'
+      # Add middleware to this route to strip the /v1/search prefix
+      - 'traefik.http.middlewares.strip_search_prefix.stripprefix.prefixes=/${API_VERSION}/search'
+      - 'traefik.http.middlewares.strip_search_prefix.stripprefix.forceSlash=true'
+      - 'traefik.http.routers.search.middlewares=strip_search_prefix'
+
   # posts service
   posts:
     container_name: 'posts'
@@ -157,3 +185,22 @@ services:
         hard: -1
     ports:
       - '9200'
+    labels:
+      # Enable Traefik in development mode
+      - 'traefik.enable=true'
+      # Traefik routing for elasticsearch at http://elasticsearch.localhost
+      - 'traefik.http.routers.elasticsearch.rule=Host(`elasticsearch.localhost`)'
+      # Specify the redis port
+      - 'traefik.http.services.elasticsearch.loadbalancer.server.port=9200'
+
+  apm:
+    image: docker.elastic.co/apm/apm-server:7.10.2
+    container_name: 'apm'
+    restart: unless-stopped
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - KIBANA_HOST=http://kibana:5601
+    ports:
+      - '8200'
+    depends_on:
+      - elasticsearch

--- a/src/api/readme.md
+++ b/src/api/readme.md
@@ -41,11 +41,12 @@ npm run services:stop
 
 ## API Lookup Table
 
-| API   | Docker Tag          | URL                       | Description                                       |
-| ----- | ------------------- | ------------------------- | ------------------------------------------------- |
-| posts | telescope_posts_svc | http://localhost/v1/posts | Provides access to cached user posts              |
-| image | telescope_img_svc   | http://localhost/v1/image | Provides a dynamic image processing service       |
-| auth  | telescope_auth_svc  | http://localhost/v1/auth  | Provides authentication and authorization service |
+| API    | Docker Tag           | URL                        | Description                                       |
+| ------ | -------------------- | -------------------------- | ------------------------------------------------- |
+| posts  | telescope_posts_svc  | http://localhost/v1/posts  | Provides access to cached user posts              |
+| image  | telescope_img_svc    | http://localhost/v1/image  | Provides a dynamic image processing service       |
+| auth   | telescope_auth_svc   | http://localhost/v1/auth   | Provides authentication and authorization service |
+| search | telescope_search_svc | http://localhost/v1/search | Provides an ELK query controller service          |
 
 ## Support Services Lookup Table (development only)
 

--- a/src/api/search/Dockerfile
+++ b/src/api/search/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts-alpine as base
+
+# https://snyk.io/blog/10-best-practices-to-containerize-nodejs-web-applications-with-docker/
+RUN apk add dumb-init
+
+# TODO: Add feeding in the port from a .env file
+
+# Force production env, regardless of what we get from .env
+ENV NODE_ENV production
+
+WORKDIR /app
+
+COPY --chown=node:node . .
+
+RUN npm install ci --only=production
+
+USER node
+
+CMD ["dumb-init", "node", "server.js"]

--- a/src/api/search/README.md
+++ b/src/api/search/README.md
@@ -1,0 +1,37 @@
+# Search Service
+
+The Search Service provides a direct querying controller which interfaces with our ELK stack.
+
+## Install
+
+```
+npm install
+```
+
+## Usage
+
+```
+# normal mode
+npm start
+```
+
+By default the server is running on http://localhost:4445/.
+
+### Examples
+
+- `GET /query?text=Telescope&filter=post&page=0` - Returns the search results of posts containing the keyword "Telescope"
+- `GET /query?text=SenecaCDOT?filter=author&page=0` - Returns the search results of authors which relate to the keyword "SenecaCDOT"
+- `GET /healthcheck` - returns `{ "status": "ok" }` if everything is running properly
+
+## Docker / Docker-Compose
+
+### Docker
+
+- To build and tag: `docker build . -t telescope_search_svc:latest`
+- To run locally: `docker run -p 4445:4445 telescope_search_svc:latest`
+
+### Docker-Compose
+
+_Commands to be run from the `~/src/api` directory_
+
+- To build and run: `docker-compose -f docker-compose-api-production.yml up --build search`

--- a/src/api/search/package.json
+++ b/src/api/search/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@senecacdot/search-service",
+  "private": true,
+  "version": "1.0.0",
+  "description": "A service for optimizing images",
+  "scripts": {
+    "dev": "nodemon server.js | pino-pretty -c -t",
+    "start": "node server.js",
+    "test": "jest test.js"
+  },
+  "repository": "Seneca-CDOT/telescope",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/Seneca-CDOT/telescope/issues"
+  },
+  "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
+  "dependencies": {
+    "@elastic/elasticsearch": "^7.11.0",
+    "@elastic/elasticsearch-mock": "^0.3.0",
+    "@senecacdot/satellite": "^1.x",
+    "express-validator": "^6.9.2"
+  },
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "devDependencies": {
+    "del-cli": "^3.0.1",
+    "eslint": "^7.20.0",
+    "jest": "^26.6.3",
+    "nodemon": "^2.0.7",
+    "pino-pretty": "^4.5.0",
+    "supertest": "^6.1.3"
+  }
+}

--- a/src/api/search/server.js
+++ b/src/api/search/server.js
@@ -1,0 +1,9 @@
+const { Satellite } = require('@senecacdot/satellite');
+
+const query = require('./src/routes/query');
+
+const service = new Satellite();
+service.router.use('/query', query);
+
+const port = parseInt(process.env.SEARCH_PORT || 4445, 10);
+service.start(port);

--- a/src/api/search/src/bin/validation.js
+++ b/src/api/search/src/bin/validation.js
@@ -1,0 +1,48 @@
+const { check, validationResult } = require('express-validator');
+
+const queryValidationRules = [
+  // text must be between 1 and 256 and not empty
+  check('text')
+    .exists({ checkFalsy: true })
+    .withMessage('text should not be empty')
+    .bail()
+    .isLength({ max: 256, min: 1 })
+    .withMessage('text should be between 1 to 256 characters')
+    .bail(),
+  // filter must exist and have a valid value
+  check('filter')
+    .exists({ checkFalsy: true })
+    .withMessage('filter should exist')
+    .bail()
+    .isIn(['post', 'author'])
+    .withMessage('invalid filter value')
+    .bail(),
+
+  check('perPage')
+    .optional()
+    .isInt({ min: 1, max: 10 })
+    .withMessage('perPage should be empty or a number between 1 to 10')
+    .bail(),
+
+  check('page')
+    .optional()
+    .isInt({ min: 0, max: 999 })
+    .withMessage('page should be empty or a number between 0 to 999')
+    .bail(),
+];
+
+const validateQuery = (rules) => {
+  return async (req, res, next) => {
+    await Promise.all(rules.map((rule) => rule.run(req)));
+
+    const result = validationResult(req);
+    if (result.isEmpty()) {
+      return next();
+    }
+
+    const errors = result.array();
+    return res.status(400).send(errors);
+  };
+};
+
+module.exports.validateQuery = validateQuery(queryValidationRules);

--- a/src/api/search/src/elastic.js
+++ b/src/api/search/src/elastic.js
@@ -1,14 +1,7 @@
-/*
- * NOTE: This has been ported to ~/src/api/search
- * Future updates will remove the codebase below
- * and point towards `service.docker.localhost` for querying.
- */
-
-const { ELASTIC_URL, ELASTIC_PORT } = process.env;
+const { ELASTICSEARCH_HOSTS } = process.env;
 const { Client } = require('@elastic/elasticsearch');
 const Mock = require('@elastic/elasticsearch-mock');
-const { logger } = require('../utils/logger');
-const parseUrl = require('../utils/url-parser');
+const { logger } = require('@senecacdot/satellite');
 
 function MockClient(options) {
   const mock = new Mock();
@@ -39,10 +32,10 @@ const ElasticConstructor = useMockElastic ? MockClient : Client;
 
 function createElasticClient() {
   try {
-    const elasticUrl = parseUrl(ELASTIC_URL, ELASTIC_PORT) || 'http://localhost:9200';
+    const elasticUrl = ELASTICSEARCH_HOSTS;
     return new ElasticConstructor({ node: elasticUrl });
   } catch (error) {
-    const message = `Unable to parse elastic URL "${ELASTIC_URL}" and/or PORT "${ELASTIC_PORT}"`;
+    const message = `Unable to parse elastic URL:PORT "${ELASTICSEARCH_HOSTS}"`;
     logger.error({ error }, message);
     throw new Error(message);
   }

--- a/src/api/search/src/routes/query.js
+++ b/src/api/search/src/routes/query.js
@@ -1,0 +1,17 @@
+const { Router, logger } = require('@senecacdot/satellite');
+const { validateQuery } = require('../bin/validation');
+const search = require('../search');
+
+const router = Router();
+
+router.get('/', validateQuery, async (req, res) => {
+  try {
+    const { text, filter, page, perPage } = req.query;
+    res.send(await search(text, filter, page, perPage));
+  } catch (error) {
+    res.status(500).send(`There was an error while executing your query: ${error}`);
+    logger.error({ error }, 'Something went wrong with search indexing');
+  }
+});
+
+module.exports = router;

--- a/src/api/search/src/search.js
+++ b/src/api/search/src/search.js
@@ -1,0 +1,79 @@
+const { ELASTIC_MAX_RESULTS_PER_PAGE = 5 } = process.env;
+const { client } = require('./elastic');
+
+const index = 'posts';
+const type = 'post';
+
+/**
+ * Creates fields from filter, now the filter is used for author and post but it will be added more.
+ * the fields will be used for ES
+ * @param {string} filter
+ */
+const createFieldsFromFilter = (filter) => {
+  switch (filter) {
+    case 'author':
+      return ['author'];
+    case 'post':
+    default:
+      return ['text', 'title'];
+  }
+};
+
+const sortFromFilter = (filter) => {
+  switch (filter) {
+    case 'author':
+      return [{ published: { order: 'desc' } }];
+    case 'post':
+    default:
+      return undefined;
+  }
+};
+
+const calculateFrom = (page, perPage) => {
+  const ES_MAX = 10000; // 10K is the upper limit of what ES will return without issue for searches
+  const wanted = page * perPage;
+  // Don't exceed 10K, and if we will, return an offset under it by one page size
+  return wanted + perPage <= ES_MAX ? wanted : ES_MAX - perPage;
+};
+
+/**
+ * Searches text in elasticsearch
+ * @param textToSearch
+ * @param filter
+ * @return all the results matching the passed text
+ */
+const search = async (
+  textToSearch,
+  filter = 'post',
+  page = 0,
+  perPage = ELASTIC_MAX_RESULTS_PER_PAGE
+) => {
+  const query = {
+    query: {
+      simple_query_string: {
+        query: textToSearch,
+        default_operator: 'and',
+        fields: createFieldsFromFilter(filter),
+      },
+    },
+    sort: sortFromFilter(filter),
+  };
+
+  const {
+    body: { hits },
+  } = await client.search({
+    from: calculateFrom(page, perPage),
+    size: perPage,
+    _source: ['id'],
+    index,
+    type,
+    body: query,
+  });
+
+  return {
+    results: hits.total.value,
+    values: hits.hits.map(({ _id }) => ({ id: _id, url: `/posts/${_id}` })),
+  };
+};
+
+module.exports = search;

--- a/src/api/search/test.js
+++ b/src/api/search/test.js
@@ -1,0 +1,118 @@
+const request = require('supertest');
+process.env.ELASTICSEARCH_HOSTS = 'http://elasticsearch:9200';
+
+const app = require('./server');
+
+describe('Testing query route', () => {
+  test('Testing with valid length of characters for text', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post`);
+    expect(res.status).toBe(200);
+  });
+
+  test('Testing with invalid length of characters for text', async () => {
+    // searchTerm is 257 chars long
+    const searchTerm = encodeURIComponent(
+      '8l4XOYWZ3SA9aevIozTcEAng3GOSCAiiDARThEkAFn2F2YtBexA3lcg1O38SGSHILQrrNYReKWOC6RM4ZQQIGqZoLSOLlbbYqlfSkIDM83aeGDYW7KU8OSLbIXUIWIF4TINwrjxi453biwyjgYsJeqFx9ORd0EIw3dMwGPWhoMbvTIxUWXV032qgPRmohLbTf8xnMyttPjIOk3rHBXpukWSnkZiKyBMsUniZZnxYPw7yIhfoaS77jIPRUuiQufDdO'
+    );
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post`);
+    expect(searchTerm.length).toBeGreaterThan(256);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with missing text param', async () => {
+    const res = await request(app).get('/query?filter=post');
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with missing filter param', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with invalid filter', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=test`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with valid post filter', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post`);
+    expect(res.status).toBe(200);
+  });
+
+  test('Testing with valid author filter', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=author`);
+    expect(res.status).toBe(200);
+  });
+
+  test('Testing with empty param values', async () => {
+    const res = await request(app).get(`/query?text=&filter=`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with empty page value', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with invalid page value', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=invalid`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with page above range', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=1000`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with page below range', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=-1`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with valid page in range', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=1`);
+    expect(res.status).toBe(200);
+  });
+
+  test('Testing with empty per page value', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=0&perPage=`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with invalid per page value', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(
+      `/query?text=${searchTerm}&filter=post&page=0&perPage=invalid`
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with per page above range ', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=0&perPage=11`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with per page below range ', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=0&perPage=0`);
+    expect(res.status).toBe(400);
+  });
+
+  test('Testing with valid per page in range ', async () => {
+    const searchTerm = encodeURIComponent('I Love Telescope');
+    const res = await request(app).get(`/query?text=${searchTerm}&filter=post&page=0&perPage=3`);
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Closes #1737

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [X] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Adds support for `search.docker.localhost`, which ports the original ELK query controller to a dedicated service. The following is added as a warning to not work further on the original codebase for querying: 




```javascript
/*
 * NOTE: This has been ported to ~/src/api/search
 * Future updates will remove the codebase below
 * and point towards `service.docker.localhost` for querying.
 */
 ```

![image](https://user-images.githubusercontent.com/14265337/108604961-fc3f1c00-737e-11eb-819e-e8bf54cd8e8f.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
