### PR TITLE
Fix #1943: Remove Docker localhost.* DNS for Windows development

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -14,11 +14,11 @@ COMPOSE_FILE=docker/docker-compose.yml;docker/development.yml
 
 
 # The host where the Telescope 1.0 front-end and back-end are run.
-TELESCOPE_HOST=telescope.localhost
+TELESCOPE_HOST=http://localhost:3000
 
-# The host where all the microservices run (e.g., http://api.telescope.localhost)
+# The host where all the microservices run (e.g., http://localhost)
 # NOTE: if you change this, change all other occurrences below too.
-API_HOST=api.telescope.localhost
+API_HOST=http://localhost
 
 # The API Version, used as a prefix on all routes: /v1
 API_VERSION=v1
@@ -28,30 +28,30 @@ API_VERSION=v1
 # Auth Service
 ################################################################################
 
-# Image Service Port (default is 4444)
+# Auth Service Port (default is 4444)
 AUTH_PORT=7777
 
 # Auth Service URL
-AUTH_URL=http://api.telescope.localhost/v1/auth
+AUTH_URL=http://localhost/v1/auth
 
 # The Single Sign On (SSO) login service URL
-SSO_LOGIN_URL=http://login.localhost/simplesaml/saml2/idp/SSOService.php
+SSO_LOGIN_URL=http://localhost:8081/simplesaml/saml2/idp/SSOService.php
 
 # The callback URL endpoint to be used by the SSO login service (see the /auth route)
-SSO_LOGIN_CALLBACK_URL=http://api.telescope.localhost/v1/auth/login/callback
+SSO_LOGIN_CALLBACK_URL=http://localhost/v1/auth/login/callback
 
 # The Single Logout (SLO) service URL
-SLO_LOGOUT_URL=http://login.localhost/simplesaml/saml2/idp/SingleLogoutService.php
+SLO_LOGOUT_URL=http://localhost:8081/simplesaml/saml2/idp/SingleLogoutService.php
 
 # The callback URL endpoint to be used by the SLO logout service (see the /auth route)
-SLO_LOGOUT_CALLBACK_URL=http://api.telescope.localhost/v1/auth/logout/callback
+SLO_LOGOUT_CALLBACK_URL=http://localhost/v1/auth/logout/callback
 
 # The SSO Identity Provider's public key certificate. NOTE: this is the public
 # key cert of the test login IdP docker container.  Update for staging and prod.
 SSO_IDP_PUBLIC_KEY_CERT=MIIDXTCCAkWgAwIBAgIJALmVVuDWu4NYMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMjMxMTQzNDQ3WhcNNDgwNjI1MTQzNDQ3WjBFMQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzUCFozgNb1h1M0jzNRSCjhOBnR+uVbVpaWfXYIR+AhWDdEe5ryY+CgavOg8bfLybyzFdehlYdDRgkedEB/GjG8aJw06l0qF4jDOAw0kEygWCu2mcH7XOxRt+YAH3TVHa/Hu1W3WjzkobqqqLQ8gkKWWM27fOgAZ6GieaJBN6VBSMMcPey3HWLBmc+TYJmv1dbaO2jHhKh8pfKw0W12VM8P1PIO8gv4Phu/uuJYieBWKixBEyy0lHjyixYFCR12xdh4CA47q958ZRGnnDUGFVE1QhgRacJCOZ9bd5t9mr8KLaVBYTCJo5ERE8jymab5dPqe5qKfJsCZiqWglbjUo9twIDAQABo1AwTjAdBgNVHQ4EFgQUxpuwcs/CYQOyui+r1G+3KxBNhxkwHwYDVR0jBBgwFoAUxpuwcs/CYQOyui+r1G+3KxBNhxkwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAAiWUKs/2x/viNCKi3Y6blEuCtAGhzOOZ9EjrvJ8+COH3Rag3tVBWrcBZ3/uhhPq5gy9lqw4OkvEws99/5jFsX1FJ6MKBgqfuy7yh5s1YfM0ANHYczMmYpZeAcQf2CGAaVfwTTfSlzNLsF2lW/ly7yapFzlYSJLGoVE+OHEu8g5SlNACUEfkXw+5Eghh+KzlIN7R6Q7r2ixWNFBC/jWf7NKUfJyX8qIG5md1YUeT6GBW9Bm2/1/RiO24JTaYlfLdKK9TYb8sG5B+OLab2DImG99CJ25RkAcSobWNF5zD0O6lgOo3cEdB/ksCq3hmtlC/DlLZ/D8CJ+7VuZnS1rR2naQ==
 
 # Our apps's Entity ID, which is also the URL to our metadata.
-SAML_ENTITY_ID=http://api.telescope.localhost/v1/auth/sp
+SAML_ENTITY_ID=http://localhost/v1/auth/sp
 
 # SECRET = cookie session SECRET. If left empty, one will be set automatically
 SECRET=secret-sauce
@@ -65,10 +65,10 @@ ADMINISTRATORS=user1@example.com
 ALLOWED_APP_ORIGINS=http://localhost:8000 http://localhost:8888
 
 # The URI of the auth server
-JWT_ISSUER=http://api.telescope.localhost/v1/auth
+JWT_ISSUER=http://localhost/v1/auth
 
 # The microservices origin
-JWT_AUDIENCE=http://api.telescope.localhost
+JWT_AUDIENCE=http://localhost
 
 # How long should a JWT work before it expires
 JWT_EXPIRES_IN=1h
@@ -82,7 +82,7 @@ JWT_EXPIRES_IN=1h
 IMAGE_PORT=4444
 
 # Image Service URL
-IMAGE_URL=http://api.telescope.localhost/v1/image
+IMAGE_URL=http://localhost/v1/image
 
 
 ################################################################################
@@ -93,7 +93,7 @@ IMAGE_URL=http://api.telescope.localhost/v1/image
 POSTS_PORT=5555
 
 # Posts Service URL
-POSTS_URL=http://api.telescope.localhost/v1/posts
+POSTS_URL=http://localhost/v1/posts
 
 # Redis Mock info
 MOCK_REDIS=
@@ -107,7 +107,7 @@ MOCK_REDIS=
 FEED_DISCOVERY_PORT=7777
 
 # Feed Discovery Service URL
-FEED_DISCOVERY_URL=http://api.telescope.localhost/v1/feed-discovery
+FEED_DISCOVERY_URL=http://localhost/v1/feed-discovery
 
 
 ################################################################################

--- a/docker/development.yml
+++ b/docker/development.yml
@@ -24,14 +24,12 @@ services:
       - '8080:8080'
 
   # SSO Identity Provider test service, https://simplesamlphp.org
-  # Access to the login page available at http://login.localhost/simplesaml
+  # Access to the login page available at http://localhost:8081
   login:
     image: kristophjunge/test-saml-idp
     container_name: 'login'
     ports:
-      - '8080'
-    depends_on:
-      - traefik
+      - '8081:8080'
     environment:
       - SIMPLESAMLPHP_SP_ENTITY_ID=${SAML_ENTITY_ID}
       - SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE=${SSO_LOGIN_CALLBACK_URL}
@@ -39,13 +37,6 @@ services:
     volumes:
       - ../config/simplesamlphp-users.php:/var/www/simplesamlphp/config/authsources.php
       - ../config/saml20-idp-hosted.php:/var/www/simplesamlphp/metadata/saml20-idp-hosted.php
-    labels:
-      # Enable Traefik
-      - 'traefik.enable=true'
-      # Traefik routing for login at http://login.localhost/simplesaml
-      - 'traefik.http.routers.login.rule=Host(`login.localhost`)'
-      # Specify the login port
-      - 'traefik.http.services.login.loadbalancer.server.port=8080'
 
   # Firebase Emulator for offline testing
   firebase:
@@ -57,18 +48,9 @@ services:
     command: firebase emulators:start --project telescope --only firestore
     ports:
       # Emulator Suite UI
-      - '4000'
-      # Cloud Firestore. NOTE: web UI and Firebase testing needs to access this via localhost:8088
+      - '4000:4000'
+      # Cloud Firestore
       - '8088:8088'
-    depends_on:
-      - traefik
-    labels:
-      # Enable Traefik on the firebase container
-      - 'traefik.enable=true'
-      # Traefik routing for the firebase UI at http://ui.firebase.localhost
-      - 'traefik.http.routers.firebase_ui.rule=Host(`ui.firebase.localhost`)'
-      - 'traefik.http.routers.firebase_ui.service=firebase_ui'
-      - 'traefik.http.services.firebase_ui.loadbalancer.server.port=4000'
 
   redis:
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the image service at /v1/image
-      - 'traefik.http.routers.image.rule=Host(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/image`)'
+      - 'traefik.http.routers.image.rule=PathPrefix(`/${API_VERSION}/image`)'
       # Specify the image service port
       - 'traefik.http.services.image.loadbalancer.server.port=${IMAGE_PORT}'
       # Add middleware to this route to strip the /v1/image prefix
@@ -60,7 +60,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the auth service at /v1/auth
-      - 'traefik.http.routers.auth.rule=Host(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/auth`)'
+      - 'traefik.http.routers.auth.rule=PathPrefix(`/${API_VERSION}/auth`)'
       # Specify the auth service port
       - 'traefik.http.services.auth.loadbalancer.server.port=${AUTH_PORT}'
       # Add middleware to this route to strip the /v1/auth prefix
@@ -85,7 +85,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the image service at /v1/image
-      - 'traefik.http.routers.posts.rule=Host(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/posts`)'
+      - 'traefik.http.routers.posts.rule=PathPrefix(`/${API_VERSION}/posts`)'
       # Specify the posts service port
       - 'traefik.http.services.posts.loadbalancer.server.port=${POSTS_PORT}'
       # Add middleware to this route to strip the /v1/posts prefix
@@ -109,13 +109,13 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the feed discovery service at /v1/image
-      - 'traefik.http.routers.feed-discovery.rule=Host(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/feed-discovery`)'
+      - 'traefik.http.routers.feed-discovery.rule=PathPrefix(`/${API_VERSION}/feed-discovery`)'
       # Specify the feed discovery service port
       - 'traefik.http.services.feed-discovery.loadbalancer.server.port=${FEED_DISCOVERY_PORT}'
       # Add middleware to this route to strip the /v1/feed-discovery prefix
       - 'traefik.http.middlewares.strip_feed_discovery_prefix.stripprefix.prefixes=/${API_VERSION}/feed-discovery'
       - 'traefik.http.middlewares.strip_feed_discovery_prefix.stripprefix.forceSlash=true'
-      - 'traefik.http.routers.feed_discovery.middlewares=strip_feed_discovery_prefix'
+      - 'traefik.http.routers.feed-discovery.middlewares=strip_feed_discovery_prefix'
 
   ##############################################################################
   # Third-Party Dependencies and Support Services
@@ -157,10 +157,3 @@ services:
         hard: -1
     ports:
       - '9200'
-    labels:
-      # Enable Traefik in development mode
-      - 'traefik.enable=true'
-      # Traefik routing for elasticsearch at http://elasticsearch.localhost
-      - 'traefik.http.routers.elasticsearch.rule=Host(`elasticsearch.localhost`)'
-      # Specify the redis port
-      - 'traefik.http.services.elasticsearch.loadbalancer.server.port=9200'

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -48,18 +48,4 @@ docker-compose -f docker-compose.yml up --build login redis telescope
 
 ### Running the Microservices
 
-For your convenience, you can use the following `npm` scripts:
-
-```
-# start the microservices containers and gateway in development
-npm run api:start
-
-# stop the containers
-npm run api:stop
-```
-
-The services will now be available via the defined routes:
-
-| Service                  | URL                                  |
-| ------------------------ | ------------------------------------ |
-| Background Image Service | http://image.docker.localhost/image/ |
+See the [docs for running the services](src/api/readme.md).

--- a/src/api/auth/src/routes.js
+++ b/src/api/auth/src/routes.js
@@ -200,7 +200,7 @@ router.get('/authorize', passport.authenticate('jwt', { session: false }), (req,
 
 /**
  * Provide SAML Metadata endpoint for our Service Provider's Entity ID.
- * The naming is {host}/sp, for example: http://auth.docker.localhost/sp
+ * The naming is {host}/sp, for example: http://localhost/v1/auth/sp
  */
 router.get('/sp', (req, res) => {
   res.type('application/xml');

--- a/src/api/auth/test/e2e/auth-flows.test.js
+++ b/src/api/auth/test/e2e/auth-flows.test.js
@@ -90,7 +90,7 @@ it('should use the same origin in .env for ALLOWED_APP_ORIGINS that test cases u
 
 it('should use the same AUTH_URL as we have hard-coded in the test HTML', () => {
   // NOTE: if this fails, make sure your src/api/.env has the same info as ./index.html
-  expect(AUTH_URL).toEqual('http://api.telescope.localhost/v1/auth');
+  expect(AUTH_URL).toEqual('http://localhost/v1/auth');
 });
 
 describe('Login', () => {

--- a/src/api/auth/test/e2e/index.html
+++ b/src/api/auth/test/e2e/index.html
@@ -6,12 +6,12 @@
   </head>
   <body>
     <a
-      href="http://api.telescope.localhost/v1/auth/login?redirect_uri=http://localhost:8888/&state=abc123"
+      href="http://localhost/v1/auth/login?redirect_uri=http://localhost:8888/&state=abc123"
       id="login"
       >Login</a
     >
     <a
-      href="http://api.telescope.localhost/v1/auth/logout?redirect_uri=http://localhost:8888/&state=abc123"
+      href="http://localhost/v1/auth/logout?redirect_uri=http://localhost:8888/&state=abc123"
       id="logout"
       >Logout</a
     >

--- a/src/api/auth/test/manual/script.js
+++ b/src/api/auth/test/manual/script.js
@@ -6,7 +6,7 @@ import { nanoid } from 'https://cdn.jsdelivr.net/npm/nanoid/nanoid.js';
 import jwtDecode from 'https://cdn.jsdelivr.net/npm/jwt-decode@3.1.2/build/jwt-decode.esm.js';
 
 // Use same URL as your .env
-const authServer = 'http://api.telescope.localhost/v1/auth';
+const authServer = 'http://localhost/v1/auth';
 
 function printToken(token) {
   const jwtElem = document.querySelector('#jwt');

--- a/src/api/readme.md
+++ b/src/api/readme.md
@@ -41,22 +41,22 @@ npm run services:stop
 
 ## API Lookup Table
 
-| API   | Docker Tag          | URL                                     | Description                                       |
-| ----- | ------------------- | --------------------------------------- | ------------------------------------------------- |
-| posts | telescope_posts_svc | http://api.telescope.localhost/v1/posts | Provides access to cached user posts              |
-| image | telescope_img_svc   | http://api.telescope.localhost/v1/image | Provides a dynamic image processing service       |
-| auth  | telescope_auth_svc  | http://api.telescope.localhost/v1/auth  | Provides authentication and authorization service |
+| API   | Docker Tag          | URL                       | Description                                       |
+| ----- | ------------------- | ------------------------- | ------------------------------------------------- |
+| posts | telescope_posts_svc | http://localhost/v1/posts | Provides access to cached user posts              |
+| image | telescope_img_svc   | http://localhost/v1/image | Provides a dynamic image processing service       |
+| auth  | telescope_auth_svc  | http://localhost/v1/auth  | Provides authentication and authorization service |
 
 ## Support Services Lookup Table (development only)
 
-| API                | URL                                                   | Description                                                               |
-| ------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------- |
-| Traefik Dashboard  | http://localhost:8080                                 | [Traefik Dashboard](https://doc.traefik.io/traefik/operations/dashboard/) |
-| Redis              | redis://localhost:6379                                | Redis server                                                              |
-| Elasticsearch      | http://elasticsearch.localhost, http://localhost:9200 | Elasticserach                                                             |
-| Firebase UI        | http://ui.firebase.localhost                          | UI Dashboard to Firebase Emulator                                         |
-| Firebase Firestore | http://localhost:8088                                 | Firestore Emulator Service                                                |
-| Login              | http://login.localhost/simplesaml                     | SAML SSO Identity Provider                                                |
+| API                | URL                              | Description                                                               |
+| ------------------ | -------------------------------- | ------------------------------------------------------------------------- |
+| Traefik Dashboard  | http://localhost:8080            | [Traefik Dashboard](https://doc.traefik.io/traefik/operations/dashboard/) |
+| Redis              | redis://localhost:6379           | Redis server                                                              |
+| Elasticsearch      | http://localhost:9200            | Elasticserach                                                             |
+| Firebase UI        | http://localhost:4000            | UI Dashboard to Firebase Emulator                                         |
+| Firebase Firestore | http://localhost:8088            | Firestore Emulator Service                                                |
+| Login              | http://localhost:8081/simplesaml | SAML SSO Identity Provider                                                |
 
 ## References
 

--- a/src/web/src/components/AuthProvider.tsx
+++ b/src/web/src/components/AuthProvider.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import User from '../User';
 
 // TODO: do this via config...
-const apiUrl = `http://api.telescope.localhost/v1/auth`;
+const apiUrl = `http://localhost/v1/auth`;
 
 export interface AuthContextInterface {
   login: (returnTo?: string) => void;


### PR DESCRIPTION
Fixes #1942 
Fixes #1943 

It turns out that some versions of Docker on Windows can't do custom DNS resolution to things like `api.telescope.localhost`.  I was using this to make it easier to remember all the names of the services we run, but since we can't, I'm switching to use `localhost` and port numbers.

The only service I haven't changed is Elasticsearch which @manekenpix is doing in #1933.  We need to use 9200 in development for elasticsearch vs. `elasticsearch.localhost`.