### PR TITLE
Use POSTS_PORT vs. IMAGE_PORT in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       # Traefik routing for the image service at /v1/image
       - 'traefik.http.routers.posts.rule=Host(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/posts`)'
       # Specify the posts service port
-      - 'traefik.http.services.posts.loadbalancer.server.port=${IMAGE_PORT}'
+      - 'traefik.http.services.posts.loadbalancer.server.port=${POSTS_PORT}'
       # Add middleware to this route to strip the /v1/posts prefix
       - 'traefik.http.middlewares.strip_posts_prefix.stripprefix.prefixes=/${API_VERSION}/posts'
       - 'traefik.http.middlewares.strip_posts_prefix.stripprefix.forceSlash=true'


### PR DESCRIPTION
Typo in how we are defining the port for Traefik for the POSTS service (cc @HyperTHD).