### PR TITLE
Fixes #1795 - added trailing slash to next.config.js

### DIFF
--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -27,4 +27,5 @@ module.exports = withMDX({
   pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
   poweredByHeader: false,
   reactStrictMode: true,
+  trailingSlash: true,
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1795 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
First of all, the problem was not in NGINX. 
The bug can be explained in the following way: 
When we did a request to `/search` and  `/about`, NGINX was not able to find those, because in the static (built) version of the frontend that NGINX had we had `/search.js` and `/about.js`, not `/search/index.js` and `/about/index.js`. 
So NGINX was following this instruction: `try_files $uri $uri/ @proxy;` and, after not being able to find the needed pages, sent the request to the Backend. The Backend replied with an error handler, and because the Next.js app was not running (nobody started it yet) - the `/error` page request went back to Backend, and again, and again, and again.

What I and @humphd and @manekenpix did to fix this is: we changed the way Next.js built a static version of the Frontend, so now each of the pages is stored in the following format: `/search/index.js`. 

[Documentation for trailingSlash: true](https://nextjs.org/docs/api-reference/next.config.js/exportPathMap#adding-a-trailing-slash)

## Testing 
1. Build a version of the frontend by going to `/src/web` and running `npm run build`,
2. Start an http server on `/out` with `npx http-server out`,
3. Go to `localhost:8080/search` - you should receive a 404 error.

After pulling this branch and completing the same steps you will not receive an error.

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
