### PR TITLE
Closes #1705: Add Let's Encrypt to Traefik Microservices router

### DIFF
--- a/src/api/config/certs.yml
+++ b/src/api/config/certs.yml
@@ -1,0 +1,13 @@
+tls:
+  certificates:
+    # The path to certs specified here is just a placeholder.
+    # During production deployment, it should be changed to `/certs/${PATH_TO_CERTS} (from .env)
+    - certFile: /certs/path/to/certs
+      keyFile: /certs/path/to/certs
+  options:
+    default:
+      sniStrict: true
+      minVersion: VersionTLS12
+
+    mintls13:
+      minVersion: VersionTLS13

--- a/src/api/env.production
+++ b/src/api/env.production
@@ -17,6 +17,9 @@ COMPOSE_FILE=docker-compose.yml;production.yml
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=api.telescope.cdot.systems
 
+# Path to certificates
+PATH_TO_CERTS=
+
 # The API Version, used as a prefix on all routes: /v1
 API_VERSION=v1
 

--- a/src/api/env.staging
+++ b/src/api/env.staging
@@ -17,6 +17,9 @@ COMPOSE_FILE=docker-compose.yml;production.yml
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=dev.api.telescope.cdot.systems
 
+# Path to certificates
+PATH_TO_CERTS=
+
 # The API Version, used as a prefix on all routes: /v1
 API_VERSION=v1
 

--- a/src/api/production.yml
+++ b/src/api/production.yml
@@ -18,15 +18,20 @@ services:
       - '--api.insecure=false'
       - '--providers.docker=true'
       - '--providers.docker.exposedbydefault=false'
-      - '--entrypoints.web.address=:80'
-      # TODO: https/ssl setup...
+      - '--providers.file.directory=/config'
+      - '--providers.file.watch=true'
+      - '--entrypoints.web-secure.address=:443'
+      - '--entrypoints.web-secure.http.tls=true'
     ports:
-      - '80:80'
-      - '8080:8080'
+      - '443:443'
     labels:
       - 'traefik.enable=true'
       # GZip compression middleware: gzip_compress
       - 'traefik.http.middlewares.gzip_compress.compress=true'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./config:/config
+      - ${PATH_TO_CERTS}:/certs
 
   # image service
   image:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Closes #1705
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Currently, telescope has a microservice ([certbot](https://github.com/Seneca-CDOT/telescope/blob/9788288925ba547633c219441e8519a41c2a8585/docker-compose-production.yml#L77)) in its `docker-compose-production.yml` that takes care of our SSL certificates. With this PR, `traefik` will have access to those certificates so [`TLS`](https://www.networkworld.com/article/2303073/lan-wan-what-is-transport-layer-security-protocol.html) can be enabled for all the microservices.

**Note**
`Traefik` can generate and renew certificates automatically, but since there are pieces in telescope that are not part of `traefik` and need to have access to the certificates, I thought it'd be better to keep this task outside of the microservices workflow for now. This can be changed in the future.

Also, we'll have to make changes to our autodeployment server to set the certificates' path in a `env` variable. This way, `traefik` and anything outside of `traefik` that needs the certificates will know where to find them. This can be done in a follow-up PR.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
