### PR TITLE
Fix: expose ports in development

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -69,3 +69,11 @@ services:
       - 'traefik.http.routers.firebase_ui.rule=Host(`ui.firebase.localhost`)'
       - 'traefik.http.routers.firebase_ui.service=firebase_ui'
       - 'traefik.http.services.firebase_ui.loadbalancer.server.port=4000'
+
+  redis:
+    ports:
+      - '6379:6379'
+
+  elasticsearch:
+    ports:
+      - '9200:9200'


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR exposes `Redis`' and `Elasticsearch`'s ports in development (we removed this in #1706)

For testing, simply start docker in development mode:
- `docker-compose --env-file config/env.development up --build`
or
- `npm run services:start`

and then run Telescope: `npm start`.

Telescope should be able to find `redis` and `elasticsearch`.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
