### PR TITLE
Fixes #1780 - make GitHub Contributor Card styling consistent

### DIFF
--- a/src/web/src/components/GitHubContributorCard.tsx
+++ b/src/web/src/components/GitHubContributorCard.tsx
@@ -8,14 +8,14 @@ function contributionsCount(contributions: number) {
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    backgroundColor: theme.palette.primary.light,
+    backgroundColor: theme.palette.secondary.main,
   },
   typography: {
-    color: theme.palette.primary.contrastText,
+    color: theme.palette.text.primary,
     fontSize: '13px',
   },
   link: {
-    color: theme.palette.primary.contrastText,
+    color: theme.palette.text.primary,
     textDecorationLine: 'underline',
     alignItems: 'flex-start',
   },

--- a/src/web/src/pages/layouts/MDXPageBase.tsx
+++ b/src/web/src/pages/layouts/MDXPageBase.tsx
@@ -17,27 +17,21 @@ type MDXPageBaseProps = {
 };
 
 const useStyles = makeStyles((theme) => {
-  const {
-    palette: {
-      primary: { main },
-    },
-  } = theme;
-
   return {
     root: {
       fontFamily: 'Roboto',
       '& h1': {
-        color: main,
+        color: theme.palette.text.secondary,
         fontSize: 24,
         paddingLeft: '5px',
       },
       '& h2': {
-        color: main,
+        color: theme.palette.text.secondary,
         fontSize: 20,
         paddingLeft: '5px',
       },
       '& p': {
-        color: main,
+        color: theme.palette.text.primary,
         fontSize: 16,
         padding: '3px 5px',
       },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1780 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
After @chrispinkney styled the About page, the colouring of the GitHub Contributor Card changed. 
At the same time, @tonyvugithub pushed a PR that changed the colour palette, so now all the colours are a bit different from what we had in Gatsby #1811. 
There is still a need to fix the styling, so with the new colour palette I propose a new view of the GitHubContributor card:
![image](https://user-images.githubusercontent.com/36719387/109314872-f2278c80-785a-11eb-8652-a6ed4919fa75.png)

Our [online](https://telescope.cdot.systems/about) version: 
![image](https://user-images.githubusercontent.com/36719387/109316526-c3121a80-785c-11eb-8ade-dee8a527d6e8.png)


Also, I had to go to `MDXPageBase.tsx` and change the way the colours were declared for the theme - otherwise, the text in the `GitHubContributorCard` was dark-blue.  MDX sets the rule "p = colour", so it is impossible to control the set the text colour of internal components manually - it is controlled by Parent `MDX` component. 

**So I also changed the text colour of about page from dark-blue to black - the headers are still dark-blue though.**

Feel free to comment or propose any changes, I will be happy to make any changes if needed. 
## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
