### PR TITLE
Fixes #2002: Don't center table contents in figure

### DIFF
--- a/src/web/src/styles/telescope-post-content.css
+++ b/src/web/src/styles/telescope-post-content.css
@@ -49,6 +49,10 @@
   text-align: center;
 }
 
+.telescope-post-content figure > table {
+  text-align: start;
+}
+
 .telescope-post-content img[src*='emoji'],
 .telescope-post-content img[src*='smileys'] {
   display: inline-block;


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #2002 

## Type of Change

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
Simple and small CSS addition in our `styles/telescope-post-content.css` to *undo* the centring of the text within the post when it comes to the content within a table.

| Before |
| :---: |
| ![issuepic](https://user-images.githubusercontent.com/427398/111876558-a48fd280-8975-11eb-8062-e203328c5327.png) |
| After |
| ![tablestuff](https://user-images.githubusercontent.com/48869737/112541517-dcd64d00-8d89-11eb-9376-b3630cdcec44.PNG) |


## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
