### PR TITLE
Configure staging/Vercel to use new auth service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@
 ARG API_URL
 # API Service URLs, set via ENV in docker or next build
 ARG IMAGE_URL
+ARG AUTH_URL
 
 # Context: Build Context
 FROM node:lts-alpine as build
@@ -39,6 +40,7 @@ FROM build AS backend_dependencies
 # Forward the API_URL and Service URLs build ARGs from pervious stage
 ARG API_URL
 ARG IMAGE_URL
+ARG AUTH_URL
 
 # Install Production Modules!
 # Disable postinstall hook in this case since we are being explict with installs
@@ -59,6 +61,9 @@ ENV NEXT_PUBLIC_API_URL ${API_URL}
 
 ARG IMAGE_URL
 ENV NEXT_PUBLIC_IMAGE_URL ${IMAGE_URL}
+
+ARG AUTH_URL
+ENV NEXT_PUBLIC_AUTH_URL ${AUTH_URL}
 
 COPY ./src/web ./src/web
 COPY ./.git ./.git

--- a/config/env.staging
+++ b/config/env.staging
@@ -47,7 +47,7 @@ SSO_LOGIN_CALLBACK_URL=https://login.microsoftonline.com/3ddc4284-8377-4878-94bf
 SLO_LOGOUT_URL=https://login.microsoftonline.com/3ddc4284-8377-4878-94bf-a35840ca61fe/saml2
 
 # The callback URL endpoint to be used by the SLO logout service (see the /auth route)
-SLO_LOGOUT_CALLBACK_URL=https://dev.api.telescope.cdot.systems/v1/auth//logout/callback
+SLO_LOGOUT_CALLBACK_URL=https://dev.api.telescope.cdot.systems/v1/auth/logout/callback
 
 # The SSO Identity Provider's public key certificate. NOTE: this is the public
 # key cert of the test login IdP docker container.  Update for staging and prod.
@@ -65,10 +65,12 @@ SECRET=secret-sauce
 ADMINISTRATORS=user1@example.com
 
 # Origins of web apps that we'll allow for redirects. See src/api/auth/test
-ALLOWED_APP_ORIGINS=http://dev.telescope.cdot.systems
+# In addition to the staging front-end, we also allow Vercel's various domains
+# to interact with the backend services.
+ALLOWED_APP_ORIGINS=http://dev.telescope.cdot.systems https://telescope-git-master-humphd.vercel.app https://telescope-humphd.vercel.app https://telescope-dusky.now.sh
 
 # The URI of the auth server
-JWT_ISSUER=https://dev.api.telescope.cdot.systems/v1/auth/
+JWT_ISSUER=https://dev.api.telescope.cdot.systems/v1/auth
 
 # The microservices origin
 JWT_AUDIENCE=https://dev.api.telescope.cdot.systems

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -25,6 +25,7 @@ services:
         - API_URL=${API_URL}
         # Telescope 2.0 Microservice URLs
         - IMAGE_URL=${IMAGE_URL}
+        - AUTH_URL=${AUTH_URL}
     container_name: 'telescope'
     restart: unless-stopped
     environment:

--- a/src/web/src/config.ts
+++ b/src/web/src/config.ts
@@ -2,14 +2,15 @@
 // and gets set in next.config.js at build time.
 const telescopeUrl = process.env.NEXT_PUBLIC_API_URL;
 const imageServiceUrl = process.env.NEXT_PUBLIC_IMAGE_URL;
+const authServiceUrl = process.env.NEXT_PUBLIC_AUTH_URL;
 
 const title = `Telescope`;
 const description = `A tool for tracking blogs in orbit around Seneca's open source involvement`;
 const author = `SDDS Students and professors`;
 const keywords = 'blogfeeds, canada, opensourced';
 
-const loginUrl = `${telescopeUrl}/auth/login`;
-const logoutUrl = `${telescopeUrl}/auth/logout`;
+const loginUrl = `${authServiceUrl}/login`;
+const logoutUrl = `${authServiceUrl}/logout`;
 const userFeedsUrl = `${telescopeUrl}/user/feeds`;
 const feedsUrl = `${telescopeUrl}/feeds`;
 


### PR DESCRIPTION
I'm working on getting our authentication system moved from the 1.0 back-end to the new auth microservice.  Our SSO has been updated for staging by ITS, and now we need to make some adjustments to the config, build, and front-end code.

This fixes a few issues with ENV variables for staging, uses `AUTH_URL` in our Docker build for the front-end, and passes the value through to next.js, so we can hit the right end-point in staging/production.

I've also included all the various URLs we have for Vercel, so we can test things there against our backend.  NOTE: PR previews will not work, since we get a different sub-domain (and therefore different origin) on each build.  I've only been able to do this for stable URLs (e.g., whatever we merge to `master`).

cc @HyperTHD, this is another good example for you of how you pass the posts service URL through the Docker build to the frontend.
