### PR TITLE
Improve user accessibility of link to AAA

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -166,10 +166,10 @@ const useStyles = makeStyles((theme: Theme) =>
       backgroundColor: theme.palette.background.default,
       width: '95%',
       '& a': {
-        color: theme.palette.type === 'dark' ? theme.palette.secondary.main : 'default',
+        color: theme.palette.type === 'dark' ? '#7BA4DB' : 'default',
       },
       '& a:visited': {
-        color: theme.palette.type === 'dark' ? 'grey' : 'default',
+        color: theme.palette.type === 'dark' ? '#CCA1A6' : 'default',
       },
     },
   })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes: #2003

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
I check the contrast ratio of our link in dark mode, both visited and unvisited link are not level AAA. (Current unvisited link color with background color has 6.68 which is only AA level)
Therefore, not only the visited link color that was mentioned in the issue #2003 , I also change the color of the unvisited link to meet AAA requirement. And, since the visited link color for light mode is a bit reddish purple, I change the visited link color in dark mode from grey to something red-purple-ish as well.

Please let me know if you have other thoughts about the color :smiley: 

Before
![image](https://user-images.githubusercontent.com/50813726/112576314-6c025580-8dc8-11eb-8141-f7f536dbb297.png)


After
![image](https://user-images.githubusercontent.com/50813726/112576111-0a41eb80-8dc8-11eb-8cdb-32075ef8be34.png)

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
