### PR TITLE
Fixes #2000 redirect URL error

### DIFF
--- a/src/web/src/components/AuthProvider.tsx
+++ b/src/web/src/components/AuthProvider.tsx
@@ -4,11 +4,11 @@ import { useRouter } from 'next/router';
 import { nanoid } from 'nanoid';
 
 import User from '../User';
-import { loginUrl, logoutUrl } from '../config';
+import { loginUrl, logoutUrl, telescopeUrl } from '../config';
 
 export interface AuthContextInterface {
   login: (returnTo?: string) => void;
-  logout: (returnTo?: string) => void;
+  logout: () => void;
   user?: User;
   token?: string;
 }
@@ -98,18 +98,17 @@ const AuthProvider = ({ children }: Props) => {
     setAuthState(loginState);
 
     // Set our return URL
-    const redirectUri = encodeURIComponent(returnTo || window.location.href);
-    window.location.href = `${loginUrl}?redirect_uri=${redirectUri}&state=${loginState}`;
+    const url = new URL(returnTo || '', telescopeUrl);
+    window.location.href = `${loginUrl}?redirect_uri=${url.href}&state=${loginState}`;
   };
 
-  const logout = (returnTo?: string) => {
+  const logout = () => {
     // Clear our existing token and state
     removeToken();
     removeAuthState();
 
-    // Set our return URL
-    const redirectUri = encodeURIComponent(returnTo || window.location.href);
-    window.location.href = `${logoutUrl}?redirect_uri=${redirectUri}`;
+    // Redirect to logout
+    window.location.href = `${logoutUrl}?redirect_uri=${telescopeUrl}`;
   };
 
   return (

--- a/src/web/src/pages/myfeeds.tsx
+++ b/src/web/src/pages/myfeeds.tsx
@@ -8,7 +8,7 @@ const MyFeedsPage = () => {
 
   // Redirect the user to login if they aren't authenticated already
   if (!user) {
-    return login('/myfeeds');
+    return login(`/myfeeds`);
   }
 
   return (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2000
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
@humphd In this PR I have fixed the error when we log out from /myfeeds by allowing relative `redirect_uri` and add Telescope base URL to it.  However, there's another problem, when we call `logout()`, before the logout URL is reached, `myfeeds` component re-renders because `user` is now undefined, and it redirects us to login and cancels the logout request. I couldn't come up with an easy solution to prevent this. I was wondering if you can help me with this issue?  

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
