### PR TITLE
Don't wait for services shutdown in CI for e2e tests

### DIFF
--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -86,4 +86,3 @@ jobs:
           npm install
           npm run services:start
           npm run jest:e2e
-          npm run services:stop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
           npm install
           npm run services:start
           npm run jest:e2e
-          npm run services:stop
   release:
     needs: [prettier, eslint, unit, e2e]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The e2e tests can fail if the docker containers don't shut down cleanly:

```
[Jest Process Manager] http-server stopped.

> @senecacdot/telescope@1.8.0 services:stop /home/runner/work/telescope/telescope
> node bin/services-stop.js

Stopping image          ... 
Stopping auth           ... 
Stopping feed-discovery ... 
Stopping posts          ... 
Stopping traefik        ... 
Stopping elasticsearch  ... 
Stopping login          ... 
Stopping firebase       ... 
Stopping redis          ... 
Stopping posts          ... done
Stopping auth           ... done
Stopping image          ... done
Stopping feed-discovery ... done
Stopping login          ... done
Stopping firebase       ... done
Stopping redis          ... done
Stopping elasticsearch  ... done
Stopping traefik        ... done
Removing image          ... 
Removing auth           ... 
Removing feed-discovery ... 
Removing posts          ... 
Removing traefik        ... 
Removing elasticsearch  ... 
Removing login          ... 
Removing firebase       ... 
Removing redis          ... 
Removing traefik        ... done
Removing posts          ... done
Removing feed-discovery ... done
Removing login          ... done
Removing firebase       ... done
Removing redis          ... done
Removing auth           ... done
Removing image          ... done
Removing elasticsearch  ... done
Removing network telescope_api_default
error while removing network: network telescope_api_default id 1a065acc4ddb3c6673e19eb77e23ec4de3d448eedb2f91b952be2ac49217011e has active endpoints
Error stopping services with docker-compose: undefined
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @senecacdot/telescope@1.8.0 services:stop: `node bin/services-stop.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @senecacdot/telescope@1.8.0 services:stop script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2021-03-17T13_13_12_341Z-debug.log
Error: Process completed with exit code 1.
```

We don't really need to do this, since GitHub will just kill the entire VM that they are running within.