### PR TITLE
Update autodeployment deps, remove body-parser

### DIFF
--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -4,14 +4,13 @@
   "description": "A tool for automatic deployment",
   "main": "server.js",
   "dependencies": {
-    "@octokit/webhooks": "^8.4.0",
-    "body-parser": "^1.19.0",
-    "date-fns": "^2.17.0",
+    "@octokit/webhooks": "^8.6.0",
+    "date-fns": "^2.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "merge-stream": "^2.0.0",
-    "pm2": "^4.4.1",
-    "shelljs": "^0.8.3"
+    "pm2": "^4.5.5",
+    "shelljs": "^0.8.4"
   },
   "scripts": {
     "start": "node server.js"

--- a/tools/autodeployment/server.js
+++ b/tools/autodeployment/server.js
@@ -2,7 +2,6 @@ require('dotenv').config();
 const path = require('path');
 const https = require('https');
 const express = require('express');
-const bodyParser = require('body-parser');
 const { Webhooks } = require('@octokit/webhooks');
 const shell = require('shelljs');
 const mergeStream = require('merge-stream');
@@ -11,7 +10,7 @@ const fs = require('fs');
 const { buildStart, buildStop, handleStatus } = require('./info');
 
 const app = express();
-app.use(bodyParser.json());
+app.use(express.json());
 
 // Current build process output stream (if any)
 let out;


### PR DESCRIPTION
Every time I run `npm install` I see this:

```
> @senecacdot/telescope@1.8.1 install:autodeployment /Users/humphd/repos/telescope
> cd tools/autodeployment && npm install

audited 257 packages in 2.968s

8 packages are looking for funding
  run `npm fund` for details

found 3 vulnerabilities (2 moderate, 1 high)
  run `npm audit fix` to fix them, or `npm audit` for details
```

I decided to fix it.  I've update the deps, and removed the unnecessary body-parser dep (it's built into express now).