### PR TITLE
Fixes #1955: Replace normal hyphen with a non-breaking hyphen

### DIFF
--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -11,6 +11,9 @@ const useStyles = makeStyles((theme: Theme) =>
       flexDirection: 'column',
       justifyContent: 'center',
       borderLeft: '2.5px solid #707070',
+      [theme.breakpoints.up('lg')]: {
+        width: '22rem',
+      },
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #1955 

## Type of Change
- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
My name was being broken at the hyphen. I added a line of code to replace all instances of a normal hyphen within the author's name with a [non-breaking hyphen](https://www.toptal.com/designers/htmlarrows/punctuation/non-breaking-hyphen/). 

| Before |
| :---: |
| <img width="201" alt="Screen Shot 2021-03-15 at 8 59 02 PM" src="https://user-images.githubusercontent.com/60857409/111312117-5dcc7080-8635-11eb-83b7-1d600a3bc482.png"> |
| After |
| ![image](https://user-images.githubusercontent.com/48869737/112551887-2ded3d80-8d98-11eb-9a31-6a1df8f02254.png) |

It was [mentioned](https://github.com/Seneca-CDOT/telescope/issues/1955#issuecomment-800256159) in the original issue that a possible fix was to expand the author section, especially since there are other authors with even longer names so I messed around with expanding the width/ giving the authors section a minimum width. This created unintended side effects when resizing the screen to be smaller as the names would begin to clip into the right side of the screen. That being said I'd like to know what you guys think - I can file an issue to better display(?) longer names.

## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

## How to Test
View Vercel deployment and scroll down and see each name, when you see my name you will notice that my last name breaks as a whole instead of in the middle where the hyphen is.
