### PR TITLE
Change color for search bar in dark mode

### DIFF
--- a/src/web/src/components/SearchBar.tsx
+++ b/src/web/src/components/SearchBar.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
       border: 'solid 1px transparent',
       transition: 'background-color .5s',
       '&:hover': {
-        backgroundColor: theme.palette.action.selected,
+        backgroundColor: theme.palette.type === 'light' ? '#ffffff' : '#000000',
         border: 'solid 1px #999999',
       },
       [theme.breakpoints.down('xs')]: {
@@ -85,7 +85,7 @@ const useStyles = makeStyles((theme: Theme) =>
     selectItem: {
       fontSize: '1.4rem',
       textTransform: 'capitalize',
-      color: theme.palette.primary.main,
+      color: '#121d59',
     },
   })
 );

--- a/src/web/src/components/SearchBar.tsx
+++ b/src/web/src/components/SearchBar.tsx
@@ -85,7 +85,7 @@ const useStyles = makeStyles((theme: Theme) =>
     selectItem: {
       fontSize: '1.4rem',
       textTransform: 'capitalize',
-      color: '#121d59',
+      color: theme.palette.primary.main,
     },
   })
 );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes: #2009

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
For #2009
![darkSearch](https://user-images.githubusercontent.com/50813726/112561040-c8ef1300-8daa-11eb-9781-07929201c178.gif)


I change the color of hovered search bar for dark mode to improve user accessibility, Please let me know if you have different thought of the color choosing, thanks!
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
