### PR TITLE
Fix eslint and prettier for repo updates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
   plugins: ['prettier', 'promise', 'react', 'react-hooks'],
   settings: {
     react: {
-      version: '16.13',
+      version: 'detect',
     },
   },
   overrides: [
@@ -51,7 +51,7 @@ module.exports = {
 
     // JavaScript for Node.js
     {
-      files: ['src/backend/**/*.js', 'src/tools/**/*.js', 'src/api/**/*.js'],
+      files: ['src/backend/**/*.js', 'tools/**/*.js', 'src/api/**/*.js'],
       env: {
         node: true,
       },

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,6 @@ package-lock.json
 node_modules/
 coverage/
 certs
-public
 .cache
 .next
 out


### PR DESCRIPTION
We had a few things to clean up in our eslint/prettier configs with the changes after we dropped gatsby:

- change how it gets the react version to `'detect'` from a fixed version number
- fixed the path to the tools/ directory (it's not in src)
- added the public path back, since next uses it as part of the source code (Gatsby didn't)