### PR TITLE
Fix issue #1855: add temporary avatar

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -14,6 +14,7 @@ import { Post } from '../../interfaces';
 import AdminButtons from '../AdminButtons';
 import Spinner from '../Spinner';
 import PostDesktopInfo from './PostInfo';
+import PostAvatar from './PostAvatar';
 
 type Props = {
   postUrl: string;
@@ -258,7 +259,7 @@ const PostComponent = ({ postUrl }: Props) => {
         {!desktop && (
           <>
             <div className={classes.authorAvatarContainer}>
-              <div className={classes.circle} />
+              <PostAvatar name={post.feed.author} />
             </div>
             <div className={classes.authorNameContainer}>
               <h1 className={classes.author}>

--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -1,0 +1,50 @@
+import { createStyles, Theme, Avatar } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+type AvatarProps = {
+  name: String;
+  img?: String;
+};
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    circle: {
+      marginLeft: '0.5rem',
+      color: '#e5e5e5',
+      backgroundColor: '#121D59',
+      fontSize: '2.5rem',
+      width: '3em',
+      height: '3em',
+      [theme.breakpoints.down(1200)]: {
+        fontSize: '2em',
+        width: '2.5em',
+        height: '2.5em',
+      },
+    },
+  })
+);
+
+const PostAvatar = ({ name, img }: AvatarProps) => {
+  const classes = useStyles();
+
+  if (img) {
+    return <Avatar src="img" />;
+  }
+
+  if (name) {
+    const nameArr = name.split(' ');
+    let initials;
+    if (nameArr.length >= 2) {
+      const firstName = nameArr[0].substring(0, 1).toUpperCase();
+      const lastName = nameArr[nameArr.length - 1].substring(0, 1).toUpperCase();
+      initials = firstName + lastName;
+    } else if (nameArr.length === 1) {
+      initials = nameArr[0].substring(0, 1).toUpperCase();
+    }
+    return <Avatar className={classes.circle}>{initials}</Avatar>;
+  }
+
+  return <Avatar />;
+};
+
+export default PostAvatar;

--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -2,8 +2,8 @@ import { createStyles, Theme, Avatar } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 type AvatarProps = {
-  name: String;
-  img?: String;
+  name: string;
+  img?: string;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -28,12 +28,16 @@ const PostAvatar = ({ name, img }: AvatarProps) => {
   const classes = useStyles();
 
   if (img) {
-    return <Avatar className={classes.avatar} src="img" />;
+    return <Avatar className={classes.avatar} src={img} />;
   }
 
   if (name.length > 0) {
     const initials = name
       .split(' ')
+      // splitName represents the current value, i represents its index, and arr represent the whole splitted name-word array
+      // if the index is 0, means it's the first word in the name
+      // if the index+1 equals to the array length, it means the current value is the last word in the name
+      // anything rather than first word or last word will not be included in initials
       .map((splitName, i, arr) =>
         i === 0 || i + 1 === arr.length ? splitName[0].toUpperCase() : null
       )

--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -8,7 +8,7 @@ type AvatarProps = {
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    circle: {
+    avatar: {
       marginLeft: '0.5rem',
       color: '#e5e5e5',
       backgroundColor: '#121D59',
@@ -28,7 +28,7 @@ const PostAvatar = ({ name, img }: AvatarProps) => {
   const classes = useStyles();
 
   if (img) {
-    return <Avatar src="img" />;
+    return <Avatar className={classes.avatar} src="img" />;
   }
 
   if (name) {
@@ -41,10 +41,10 @@ const PostAvatar = ({ name, img }: AvatarProps) => {
     } else if (nameArr.length === 1) {
       initials = nameArr[0].substring(0, 1).toUpperCase();
     }
-    return <Avatar className={classes.circle}>{initials}</Avatar>;
+    return <Avatar className={classes.avatar}>{initials}</Avatar>;
   }
 
-  return <Avatar />;
+  return <Avatar className={classes.avatar} />;
 };
 
 export default PostAvatar;

--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -34,7 +34,9 @@ const PostAvatar = ({ name, img }: AvatarProps) => {
   if (name.length > 0) {
     const initials = name
       .split(' ')
-      .map((splitName, i, arr) => (i === 0 || i + 1 === arr.length ? splitName[0] : null))
+      .map((splitName, i, arr) =>
+        i === 0 || i + 1 === arr.length ? splitName[0].toUpperCase() : null
+      )
       .join('');
     return <Avatar className={classes.avatar}>{initials}</Avatar>;
   }

--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -31,16 +31,11 @@ const PostAvatar = ({ name, img }: AvatarProps) => {
     return <Avatar className={classes.avatar} src="img" />;
   }
 
-  if (name) {
-    const nameArr = name.split(' ');
-    let initials;
-    if (nameArr.length >= 2) {
-      const firstName = nameArr[0].substring(0, 1).toUpperCase();
-      const lastName = nameArr[nameArr.length - 1].substring(0, 1).toUpperCase();
-      initials = firstName + lastName;
-    } else if (nameArr.length === 1) {
-      initials = nameArr[0].substring(0, 1).toUpperCase();
-    }
+  if (name.length > 0) {
+    const initials = name
+      .split(' ')
+      .map((splitName, i, arr) => (i === 0 || i + 1 === arr.length ? splitName[0] : null))
+      .join('');
     return <Avatar className={classes.avatar}>{initials}</Avatar>;
   }
 

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -1,4 +1,5 @@
 import { createStyles, ListSubheader, makeStyles, Theme } from '@material-ui/core';
+import PostAvatar from './PostAvatar';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -68,7 +69,7 @@ const PostDesktopInfo = ({ authorName, postDate, blogUrl, postUrl }: Props) => {
   return (
     <ListSubheader className={classes.root}>
       <div className={classes.authorAvatarContainer}>
-        <div className={classes.circle} />
+        <PostAvatar name={authorName} />
       </div>
       <div className={classes.authorNameContainer}>
         <h1 className={classes.author}>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Before GitHub integration or till we get the image from author, we need a temporary avatar to replace the current blank circle.
Fixes: #1855 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

This `PostAvatar` component takes name or img source (currently, I set img to optional because we don't have any image to pass). Ideally, if the img source is provided, it should display the image; if the img is not provided and the name is provided, it'll generate initials as an avatar.

#### Desktop
![Screen Shot 2021-03-12 at 10 52 08](https://user-images.githubusercontent.com/50813726/110966690-872e8900-8323-11eb-98fe-0494a90b2625.png)
#### Mobile
![Screenshot_2021-03-12 Telescope](https://user-images.githubusercontent.com/50813726/110966692-885fb600-8323-11eb-958b-dc185f182f1f.png)

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
