### PR TITLE
Closes #1744: Explore using Portainer to allow admins to manage docker containers

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -193,6 +193,20 @@ http {
       proxy_pass http://telescope:3000;
     }
 
+    # Non-cached /portainer route
+    location /portainer/api/websocket/  {
+      proxy_cache_bypass 1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_pass  http://portainer:9000/api/websocket;
+    }
+
+    location /portainer/ {
+      proxy_cache_bypass 1;
+      proxy_set_header Connection "";
+      proxy_pass http://portainer:9000/;
+    }
+
     # Static next.js front-end
     location / {
       # Directory from which we serve Next's static content

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -227,6 +227,20 @@ services:
       # Disable Elasticsearch routing via Traefik in production (we enable it in development)
       - 'traefik.enable=false'
 
+  portainer:
+    image: portainer/portainer-ce:alpine
+    container_name: 'portainer'
+    command: -H unix:///var/run/docker.sock --admin-password-file '/data/portainer'
+    restart: unless-stopped
+    ports:
+      - 9000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../../config:/data
+      - ../../config/portainer:/data/portainer
+    depends_on:
+      - nginx
+
   # TODO: Kibana + APM, see https://github.com/Seneca-CDOT/telescope/blob/372a6076540351cd54d85478521bcfbe8edefc87/src/api/production.yml
 
 volumes:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #1744 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

- [] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds [portainer](https://www.portainer.io/) to `docker-compose` in production.
Originally, I thought about adding `portainer` _behind_ `traefik`, but that would prevent users from checking Telescope if/when `traefik` is down, so I decided to _hide_  `portainer` behind `nginx` (route `/portainer`).

To avoid having to set up an account at first launch, I added the possibility of storing a password in a text file (which could easily live in our staging and production servers), and `portainer` will read the file during deployment.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
