### PR TITLE
Reduce test log spam

### DIFF
--- a/src/backend/lib/config.js
+++ b/src/backend/lib/config.js
@@ -1,22 +1,17 @@
 const path = require('path');
 const dotenv = require('dotenv');
 
+// Try and load our default .env file
 const result = dotenv.config();
-
 if (result.error) {
-  console.warn(
-    '\n\n\t💡 It appears that you have not yet configured a .env file.' +
-      '\n\t   Please refer to our documentation regarding environment configuration:' +
-      '\n\t   https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md\n'
-  );
-
   // Try and use the example env instead if we're not in production
   if (process.env.NODE_ENV !== 'production') {
     const envSamplePath = path.resolve(process.cwd(), path.join('config', 'env.development'));
-    console.log(`Attempting to use default env in ${envSamplePath} instead.\n`);
     const secondAttempt = dotenv.config({ path: envSamplePath });
     if (secondAttempt.error) {
-      console.warn(`Failed to load ${envSamplePath} env fallback file.`);
+      console.warn(
+        `Failed to load .env and ${envSamplePath} env files.\nSee https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md`
+      );
     }
   }
 }

--- a/src/backend/web/routes/admin.js
+++ b/src/backend/web/routes/admin.js
@@ -52,6 +52,7 @@ router.use(
     pathRewrite: {
       '^/admin/build/status': '/status',
     },
+    logLevel: 'silent',
   })
 );
 router.use(
@@ -62,6 +63,7 @@ router.use(
     pathRewrite: {
       '^/admin/build/log': '/log',
     },
+    logLevel: 'silent',
   })
 );
 

--- a/src/backend/web/routes/index.js
+++ b/src/backend/web/routes/index.js
@@ -44,7 +44,14 @@ router.use('/legacy', express.static(path.join(__dirname, '../planet/static')));
 if (process.env.NODE_ENV === 'development') {
   if (process.env.PROXY_FRONTEND) {
     // Allow proxying the Next dev server through our backend if PROXY_FRONTEND=1 is set in env
-    router.use('/', createProxyMiddleware({ target: 'http://localhost:8000', changeOrigin: true }));
+    router.use(
+      '/',
+      createProxyMiddleware({
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        logLevel: 'silent',
+      })
+    );
   } else {
     // Or serve the static files in the Next build directory
     router.use(express.static(path.join(__dirname, '../../../web/out')));


### PR DESCRIPTION
Our tests have a lot of spam in them from various console.logs, and it makes trying to read and debug them a lot harder than it needs to be.

This turns off non-critical logs so we can focus on the pass/fail info.  Here is what they look like now:

@yuanLeeMidori this might make it easier for you to debug that unhandled promise rejection.

<details>
<summary>New Log Output</summary>

$ npm test

> @senecacdot/telescope@1.8.0 pretest /Users/humphd/repos/telescope
> npm run lint


> @senecacdot/telescope@1.8.0 lint /Users/humphd/repos/telescope
> npm run eslint


> @senecacdot/telescope@1.8.0 eslint /Users/humphd/repos/telescope
> eslint --config .eslintrc.js


> @senecacdot/telescope@1.8.0 test /Users/humphd/repos/telescope
> npm run jest


> @senecacdot/telescope@1.8.0 jest /Users/humphd/repos/telescope
> cross-env NODE_ENV=test LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest -c jest.config.js --

(node:48537) UnhandledPromiseRejectionWarning: StatusCodeError: 404 - "Not Found"
(Use `node --trace-warnings ...` to show where the warning was created)
(node:48537) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:48537) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  test/feed-processor.test.js (12.636 s)
  Feed Processor Tests
    ✓ Passing a valid Atom feed URI should pass (202 ms)
    ✓ Passing a valid RSS feed URI should pass (47 ms)
    ✓ Passing a valid URI with HTML response should work (9 ms)
    ✓ Passing an invalid RSS category feed should pass (6 ms)
    ✓ Passing a valid RSS category feed should pass (36 ms)
    ✓ Non existent feed failure case: 404 should work (9 ms)

 PASS  test/feeds-rss.test.js (13.309 s)
  GET "/feed/rss" endpoint
    ✓ should respond with status 200 and content-type application/rss+xml (3 ms)
    ✓ should respond with a valid XML string that contains all expected elements (3 ms)

 PASS  test/feeds-atom.test.js
  GET "/feed/atom" endpoint
    ✓ should respond with status 200 and content-type application/atom+xml (1 ms)
    ✓ should respond with a valid XML string that contains all expected elements (1 ms)

 PASS  test/feeds-opml.test.js
  GET "/feed/opml" endpoint
    ✓ should respond with status 200 and content-type text/x-opml (2 ms)
    ✓ should respond with a valid XML string that contains all expected elements (4 ms)

 PASS  test/posts.test.js
  test /posts endpoint
    ✓ requests default number of items (12 ms)
    ✓ requests a specific number of items (7 ms)
    ✓ requests more items than the limit set by the server (6 ms)
    ✓ request posts with both query params (5 ms)
    ✓ request posts with both only page param (5 ms)
    ✓ request posts with non-integer page param (3 ms)
    ✓ request posts with non-integer per_page param (5 ms)
  test /posts/:id responses
    ✓ pass an id that doesn't exist (5 ms)
    ✓ pass an id that does exist (7 ms)
    ✓ requests text (98 ms)
    ✓ requests HTML (9 ms)
    ✓ requests JSON (5 ms)
    ✓ requests ID with 6 characters Test (3 ms)
    ✓ requests ID with 14 characters Test (3 ms)
    ✓ requests ID with valid length but not exist Test (2 ms)

 PASS  test/post.test.js
  Post data class tests
    ✓ Post should be a function
    ✓ Post constructor should populate all expected properties (1 ms)
    ✓ Post constructor should work with with published and updated as Strings (1 ms)
    ✓ Post constructor should work with with published and updated as Dates
    ✓ Post constructor should throw if feed is missing or not a Feed instance (27 ms)
    ✓ Post constructor should throw if a string or date is not passed (1 ms)
    ✓ Post.create() should be able to parse an Object into a Post (3 ms)
    ✓ Posts should have a (dynamic) text property (27 ms)
    ✓ Post.create() should work with missing fields (2 ms)
    ✓ Post.save() and Post.byId() should both work as expected (2 ms)
    ✓ Post.byId() with invalid id should return null (1 ms)
    Post.createFromArticle() tests
      ✓ should throw if passed no article (210 ms)
      ✓ should throw if passed nothing (110 ms)
      ✓ should work with real world RSS (348 ms)
      ✓ when missing description should throw (78 ms)
      ✓ Post.createFromArticle() with missing pubdate should throw (45 ms)
      ✓ Post.createFromArticle() with missing date should not throw (176 ms)
      ✓ Post.createFromArticle() with missing link should throw (56 ms)
      ✓ Post.createFromArticle() with missing guid should throw (39 ms)
      ✓ Post.createFromArticle() with missing title should use Untitled (176 ms)
      ✓ Post.createFromArticle() with whitespace only in description should throw (85 ms)

[ 2021-03-16 11:23:41.489 ] ERROR (48537 on brightness.local): Unable to process HTML for feed
    error: {}
 PASS  test/feeds.test.js
  test GET /feeds endpoint
    ✓ requests feeds (6 ms)
  test /feeds/:id responses
    ✓ pass an id that doesn't exist (15 ms)
    ✓ pass an id that does exist (4 ms)
    ✓ Should return 400 that is less than 10 characters (5 ms)
    ✓ Should return 400 that is more than 10 characters (4 ms)
  test POST /feeds endpoint
    ✓ fails if not logged in (223 ms)
    ✓ responds with json (13 ms)
    ✓ returns 400 if no author being sent (ie: author is null or empty string) (10 ms)
    ✓ returns 400 if author provided is a number instead of string (5 ms)
    ✓ returns 400 if no url being sent (ie: url is null or empty string) (7 ms)
    ✓ returns 400 if url provided is a number instead of a string (4 ms)
    ✓ returns 400 if url is invalid (9 ms)
    ✓ returns 201 if url is valid (42 ms)
    ✓ url already in the feed list (4 ms)
  test DELETE /feeds/cache endpoint
    ✓ should respond with a 403 status trying to clear cache without logging in (3 ms)
    ✓ should respond with a 403 status trying to clear cache when logged in as normal user (3 ms)
    ✓ should respond with a 204 status trying to clear cache when logged in as admin user (40 ms)
    ✓ should respond with a 204 and all existing feed etag + lastModified be null (45 ms)
  test DELETE /feeds/:id endpoint
    ✓ should respond with a 403 status when not logged in (8 ms)
    ✓ should respond with a 403 status when targeted feed is not owned by user (8 ms)
    ✓ should respond with a 204 status when targeted feed is owned by user (10 ms)
    ✓ should respond with a 204 status when admin deletes a feed owned by user (9 ms)
    ✓ should return 400 when id is less than 10 characters (3 ms)
    ✓ should return 400 when id is more than 10 characters (3 ms)
  test PUT + DELETE /feeds/:id/flag endpoint
    ✓ should respond with a 403 status trying to flag feed without logging in (12 ms)
    ✓ should respond with a 403 status trying to flag feed when logged in as normal user (18 ms)
    ✓ should respond with a 404 status trying to flag feed that does not exist when logged in as admin user (4 ms)
    ✓ should respond with a 200 status trying to flag feed when logged in as admin user (23 ms)
    ✓ should respond with a 403 status trying to unflag feed without logging in (15 ms)
    ✓ should respond with a 403 status trying to unflag feed when logged in as normal user (14 ms)
    ✓ should respond with a 400 status trying to unflag feed that has 9 digits when logged in as admin user (4 ms)
    ✓ should respond with a 400 status trying to unflag feed that has 12 digits when logged in as admin user (3 ms)
    ✓ should respond with a 204 status trying to unflag feed when logged in as admin user (4 ms)
    ✓ should respond with a 400 status because id url param is 9 characters but validation expects 10 (4 ms)
    ✓ should respond with a 400 status because id url param is 11 characters but validation expects 10 (3 ms)

(node:48536) UnhandledPromiseRejectionWarning: Error: expect(received).resolves.toBe(expected) // Object.is equality

Expected: true
Received: false
(Use `node --trace-warnings ...` to show where the warning was created)
(node:48536) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:48536) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  test/feed.test.js
  Post data class tests
    ✓ Feed should be a function
    ✓ Feed constructor should populate all expected properties (1 ms)
    ✓ Feed constructor should throw if missing url (126 ms)
    ✓ Feed constructor should throw if missing author and url (1 ms)
    Get and Set Feed objects from database
      ✓ Feed.byId() for a valid id should return a Feed (2 ms)
      ✓ Feed.byId() for an invalid id should return null
      ✓ Feed.byUrl() for a valid url should return a Feed (1 ms)
      ✓ Feed.byId() for an invalid url should return null
      ✓ Setting etag on a feed should persist (1 ms)
      ✓ Setting lastModified on a feed should persist (1 ms)
      ✓ Feed.isDelayed() should return true only after Feed.setDelayed() is called (3 ms)
      ✓ Updated feed should be different from data (3 ms)
      ✓ Removing feeds should also remove posts (41 ms)
      ✓ clearCache should set lastModified and etag to null (4 ms)
      ✓ Flagged feed should appear in t:feeds:flagged and not t:feeds (10 ms)

11:23:47 ✨ request completed GET 200 / 13ms
11:23:47 ✨ request completed GET 200 /?per_page=50 3ms
11:23:47 ✨ request completed GET 200 /?per_page=150 3ms
11:23:47 ✨ request completed GET 200 /?page=2&per_page=50 3ms
11:23:47 ✨ request completed GET 200 /?page=3 2ms
11:23:47 ✨ request completed GET 400 /?page=test 1ms
11:23:47 ✨ request completed GET 400 /?per_page=test 1ms
11:23:47 ✨ request completed GET 200 / 2ms
11:23:47 ✨ request completed GET 200 /ffe772dd58 2ms
11:23:47 ✨ request completed GET 200 / 2ms
11:23:47 ✨ request completed GET 200 /ffe772dd58 1ms
11:23:47 ✨ request completed GET 404 /98fd166177 2ms
11:23:47 ✨ request completed GET 200 / 2ms
 PASS  src/api/posts/test/posts.test.js (22.571 s)
  /posts
    ✓ default number of items should be returned (47 ms)
    ✓ requests a specific number of items (15 ms)
    ✓ requests more items than the limit set by the server (9 ms)
    ✓ request posts with both query params (12 ms)
    ✓ request posts with both only page param (15 ms)
    ✓ request posts with non-integer page param (5 ms)
    ✓ request posts with non-integer per_page param (4 ms)
  test /posts/:id responses
    ✓ A post with an id should be returned (9 ms)
    ✓ The id of a post should match the id the post object returns (8 ms)
    ✓ Pass an id that doesn't exist (4 ms)
    ✓ requests text (124 ms)
    ✓ requests JSON (11 ms)
    ✓ requests HTML (7 ms)
    ✓ requests ID with 6 characters Test (3 ms)
    ✓ requests ID with 14 characters Test (5 ms)
    ✓ requests ID with valid length but not exist Test (3 ms)

11:23:47 ✨ request completed GET 200 /f89e65ebc8 118ms
11:23:47 ✨ request completed GET 200 / 2ms
11:23:47 ✨ request completed GET 200 /f4da610710 1ms
11:23:47 ✨ request completed GET 200 /f4da610710 1ms
11:23:47 ✨ request completed GET 200 / 1ms
11:23:47 ✨ request completed GET 200 /f89e65ebc8 1ms
11:23:47 ✨ request completed GET 400 /123456 1ms
11:23:47 ✨ request completed GET 400 /12345678901234 1ms
11:23:47 ✨ request completed GET 404 /1234567890 1ms
 PASS  test/user.test.js
  test GET /user/info endpoint
    ✓ should respond with a 403 status when not logged in (14 ms)
    ✓ should respond with a 200 status and JSON Object for logged in user (5 ms)
    ✓ should respond with a 200 status and JSON Object for logged in admin (4 ms)
  test GET /user/feeds endpoint
    ✓ should respond with a 403 status when not logged in (7 ms)
    ✓ should respond with a 200 status and JSON array if logged in (5 ms)
    ✓ should get all feeds when logged in as admin (8 ms)
    ✓ should respond with an updated array after a new user feed is added/removed (256 ms)

 PASS  src/api/feed-discovery/test/router.test.js (11.212 s)
  POST /
    Test the API returns feed URLs correctly
      ✓ should return 200 and 1 rss+xml feed url if there is one link of type="application/rss+xml" (216 ms)
      ✓ should return 200 and 1 atom+xml feed url if there is 1 link of type="application/atom+xml" (9 ms)
      ✓ should return 200 and 1 json+oembed feed url if there is 1 link of type="application/json+oembed" (9 ms)
      ✓ should return 200 and 1 xml+oembed feed url if there is 1 link of type="application/xml+oembed" (9 ms)
      ✓ should return 200 and all feed urls if there are multiple link elements that could contain a feed url (10 ms)

11:23:52 ✨ request completed POST 200 / 208ms
11:23:52 ✨ request completed POST 200 / 6ms
11:23:52 ✨ request completed POST 200 / 6ms
11:23:52 ✨ request completed POST 200 / 6ms
11:23:52 ✨ request completed POST 200 / 8ms
11:23:53 ✨ request completed GET 400 /unknown-image 4ms
11:23:53 ✨ request completed GET 200 /default.jpg 867ms
11:23:53 ✨ request completed GET 200 / 75ms
11:23:54 ✨ request completed GET 200 / 84ms
11:23:54 ✨ request completed GET 200 / 99ms
11:23:54 ✨ request completed GET 200 /?t=jpeg 106ms
11:23:54 ✨ request completed GET 200 /?t=jpg 44ms
11:23:54 ✨ request completed GET 200 /?t=png 165ms
11:23:54 ✨ request completed GET 200 /?t=webp 78ms
11:23:54 ✨ request completed GET 400 /?t=unknown 2ms
11:23:54 ✨ request completed GET 400 /?w=one 1ms
11:23:54 ✨ request completed GET 400 /?w=199 1ms
11:23:54 ✨ request completed GET 400 /?w=2001 1ms
11:23:54 ✨ request completed GET 400 /?h=one
 PASS  src/api/image/test/image.test.js (12.246 s)
  /image
    ✓ should return 400 when requesting an unknown image (12 ms)
    ✓ should return 200 when requesting a known image (870 ms)
    ✓ should return 200 when requesting no image (78 ms)
    ✓ should return a WebP with width 800px by default (169 ms)
    ✓ should return a WebP if Accept header includes it (101 ms)
    ✓ should return a JPEG when requested (109 ms)
    ✓ should return a JPG when requested (47 ms)
    ✓ should return a PNG when requested (169 ms)
    ✓ should return a WebP when requested (81 ms)
    ✓ should return 400 if type is unknown (5 ms)
    ✓ should return 400 if width is not a number (3 ms)
    ✓ should return 400 if width is under 200 (3 ms)
    ✓ should return 400 if width is over 2000 (3 ms)
    ✓ should return 400 if height is not a number (3 ms)
    ✓ should return 400 if height is under 200 (3 ms)
    ✓ should return 400 if height is over 3000 (3 ms)
    ✓ should return 400 if image name has invalid characters (3 ms)
    ✓ should return a valid image of the expected type and size (63 ms)

11:23:54 ✨ request completed GET 400 /?h=199
11:23:54 ✨ request completed GET 400 /?h=3001 1ms
11:23:54 ✨ request completed GET 400 /../package.json 1ms
11:23:54 ✨ request completed GET 200 /?t=png&w=400&h=500 60ms
 PASS  test/feed-queue.test.js
  ✓ able to add a job to the feed queue (162 ms)

 PASS  src/api/image/test/gallery.test.js
  /gallery
    ✓ should return HTML content (16 ms)
    ✓ should include <img> elements (4 ms)

11:23:55 ✨ request completed GET 200 /gallery 3ms
11:23:55 ✨ request completed GET 200 /gallery
 PASS  test/feeds-json.test.js
  GET "/feed/json" endpoint
    ✓ should respond with status 200 and content-type application/json (1 ms)
    ✓ should respond with a valid JSON object that contains all expected elements

 PASS  test/query.test.js
  Testing query route
    ✓ Testing with valid length of characters for text (14 ms)
    ✓ Testing with invalid length of characters for text (5 ms)
    ✓ Testing with missing text param (4 ms)
    ✓ Testing with missing filter param (4 ms)
    ✓ Testing with invalid filter (3 ms)
    ✓ Testing with valid post filter (5 ms)
    ✓ Testing with valid author filter (7 ms)
    ✓ Testing with empty param values (4 ms)
    ✓ Testing with empty page value (6 ms)
    ✓ Testing with invalid page value (5 ms)
    ✓ Testing with page above range (4 ms)
    ✓ Testing with page below range (6 ms)
    ✓ Testing with valid page in range (4 ms)
    ✓ Testing with empty per page value (4 ms)
    ✓ Testing with invalid per page value (4 ms)
    ✓ Testing with per page above range  (7 ms)
    ✓ Testing with per page below range  (4 ms)
    ✓ Testing with valid per page in range  (5 ms)

 PASS  test/feeds-wiki.test.js
  GET "/feed/wiki" endpoint
    ✓ should respond with status 200 and content-type text/plain
    ✓ should respond with text that matches the expected format for wiki feeds

 PASS  test/server.test.js
  Health Check
    ✓ should return a JSON object with property "status" (20 ms)
    ✓ should return a JSON object with property "info" (3 ms)

 PASS  src/api/feed-discovery/test/lib.test.js (5.815 s)
  POST /
    Test checkValidUrl middleware
      ✓ should return 400 status if the url has invalid format (170 ms)
      ✓ should call next() if the url has valid format (1 ms)
    Test checkValidBlogPage middleware
      ✓ should return 400 if the blog page responds with code other than 200 (21 ms)
      ✓ should return 400 if the blog page responds with content type other than text/html (8 ms)
    Test discoverFeedUrls middleware
      ✓ should return 404 if there is no feed url discovered (7 ms)
      ✓ should call next() if there is any discovered feed url (3 ms)

11:24:00 ✨ request completed POST 400 / 149ms
11:24:00 ✨ request completed POST 400 / 17ms
11:24:00 ✨ request completed POST 400 / 5ms
 PASS  test/replace-entities.test.js
  ✓ The result from decodeHTML() is of type string (23 ms)
  ✓ Encoded string with no code block entities should not be changed (12 ms)
  ✓ Encoded string with non-breaking space entities should be decoded (9 ms)
  ✓ Encoded string with greater than sign should be decoded twice (double encoded) (23 ms)
  ✓ Encoded string with less than sign should be decoded twice (double encoded) (13 ms)
  ✓ Encoded string with ampersand entities should be decoded (15 ms)
  ✓ Encoded string with arrow function should be decoded (9 ms)
  ✓ Encoded string with &amp;gt; should be decoded twice (double encoded) (12 ms)

 PASS  test/syntax-highlight.test.js
  syntax-highlight tests
    ✓ empty code blocks are left untouched (12 ms)
    ✓ regular prose is left untouched (12 ms)
    ✓ code outside <pre><code>...</code></pre> should be left untouched (7 ms)
    ✓ code inside <pre><code>...</code></pre> should get marked up (128 ms)
    ✓ bash is correctly marked up (11 ms)
    ✓ JavaScript is correctly marked up (32 ms)

 PASS  src/api/auth/test/token.test.js
  createToken()
    ✓ should return a valid JWT (3 ms)
    ✓ should return a JWT with the expected audience claim (1 ms)
    ✓ should return a JWT with the expected issuer claim
    ✓ should return a JWT with an expiry claim (1 ms)
    ✓ should return a JWT with an issued at claim (1 ms)

 PASS  test/fix-iframe-width.test.js
  lazy-load tests
    ✓ Non <iframe> elements are left alone (94 ms)
    ✓ empty strings are left untouched (17 ms)
    ✓ regular prose is left untouched (60 ms)
    ✓ An <iframe> gets wrapped in a <div> (57 ms)
    ✓ Multiple <iframe>s get wrapped in their own <div> (42 ms)

 PASS  test/modify-pre.test.js
  modify pre tag without <code> element tests
    ✓ html body without pre tags should not be changed (19 ms)
    ✓ pre tags with inner <code></code> elements should not be changed (11 ms)
    ✓ pre tags without inner <code></code> elements should be fixed (11 ms)
    ✓ pre tag with child <br> elements should be fixed (20 ms)

 PASS  test/wiki-feed-parser.test.js
  ✓ Testing wiki-feed-parser.parseData (228 ms)

 PASS  test/remove-empty-anchor.test.js
  Remove no content anchor tags
    ✓ Should remove <a></a>  (29 ms)
    ✓ Should not remove <a>foo</a>  (8 ms)
    ✓ Should not remove <a href="http://localhost">localhost</a> or <a href="#abc">abc</a> (16 ms)
    ✓ Should only keep third anchor in <a></a><a></a><a>should still exist</a> (7 ms)
    Should keep anchors contain media tags only
      ✓ Should not remove anchors containing single media tag eg: <a><img src="Image.com"></a> (74 ms)
      ✓ Should not remove anchors containing multiple media tags eg: <a><img><video></video><audio></audio></a> (7 ms)

 PASS  test/lazy-load.test.js
  lazy-load tests
    ✓ Non <img> and <iframe> elements are left alone (97 ms)
    ✓ empty strings are left untouched (169 ms)
    ✓ regular prose is left untouched (10 ms)
    <img> lazy loading
      ✓ An <img> has lazy loading added (15 ms)
      ✓ An <img> has lazy loading added only once (22 ms)
      ✓ Multiple <img>s have lazy loading added (269 ms)
    <iframe> lazy loading
      ✓ An <iframe> has lazy loading added (20 ms)
      ✓ An <iframe> has lazy loading added only once (14 ms)
      ✓ Multiple <iframe>s have lazy loading added (33 ms)

 PASS  test/text-parser.test.js
  text-parser tests
    ✓ textParser() with doctype (13 ms)
    ✓ textParser() with HTML body (3 ms)
    ✓ textParser() with minimal document fragment (1 ms)
    ✓ textParser() with real blog post (30 ms)

 PASS  test/storage.test.js
  Storage tests for feeds
    ✓ should allow retrieving a feed by id after inserting (1 ms)
    ✓ should return expected feed count (1 ms)
    ✓ should return expected feeds
    ✓ should deal with etag property correctly when available and missing (1 ms)
    ✓ should deal with lastModified property correctly when available and missing (1 ms)
    ✓ feed4 should have a link value (1 ms)
    ✓ feed4 should not exist after being removed (1 ms)
    ✓ feed3 should appear in flaggedFeed set after being flagged (1 ms)
    ✓ feed3 should not appear in flaggedFeed set after being unflagged
  Storage tests for posts
    ✓ should allow retrieving a post by id after inserting (1 ms)
    ✓ get all posts returns current number of posts (1 ms)
    ✓ get all posts returns sorted posts by date
    ✓ check post count (1 ms)
    ✓ testPost and testPost2 should not appear in results after being removed (1 ms)

 PASS  test/remove-empty-paragraphs.test.js
  Remove no content anchor tags
    ✓ should remove <p></p> (97 ms)
    ✓ should remove <p>   </p> (spaces) (13 ms)
    ✓ should remove <p>&#9&#9</p> (tabs) (10 ms)
    ✓ should remove <p>&#x2800 &#x2800</p> (braille) (8 ms)

 PASS  test/remove-devto-fullscreen.test.js
  ✓ should remove Dev.to Enter Fullscreen RSS bug: https://github.com/forem/forem/pull/11268 (21 ms)

 PASS  test/logger.test.js
  ✓ logger.methods to be functions (1 ms)

 PASS  test/sanitize-html.test.js
  Sanitize HTML
    ✓ <script> should be removed (2 ms)
    ✓ https://github.com/Seneca-CDOT/telescope/issues/1488
    ✓ <img> should work, but inline js should not (2 ms)
    ✓ <img src="data:..."/> URI links (gif based) should be accepted (i.e. not sanitized)
    ✓ img links over https should be accepted (i.e. not sanitized) (1 ms)
    ✓ img links over http should be accepted (i.e. not sanitized) (1 ms)
    ✓ protocoless urls should be accepted (i.e. not sanitized)
    ✓ <a><img> should work, but inline js should not (1 ms)
    ✓ <p> with inline style, sanitize strips inline style
    ✓ <p> with <strong> should work with inline style stripped (1 ms)
    ✓ <figure> with <img> should strip inline style as both are added to allowed tags (10 ms)
    ✓ <iframe> to Telescope returns an empty iframe tag (1 ms)
    ✓ <iframe> tag to a youtube embed should not get removed (1 ms)
    ✓ <iframe> tag to a vimeo player should not get removed (1 ms)
    ✓ <iframe> tag to a giphy embed should not get removed
    ✓ <iframe> tag to a spotify embed should not get removed (1 ms)
    ✓ cdn.embedly.com embedded content should not get removed (1 ms)
    ✓ <pre> with inline style, sanitize strips inline style (1 ms)
    ✓ <table> with multiple tags and links should work (1 ms)

 PASS  test/dom.test.js
  toDOM tests
    ✓ an HTML string is turned into a DOM (18 ms)
    ✓ empty strings are OK (11 ms)
    ✓ regular prose is OK (12 ms)

 PASS  test/hash.test.js
  hash function tests
    ✓ should return a 10 character hash (1 ms)
    ✓ should properly hash a string
    ✓ should return a different string if anything changes

 PASS  test/url-parser.test.js
  url-parser tests
    ✓ urlParser with double ports (1 ms)
    ✓ urlParser with 1 string port
    ✓ urlParser with invalid url (1 ms)
    ✓ urlParser with url with no port and no port
    ✓ urlPaser with port being a null value
    ✓ urlPaser with port being an integer (1 ms)
    ✓ urlPaser with port being an invalid string
    ✓ urlPaser with an out of range port

A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.
Test Suites: 36 passed, 36 total
Tests:       278 passed, 278 total
Snapshots:   0 total
Time:        41.19 s, estimated 110 s
Ran all test suites in 5 projects.
</details>