### PR TITLE
Fixes #1791: Handling with inline img

### DIFF
--- a/src/web/src/styles/telescope-post-content.css
+++ b/src/web/src/styles/telescope-post-content.css
@@ -16,11 +16,33 @@
   margin-left: auto;
   margin-right: auto;
   max-width: 100%;
+  max-height: 80vh;
   padding-top: 1.5rem;
   padding-bottom: 1rem;
   display: block;
   height: auto;
 }
+
+.telescope-post-content div > a > img {
+  width: 32px;
+  display: inline;
+  vertical-align: middle;
+}
+
+.telescope-post-content h1 > a > img {
+  width: 32px;
+  display: inline;
+  vertical-align: middle;
+}
+
+.telescope-post-content div > div {
+  display: inline;
+}
+
+.telescope-post-content div > h1 {
+  font-size: 1.8rem;
+}
+
 .telescope-post-content figure {
   display: block;
   margin: 0;


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #1791
Fixes #1412

## Type of Change
- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
I piggy-backed off of @huynguyez 's solution that he posted in issue #1791 ([see here](https://github.com/Seneca-CDOT/telescope/issues/1791#issuecomment-784429056)) and just added an extra line `vertical-align:50%;` to center the inline images.

| Before |
| :---: | 
| ![Capture4](https://user-images.githubusercontent.com/48869737/110953539-7aa33400-8315-11eb-85ca-e2329e484127.PNG) |

| After | 
| :---: |
| ![Capture3](https://user-images.githubusercontent.com/48869737/110953642-9c9cb680-8315-11eb-9a46-9430ff14805b.PNG) |

## Checklist
- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
