### PR TITLE
Fix #1872: pass state with login flow

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -17,6 +17,7 @@
     "highlight.js": "10.6.0",
     "jwt-decode": "^3.1.2",
     "material-ui-popup-state": "^1.7.1",
+    "nanoid": "^3.1.22",
     "next": "^10.0.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
This adds another layer of security to our login flow.  When a user initiates a login, we generate a random string in the browser, store it in localStorage, then pass it on the login redirect as a query param.

The auth service stores it, and does the login SAML flow.  When the callbacks come back, it gets that value out of the session and returns it to the browser.  The browser compares that to what's in storage, and if they match, it's clear that the user initiated the login.  Otherwise, something weird is happening (e.g., redirect with token from another site), and we ignore it.