### PR TITLE
Added initial setup for Jest Snapshot testing

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
+  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript', 'next'],
   plugins: ['@babel/plugin-transform-runtime'],
 };

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "valid-url": "1.0.9"
   },
   "devDependencies": {
+    "@babel/core": "7.13.10",
     "@babel/plugin-transform-runtime": "7.13.10",
     "@babel/preset-env": "7.13.10",
     "@babel/preset-react": "7.12.13",
@@ -102,6 +103,7 @@
     "@typescript-eslint/parser": "4.17.0",
     "@vercel/node": "1.9.1",
     "babel-jest": "26.6.3",
+    "babel-preset-next": "1.4.0",
     "cross-env": "7.0.3",
     "eslint": "7.22.0",
     "eslint-config-airbnb": "18.2.1",

--- a/src/web/jest.config.js
+++ b/src/web/jest.config.js
@@ -3,8 +3,18 @@ const baseConfig = require('../../jest.config.base');
 module.exports = {
   ...baseConfig,
   preset: 'ts-jest',
+  testEnvironment: 'jsdom',
   rootDir: '../..',
   testMatch: ['<rootDir>/src/web/src/**/*.test.{ts,tsx}'],
   testPathIgnorePatterns: ['<rootDir>/src/web/.next', '<rootDir>/src/web/out'],
   collectCoverageFrom: ['src/**/*{ts,tsx}'],
+  transform: {
+    '^.+\\.(ts)$': 'ts-jest',
+    '^.+\\.(tsx)$': '<rootDir>/node_modules/babel-jest',
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/src/web/tsconfig.jest.json',
+    },
+  },
 };

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^14.14.28",
     "@types/react": "^17.0.2",
     "@types/react-material-ui-form-validator": "^2.1.0",
+    "@types/react-test-renderer": "^17.0.1",
     "@types/valid-url": "^1.0.3",
     "typescript": "^4.1.5"
   }

--- a/src/web/src/components/Logo.test.tsx
+++ b/src/web/src/components/Logo.test.tsx
@@ -1,0 +1,7 @@
+import TestRenderer from 'react-test-renderer';
+import Logo from './Logo';
+
+it('renders correctly', () => {
+  const tree = TestRenderer.create(<Logo height={50} width={50} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/web/src/components/__snapshots__/Logo.test.tsx.snap
+++ b/src/web/src/components/__snapshots__/Logo.test.tsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<img
+  alt="Telescope Logo"
+  height={50}
+  src="/logo.svg"
+  width={50}
+/>
+`;

--- a/src/web/tsconfig.jest.json
+++ b/src/web/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1970 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Added initial setup for Jest Snapshot testing. According to https://github.com/vercel/next.js/issues/8663, we need to use `"jsx": "react"` compiler for running Jest Snapshot tests properly. 
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
