### PR TITLE
Change MUI typography font to Spartan

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -8,7 +8,6 @@
     "start": "next start -p 8000"
   },
   "dependencies": {
-    "@fontsource/roboto": "^4.2.1",
     "@fontsource/spartan": "^4.2.1",
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
@@ -21,8 +20,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-material-ui-form-validator": "^2.1.4",
-    "swr": "^0.4.2",
     "react-use": "^17.1.1",
+    "swr": "^0.4.2",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {

--- a/src/web/src/components/Banner.tsx
+++ b/src/web/src/components/Banner.tsx
@@ -10,7 +10,6 @@ const useStyles = makeStyles((theme: Theme) =>
     h1: {
       position: 'absolute',
       color: theme.palette.primary.contrastText,
-      fontFamily: 'Roboto',
       fontWeight: 'bold',
       fontSize: '12rem',
       display: 'block',
@@ -36,7 +35,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     version: {
       position: 'absolute',
-      fontFamily: 'Roboto',
       opacity: 0.85,
       bottom: theme.spacing(6),
       left: theme.spacing(8),

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -12,7 +12,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   stats: {
     position: 'absolute',
     color: theme.palette.primary.contrastText,
-    fontFamily: 'Roboto',
     fontSize: '0.875rem',
     display: 'block',
     bottom: theme.spacing(12),

--- a/src/web/src/components/Posts/index.tsx
+++ b/src/web/src/components/Posts/index.tsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles((theme) =>
     },
     error: {
       color: '#B5B5B5',
-      fontFamily: 'Roboto',
       fontSize: '5rem',
       paddingBottom: '30px',
     },

--- a/src/web/src/pages/_app.tsx
+++ b/src/web/src/pages/_app.tsx
@@ -4,14 +4,13 @@ import { ThemeProvider } from '@material-ui/core/styles';
 
 import Header from '../components/Header';
 import UserProvider from '../components/UserProvider';
-import '@fontsource/roboto';
-import '@fontsource/spartan';
 
 import { darkTheme, lightTheme } from '../theme';
 import usePreferredTheme from '../hooks/use-preferred-theme';
 import { ThemeContext } from '../components/ThemeProvider';
 
 import '../styles/globals.css';
+import '@fontsource/spartan';
 
 // Reference: https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_app.js
 const App = ({ Component, pageProps }: AppProps) => {

--- a/src/web/src/pages/error.tsx
+++ b/src/web/src/pages/error.tsx
@@ -13,7 +13,6 @@ const useStyles = makeStyles((theme) => ({
     top: '45vh',
   },
   root: {
-    fontFamily: 'Roboto',
     zIndex: 100,
     padding: theme.spacing(2, 4, 2, 4),
     position: 'relative',
@@ -65,7 +64,6 @@ const useStyles = makeStyles((theme) => ({
   },
   link: {
     color: 'white',
-    fontFamily: 'Roboto, sans-serif',
     textDecoration: 'none',
     fontSize: '1.5rem',
     margin: '0 0.5rem 0 0.5rem',

--- a/src/web/src/pages/layouts/MDXPageBase.tsx
+++ b/src/web/src/pages/layouts/MDXPageBase.tsx
@@ -19,7 +19,7 @@ type MDXPageBaseProps = {
 const useStyles = makeStyles((theme) => {
   return {
     root: {
-      fontFamily: 'Roboto',
+      fontFamily: 'Spartan',
       '& h1': {
         color: theme.palette.text.secondary,
         fontSize: 24,

--- a/src/web/src/styles/telescope-post-content.css
+++ b/src/web/src/styles/telescope-post-content.css
@@ -5,8 +5,7 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   hyphens: auto;
-  font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica,
-    Ubuntu, Roboto, noto, segoe ui, arial, sans-serif;
+  font-family: Spartan, sans-serif;
 }
 
 .telescope-post-content p {

--- a/src/web/src/theme/index.ts
+++ b/src/web/src/theme/index.ts
@@ -1,7 +1,14 @@
 import { red } from '@material-ui/core/colors';
 import createMuiTheme, { Theme } from '@material-ui/core/styles/createMuiTheme';
 
+const commonThemeProps = {
+  typography: {
+    fontFamily: 'Spartan',
+  },
+};
+
 export const lightTheme: Theme = createMuiTheme({
+  ...commonThemeProps,
   palette: {
     type: 'light',
     primary: {
@@ -24,6 +31,7 @@ export const lightTheme: Theme = createMuiTheme({
 });
 
 export const darkTheme: Theme = createMuiTheme({
+  ...commonThemeProps,
   palette: {
     type: 'dark',
     primary: {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixed #1856 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
In this PR, I have updated the theme object so everything using MUI component will have Spartan font styling now. I have also removed `@fontsource/roboto` packages as i don't think we need it anymore after this merged. The rest of the changes are simply remove `fontFamily: 'Roboto'` on all components. 

<!-- Please add a detailed description of what this PR does and why it is needed --> 

## Checklist
![image](https://user-images.githubusercontent.com/55034244/109813034-c9a4e700-7bfa-11eb-87f0-c97ba4dfc808.png)
![image](https://user-images.githubusercontent.com/55034244/109813110-e6d9b580-7bfa-11eb-8bdb-38547746b678.png)

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
