### PR TITLE
Closes Issue #1932: Added environment variables to prod's Docker file

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -93,8 +93,9 @@ IMAGE_URL=http://localhost/v1/image
 USERS_PORT=6666
 
 # Users Service URL
-USERS_URL=http://localhost/v1/user
-FIRESTORE_EMULATOR_HOST=localhost:8088
+USERS_URL=http://localhost/v1/users
+FIRESTORE_EMULATOR_HOST=firebase:8088
+
 
 ################################################################################
 # Posts Service

--- a/config/env.production
+++ b/config/env.production
@@ -116,19 +116,6 @@ MOCK_REDIS=
 # Users Service
 ################################################################################
 
-# Firebase's private api key. Used to authenticate telescope with firebase
-# See https://firebase.google.com/docs/admin/setup#initialize-sdk to obtain the key
-FIREBASE_TYPE=
-FIREBASE_PROJECT_ID=
-FIREBASE_PRIVATE_KEY_ID=
-FIREBASE_PRIVATE_KEY=
-FIREBASE_CLIENT_EMAIL=
-FIREBASE_CLIENT_ID=
-FIREBASE_AUTH_URI=
-FIREBASE_TOKEN_URI=
-FIREBASE_AUTH_PROVIDER_X509_CERT_URL=
-FIREBASE_CLIENT_X509_CERT_URL=
-
 # Users Service Port (default is 6666)
 USERS_PORT=6666
 

--- a/config/env.staging
+++ b/config/env.staging
@@ -118,24 +118,12 @@ MOCK_REDIS=
 # Users Service
 ################################################################################
 
-# Firebase's private api key. Used to authenticate telescope with firebase
-# See https://firebase.google.com/docs/admin/setup#initialize-sdk to obtain the key
-FIREBASE_TYPE=
-FIREBASE_PROJECT_ID=
-FIREBASE_PRIVATE_KEY_ID=
-FIREBASE_PRIVATE_KEY=
-FIREBASE_CLIENT_EMAIL=
-FIREBASE_CLIENT_ID=
-FIREBASE_AUTH_URI=
-FIREBASE_TOKEN_URI=
-FIREBASE_AUTH_PROVIDER_X509_CERT_URL=
-FIREBASE_CLIENT_X509_CERT_URL=
-
 # Users Service Port (Default is 6666)
 USERS_PORT=6666
 
 # Users Service URL
 USERS_URL=https://dev.api.telescope.cdot.systems/v1/users
+
 
 ################################################################################
 # Feed Discovery Service

--- a/docker/development.yml
+++ b/docker/development.yml
@@ -59,3 +59,7 @@ services:
   elasticsearch:
     ports:
       - '9200:9200'
+
+  users:
+    environment:
+      - FIRESTORE_EMULATOR_HOST

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -138,11 +138,13 @@ services:
     restart: unless-stopped
     environment:
       - NODE_ENV=production
-      - USERS_PORT
       # TODO
       # - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       # - ELASTIC_APM_SERVICE_NAME=user
       # - ELASTIC_APM_SERVER_URL=http://apm:8200
+    volumes:
+      # This will take care of copying the serviceAccountKey.json file needed by firestore.js
+      - ../../config/firebase:/app
 
   ##############################################################################
   # Third-Party Dependencies and Support Services

--- a/src/api/users/README.md
+++ b/src/api/users/README.md
@@ -44,15 +44,16 @@ npm install:users-service
 # normal mode
 npm start
 
-# running firestore emulator locally
+# running firestore emulator and users microservice locally
+npm run services:start firebase users
+
+# dev mode with automatic restarts
 npm run services:start firebase
-npm start
+cd src/api/users
+npm run dev
 
 # test runner (must be used in conjunction with the firebase service)
 npm run jest:e2e (or npm run jest:e2e src\api\users\test\e2e)
-
-# dev mode with automatic restarts
-npm run dev
 ```
 
 By default the server is running on <http://localhost:6666/>.

--- a/src/api/users/jest.config.e2e.js
+++ b/src/api/users/jest.config.e2e.js
@@ -1,8 +1,7 @@
-const path = require('path');
 const baseConfig = require('../../../jest.config.base');
-require('dotenv').config({
-  path: path.join(__dirname, '../../../config/env.development'),
-});
+
+// override to pass e2e tests
+process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8088';
 
 module.exports = {
   ...baseConfig,

--- a/src/api/users/package.json
+++ b/src/api/users/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node src/server.js",
-    "dev": "nodemon src/server.js"
+    "dev": "cross-env FIRESTORE_EMULATOR_HOST=localhost:8088 nodemon src/server.js"
   },
   "dependencies": {
     "@senecacdot/satellite": "^1.x",
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^1.2.2",
+    "cross-env": "^5.2.1",
     "dotenv": "^6.2.0",
     "firebase-tools": "^9.6.1",
     "nodemon": "^2.0.7",

--- a/src/api/users/src/services/firestore.js
+++ b/src/api/users/src/services/firestore.js
@@ -1,53 +1,28 @@
+/* eslint-disable global-require */
+/* eslint-disable import/no-unresolved */
+
 const admin = require('firebase-admin');
 const { logger } = require('@senecacdot/satellite');
 
-const {
-  FIREBASE_TYPE,
-  FIREBASE_PROJECT_ID,
-  FIREBASE_PRIVATE_KEY_ID,
-  FIREBASE_PRIVATE_KEY,
-  FIREBASE_CLIENT_EMAIL,
-  FIREBASE_CLIENT_ID,
-  FIREBASE_AUTH_URI,
-  FIREBASE_TOKEN_URI,
-  FIREBASE_AUTH_PROVIDER_X509_CERT_URL,
-  FIREBASE_CLIENT_X509_CERT_URL,
-} = process.env;
-
-// If a private key exists in env.development, run in online mode
-// else run in emulator mode
-if (
-  (FIREBASE_PRIVATE_KEY,
-  FIREBASE_PROJECT_ID,
-  FIREBASE_PRIVATE_KEY_ID,
-  FIREBASE_PRIVATE_KEY,
-  FIREBASE_CLIENT_EMAIL,
-  FIREBASE_CLIENT_ID,
-  FIREBASE_AUTH_URI,
-  FIREBASE_TOKEN_URI,
-  FIREBASE_AUTH_PROVIDER_X509_CERT_URL,
-  FIREBASE_CLIENT_X509_CERT_URL)
-) {
+try {
+  // Docker is responsible for putting this file in the root of the container
   admin.initializeApp({
-    credential: admin.credential.cert({
-      type: FIREBASE_TYPE,
-      project_id: FIREBASE_PROJECT_ID,
-      private_key_id: FIREBASE_PRIVATE_KEY_ID,
-      private_key: FIREBASE_PRIVATE_KEY,
-      client_email: FIREBASE_CLIENT_EMAIL,
-      client_id: FIREBASE_CLIENT_ID,
-      auth_uri: FIREBASE_AUTH_URI,
-      token_uri: FIREBASE_TOKEN_URI,
-      auth_provider_x509_cert_url: FIREBASE_AUTH_PROVIDER_X509_CERT_URL,
-      client_x509_cert_url: FIREBASE_CLIENT_X509_CERT_URL,
-    }),
+    credential: admin.credential.cert(require('../../serviceAccountKey.json')),
   });
+
   logger.debug('Server running in online mode');
-} else {
+} catch (err) {
+  if (process.env.NODE_ENV === 'production') {
+    logger.error({ err }, 'Unable to load Firebase config');
+    process.exit(1);
+  }
+
+  // In development, fall-back to use the emulator
   admin.initializeApp({
     projectId: 'telescope',
     credential: admin.credential.applicationDefault(),
   });
+
   logger.debug('Server running in emulator mode');
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes Issue #1932 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR adds the required environment variables for the Users MS to prod's Docker file. I added some test values and `console.log`'d them after running `docker-compose --env-file config/env.production up --build` and they all displayed just fine. Users should be set up and ready to go once we finally create a Firebase project for Telescope (_don't quote me on this._)

I also hardcoded an environment variable (`process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8088'`)in `firestore.js` which allows developers to test locally when using `npm run services:start firebase` and `cd src/api/users && npm run dev` together. This environment variable is only injected when running in dev mode.
To be completely honestly, it's hacky but I couldn't get get the dev version of the users ms to work when running via Docker, only when running using `npm run dev`. I'd love to spend some time with someone to try and figure this out (as well as properly test prod), _as it's worrisome that prod may not actually work_, but it is at least set up with this PR.
<!-- Please add a detailed description of what this PR does and why it is needed -->

![pic](https://user-images.githubusercontent.com/7242003/112560582-ed96bb00-8da9-11eb-91bb-fbe17d13ba1a.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
