### PR TITLE
CSS changes to author info section

### DIFF
--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -12,6 +12,9 @@ const useStyles = makeStyles((theme: Theme) =>
       flexDirection: 'column',
       justifyContent: 'center',
       width: '100%',
+      [theme.breakpoints.up('lg')]: {
+        width: '22rem',
+      },
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -10,10 +10,12 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
-      borderLeft: '2.5px solid #707070',
-      [theme.breakpoints.up('lg')]: {
-        width: '22rem',
-      },
+      marginBottom: '80vh',
+      opacity: '0.4',
+      transition: 'opacity .5s',
+      '&:hover': {
+        opacity: '1'
+      }
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',
@@ -30,12 +32,13 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     authorNameContainer: {
       width: '100%',
+      height: '3rem'
     },
     author: {
       width: '100%',
       wordWrap: 'break-word',
-      fontSize: '2em',
-      lineHeight: '1.5em',
+      fontSize: '1.6em',
+      lineHeight: '1em',
       fontWeight: 'bold',
       marginLeft: '.5em',
       color: theme.palette.text.primary,
@@ -49,7 +52,7 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     published: {
       marginLeft: '.5em',
-      fontSize: '1.5em',
+      fontSize: '1.2em',
       fontWeight: 'lighter',
       textDecoration: 'none',
       color: theme.palette.text.primary,
@@ -76,11 +79,11 @@ const PostDesktopInfo = ({ authorName, postDate, blogUrl, postUrl }: Props) => {
         <PostAvatar name={authorName} blog={blogUrl} />
       </div>
       <div className={classes.authorNameContainer}>
-        <h1 className={classes.author}>
+        <p className={classes.author}>
           <a className={classes.link} href={blogUrl}>
             {authorName}
           </a>
-        </h1>
+        </p>
       </div>
       <div>
         <a href={postUrl} rel="bookmark" className={classes.published}>

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -8,20 +8,15 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: '2rem',
       padding: '0',
       display: 'flex',
-      borderLeft: '2.5px solid #CBCBCB',
+      borderLeft: '1.5px solid #EEEEEE',
       flexDirection: 'column',
       justifyContent: 'center',
-      opacity: '0.7',
-      transition: 'opacity .5s',
-      '&:hover': {
-        opacity: '1'
-      }
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',
       shapeMargin: '1rem',
       borderRadius: '50%',
-      marginLeft: '1.5rem'
+      marginLeft: '1.5rem',
     },
     circle: {
       display: 'block',
@@ -34,7 +29,7 @@ const useStyles = makeStyles((theme: Theme) =>
     authorNameContainer: {
       width: '100%',
       height: '3rem',
-      marginLeft: '1.5rem'
+      marginLeft: '1.5rem',
     },
     author: {
       width: '100%',

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles((theme: Theme) =>
       marginLeft: '2rem',
       padding: '0',
       display: 'flex',
-      borderLeft: '1.5px solid #EEEEEE',
+      borderLeft: '1.5px solid #999999',
       flexDirection: 'column',
       justifyContent: 'center',
     },

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) =>
       shapeOutside: 'circle(50%) border-box',
       shapeMargin: '1rem',
       borderRadius: '50%',
-      marginLeft: '1.5rem',
+      marginLeft: '1rem',
     },
     circle: {
       display: 'block',

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -5,13 +5,13 @@ import AdminButtons from '../AdminButtons';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      margin: '0',
+      marginLeft: '2rem',
       padding: '0',
       display: 'flex',
+      borderLeft: '2.5px solid #CBCBCB',
       flexDirection: 'column',
       justifyContent: 'center',
-      marginBottom: '80vh',
-      opacity: '0.4',
+      opacity: '0.7',
       transition: 'opacity .5s',
       '&:hover': {
         opacity: '1'
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
       shapeOutside: 'circle(50%) border-box',
       shapeMargin: '1rem',
       borderRadius: '50%',
+      marginLeft: '1.5rem'
     },
     circle: {
       display: 'block',
@@ -32,7 +33,8 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     authorNameContainer: {
       width: '100%',
-      height: '3rem'
+      height: '3rem',
+      marginLeft: '1.5rem'
     },
     author: {
       width: '100%',
@@ -40,7 +42,6 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: '1.6em',
       lineHeight: '1em',
       fontWeight: 'bold',
-      marginLeft: '.5em',
       color: theme.palette.text.primary,
     },
     link: {
@@ -51,7 +52,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     published: {
-      marginLeft: '.5em',
+      marginLeft: '1.5rem',
       fontSize: '1.2em',
       fontWeight: 'lighter',
       textDecoration: 'none',

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles((theme: Theme) =>
       borderLeft: '1.5px solid #999999',
       flexDirection: 'column',
       justifyContent: 'center',
+      width: '100%',
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',


### PR DESCRIPTION
UPDATED 

Closes #1995 
- only show it clear on mouse hover, less distraction on both sides while reading

![Screen Shot 2021-03-26 at 1 09 34 PM](https://user-images.githubusercontent.com/10421864/112668418-df41b100-8e34-11eb-80da-0c73d06c18a8.jpg)

- add marginBottom to make 'sticky author info box' jump earlier (ugly to see both author close together on scrolling)
![Screen Shot 2021-03-26 at 1 15 45 PM](https://user-images.githubusercontent.com/10421864/112668912-6a22ab80-8e35-11eb-89f8-5f41b8cb9b01.jpg)

Update:
with Left align in blog content, the info section placed on the right doesn't seem right. It's better on the left of the blog instead: 

![Screen Shot 2021-04-03 at 1 59 55 PM](https://user-images.githubusercontent.com/10421864/113487327-75a15280-9485-11eb-82e8-cc9d7d9beb60.jpg)

![Screen Shot 2021-04-03 at 2 02 10 PM](https://user-images.githubusercontent.com/10421864/113487330-7803ac80-9485-11eb-92b1-c8f1c348a883.jpg)

The vertical separator bar is unnecessary and made it looks just unsightly in modern day design, or if you guys wanna keep it, leave it thin and use lighter color.

or remove it and add more margin between blog content (example for Medium)
![Screen Shot 2021-04-03 at 1 58 22 PM](https://user-images.githubusercontent.com/10421864/113487425-0f68ff80-9486-11eb-8f4d-94c2d1e84f80.jpg)


ALso about the Navigation menu, no matter what color you use, it will never pops out at first load + banner image in the current design. 
My suggestion: Return it back to horizontal top, hidden when scroll down and visible when scroll up. 