### PR TITLE
Add Cache-Control to status service

### DIFF
--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "A service for getting the status of our services",
   "scripts": {
-    "start": "node server.js"
+    "start": "node src/server.js"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",

--- a/src/api/status/src/server.js
+++ b/src/api/status/src/server.js
@@ -5,11 +5,16 @@ const { check } = require('./services');
 
 const service = new Satellite();
 
-service.router.use(serveStatic('public'));
+// Static web assets can be cached for a long time
+service.router.use(serveStatic('public', { immutable: true, maxAge: '1y' }));
 
 service.router.get('/status', (req, res) => {
   check()
-    .then((status) => res.json(status))
+    .then((status) => {
+      // This status response shouldn't be cached (we need current status info)
+      res.set('Cache-Control', 'no-store, max-age=0');
+      return res.json(status);
+    })
     .catch((err) => res.status(500).json({ error: err.message }));
 });
 


### PR DESCRIPTION
Part of #1936.

This adds proper cache headers to the status service:

- static assets are cachable for 1 year
- /status API calls are not cachable

https://web.dev/http-cache/#flowchart is a useful chart for understanding this.

I also fixed a small bug to allow starting the server with npm.