### PR TITLE
Added Dependabot config for Docker, GitHub Actions, and more npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
       # Use Eastern Standard Time (UTC -05:00)
       timezone: 'America/Toronto'
     open-pull-requests-limit: 1
@@ -22,11 +23,13 @@ updates:
     # Disable automatic rebasing
     rebase-strategy: 'disabled'
 
-  # Next Front-End
+  # Next Front-End package.json
   - package-ecosystem: 'npm'
     directory: '/src/web'
     schedule:
       interval: 'weekly'
+      day: 'tuesday'
+      time: '04:00'
       timezone: 'America/Toronto'
     open-pull-requests-limit: 1
     commit-message:
@@ -38,11 +41,13 @@ updates:
       - 'area: nextjs'
     rebase-strategy: 'disabled'
 
-  # Auto-deployment Server
+  # Auto-deployment Server package.json
   - package-ecosystem: 'npm'
     directory: '/tools/autodeployment'
     schedule:
       interval: 'weekly'
+      day: 'tuesday'
+      time: '06:00'
       timezone: 'America/Toronto'
     open-pull-requests-limit: 1
     commit-message:
@@ -52,4 +57,108 @@ updates:
     labels:
       - 'dependencies'
       - 'area: autodeployment'
+    rebase-strategy: 'disabled'
+
+  # Auth Service package.json
+  - package-ecosystem: 'npm'
+    directory: '/src/api/auth'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: microservices'
+    rebase-strategy: 'disabled'
+
+  # Image Service package.json
+  - package-ecosystem: 'npm'
+    directory: '/src/api/image'
+    schedule:
+      interval: 'weekly'
+      day: 'thursday'
+      time: '04:00'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: microservices'
+    rebase-strategy: 'disabled'
+
+  # Root Dockerfile
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'thursday'
+      time: '06:00'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: docker'
+    rebase-strategy: 'disabled'
+
+  # Auth Service Dockerfile
+  - package-ecosystem: 'docker'
+    directory: '/src/api/auth'
+    schedule:
+      interval: 'weekly'
+      day: 'friday'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: docker'
+    rebase-strategy: 'disabled'
+
+  # Image Service Dockerfile
+  - package-ecosystem: 'docker'
+    directory: '/src/api/image'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: docker'
+    rebase-strategy: 'disabled'
+
+  # GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+      timezone: 'America/Toronto'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore: '
+    reviewers:
+      - 'Seneca-CDOT/telescope-maintainers'
+    labels:
+      - 'dependencies'
+      - 'area: CI/CD'
     rebase-strategy: 'disabled'


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1799
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Added Dependabot configurations for Dockerfiles, GitHub Actions, and more package.json files in our repository. Tested on my forked repository, you can see that all of them appeared under https://github.com/birtony/telescope/network/updates
![image](https://user-images.githubusercontent.com/33902374/110174056-83ec4800-7dcd-11eb-8f1b-c7498cd283ea.png)

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Warning
Even though this PR limits each package ecosystem to only 1 open PR at a time and sets Dependabot to make checks on each once a week, it can potentially lead to Dependabot creating 9 PRs at once. Although with automatic rebases turned off, that would mean 9 CI runs/preview deployments, I am not sure if it can exhaust any quotas of ours. I am also not sure if we can limit Dependabot in any other way unless we switch to using npm workspaces (#1778). @humphd, please, advise. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
