### PR TITLE
Modified base jest setup to use env.development

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,7 @@
 /* global jest */
+const path = require('path');
 const fetch = require('jest-fetch-mock');
+
+require('dotenv').config({ path: path.join(__dirname, './config/env.development') });
 
 jest.setMock('node-fetch', fetch);

--- a/src/api/auth/jest.config.e2e.js
+++ b/src/api/auth/jest.config.e2e.js
@@ -3,7 +3,6 @@ const baseConfig = require('../../../jest.config.base');
 module.exports = {
   ...baseConfig,
   rootDir: '../../..',
-  setupFiles: ['<rootDir>/jest.setup.js'],
   testMatch: ['<rootDir>/src/api/auth/test/e2e/**/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/api/auth/src/**/*.js'],
   // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright

--- a/src/api/auth/jest.config.e2e.js
+++ b/src/api/auth/jest.config.e2e.js
@@ -3,7 +3,7 @@ const baseConfig = require('../../../jest.config.base');
 module.exports = {
   ...baseConfig,
   rootDir: '../../..',
-  setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/src/api/auth/jest.setup.js'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
   testMatch: ['<rootDir>/src/api/auth/test/e2e/**/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/api/auth/src/**/*.js'],
   // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright

--- a/src/api/auth/jest.config.js
+++ b/src/api/auth/jest.config.js
@@ -3,7 +3,7 @@ const baseConfig = require('../../../jest.config.base');
 module.exports = {
   ...baseConfig,
   rootDir: '../../..',
-  setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/src/api/auth/jest.setup.js'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
   testMatch: ['<rootDir>/src/api/auth/test/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/api/auth/src/**/*.js'],
 };

--- a/src/api/auth/jest.config.js
+++ b/src/api/auth/jest.config.js
@@ -3,7 +3,6 @@ const baseConfig = require('../../../jest.config.base');
 module.exports = {
   ...baseConfig,
   rootDir: '../../..',
-  setupFiles: ['<rootDir>/jest.setup.js'],
   testMatch: ['<rootDir>/src/api/auth/test/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/api/auth/src/**/*.js'],
 };

--- a/src/api/auth/jest.setup.js
+++ b/src/api/auth/jest.setup.js
@@ -1,8 +1,0 @@
-const path = require('path');
-const result = require('dotenv').config({
-  path: path.join(__dirname, '../../../config/env.development'),
-});
-
-if (result.error) {
-  throw result.error;
-}

--- a/src/api/posts/jest.setup.js
+++ b/src/api/posts/jest.setup.js
@@ -1,10 +1,1 @@
-const path = require('path');
-const result = require('dotenv').config({
-  path: path.join(__dirname, '../env.development'),
-});
-
 process.env = { ...process.env, MOCK_REDIS: '1' };
-
-if (result.error) {
-  throw result.error;
-}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR closes #1926 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

First of all, sorry @yuanLeeMidori for taking your issue and fixing it. 

This PR adds env.development to our base jest.setup.js file. Since this file is included in the jest.base.js which is used in all services tests, this removes the need to use dotenv to include this env file in all tests separately. e2e tests were also fixed to work. All other jest.setup.js files in any of our services directories were removed, or in the case of the posts service, only a single line to include MOCK_REDIS was kept

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
