### PR TITLE
Use proper AUTH_URL values in next.config.js and AuthProvider

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -28,7 +28,7 @@ API_VERSION=v1
 # Auth Service
 ################################################################################
 
-# Auth Service Port (default is 4444)
+# Auth Service Port (default is 7777)
 AUTH_PORT=7777
 
 # Auth Service URL
@@ -103,8 +103,8 @@ MOCK_REDIS=
 # Feed Discovery Service
 ################################################################################
 
-# Feed Discovery Service Port (default is 7777)
-FEED_DISCOVERY_PORT=7777
+# Feed Discovery Service Port (default is 9999)
+FEED_DISCOVERY_PORT=9999
 
 # Feed Discovery Service URL
 FEED_DISCOVERY_URL=http://localhost/v1/feed-discovery

--- a/config/env.production
+++ b/config/env.production
@@ -31,7 +31,7 @@ API_VERSION=v1
 # Auth Service
 ################################################################################
 
-# Image Service Port (default is 4444)
+# Auth Service Port (default is 7777)
 AUTH_PORT=7777
 
 # Auth Service URL
@@ -106,8 +106,8 @@ MOCK_REDIS=
 # Feed Discovery Service
 ################################################################################
 
-# Feed Discovery Service Port (default is 7777)
-FEED_DISCOVERY_PORT=7777
+# Feed Discovery Service Port (default is 9999)
+FEED_DISCOVERY_PORT=9999
 
 # Feed Discovery Service URL
 FEED_DISCOVERY_URL=https://api.telescope.cdot.systems/v1/feed-discovery

--- a/config/env.staging
+++ b/config/env.staging
@@ -31,7 +31,7 @@ API_VERSION=v1
 # Auth Service
 ################################################################################
 
-# Image Service Port (default is 4444)
+# Auth Service Port (default is 7777)
 AUTH_PORT=7777
 
 # Auth Service URL
@@ -108,8 +108,8 @@ MOCK_REDIS=
 # Feed Discovery Service
 ################################################################################
 
-# Feed Discovery Service Port (default is 7777)
-FEED_DISCOVERY_PORT=7777
+# Feed Discovery Service Port (default is 9999)
+FEED_DISCOVERY_PORT=9999
 
 # Feed Discovery Service URL
 FEED_DISCOVERY_URL=https://dev.api.telescope.cdot.systems/v1/feed-discovery

--- a/src/api/feed-discovery/README.md
+++ b/src/api/feed-discovery/README.md
@@ -18,7 +18,7 @@ npm start
 npm run dev
 ```
 
-By default the server is running on http://localhost:7777/.
+By default the server is running on http://localhost:9999/.
 
 ### Examples
 
@@ -41,4 +41,4 @@ will return response body
 ## Docker
 
 - To build and tag: `docker build . -t telescope_feed_discovery_svc:latest`
-- To run locally: `docker run -p 7777:7777 telescope_feed_discovery_svc:latest`
+- To run locally: `docker run -p 9999:9999 telescope_feed_discovery_svc:latest`

--- a/src/api/feed-discovery/src/server.js
+++ b/src/api/feed-discovery/src/server.js
@@ -1,5 +1,5 @@
 const service = require('.');
 
-const port = parseInt(process.env.FEED_DISCOVERY_PORT || 7777, 10);
+const port = parseInt(process.env.FEED_DISCOVERY_PORT || 9999, 10);
 
 service.start(port);

--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -13,7 +13,7 @@ const dotenv = require('dotenv');
 const loadApiUrlFromEnv = (envFile) => dotenv.config({ path: envFile });
 
 // ENV Variables we need to forward to next by prefix with NEXT_PUBLIC_*
-const envVarsToForward = ['API_URL', 'IMAGE_URL', 'POSTS_URL'];
+const envVarsToForward = ['API_URL', 'IMAGE_URL', 'POSTS_URL', 'AUTH_URL'];
 
 // Copy an existing ENV Var so it's visible to next: API_URL -> NEXT_PUBLIC_API_URL
 const forwardToNext = (envVar) => {

--- a/src/web/src/components/AuthProvider.tsx
+++ b/src/web/src/components/AuthProvider.tsx
@@ -3,9 +3,7 @@ import { useLocalStorage } from 'react-use';
 import { useRouter } from 'next/router';
 
 import User from '../User';
-
-// TODO: do this via config...
-const apiUrl = `http://localhost/v1/auth`;
+import { loginUrl, logoutUrl } from '../config';
 
 export interface AuthContextInterface {
   login: (returnTo?: string) => void;
@@ -73,14 +71,14 @@ const AuthProvider = ({ children }: Props) => {
   }
 
   const login = (returnTo?: string) => {
-    window.location.href = `${apiUrl}/login?redirect_uri=${encodeURIComponent(
+    window.location.href = `${loginUrl}?redirect_uri=${encodeURIComponent(
       returnTo || window.location.href
     )}`;
   };
 
   const logout = (returnTo?: string) => {
     removeToken();
-    window.location.href = `${apiUrl}/logout?redirect_uri=${encodeURIComponent(
+    window.location.href = `${logoutUrl}?redirect_uri=${encodeURIComponent(
       returnTo || window.location.href
     )}`;
   };


### PR DESCRIPTION
@manekenpix and @HyperTHD noticed a few bugs in the way the staging auth fix was being done.  This corrects the problems by properly defining the `AUTH_URL` for next's build, and using it in the `AuthProvider`.