### PR TITLE
Fixes #1975: Decorate each post with a class that matches the blog host platform

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -184,6 +184,20 @@ const formatPublishedDate = (dateString: string) => {
   }).format(date);
 };
 
+const extractBlogClassName = (url: string) => {
+  const blogClassName = new URL(url).hostname;
+  if (blogClassName.endsWith('medium.com')) {
+    return 'is-medium';
+  }
+  if (blogClassName.endsWith('dev.to')) {
+    return 'is-devto';
+  }
+  if (blogClassName.endsWith('blogspot.com')) {
+    return 'is-blogspot';
+  }
+  return 'is-generic';
+};
+
 const PostComponent = ({ postUrl }: Props) => {
   const classes = useStyles();
   const theme = useTheme();
@@ -284,7 +298,7 @@ const PostComponent = ({ postUrl }: Props) => {
       <div className={classes.content}>
         <section
           ref={sectionEl}
-          className="telescope-post-content"
+          className={`telescope-post-content ${extractBlogClassName(post.url)}`}
           dangerouslySetInnerHTML={{ __html: post.html }}
         />
       </div>


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #1975 

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This essentially decorates `<section class="telescope-post-content">` with the blogging host platform name.  

**For example**, if the URL is `https://roycedev.medium.com/spending-the-weekend-thinking-575bcf535e58` it will extract **only** the `medium-com` and decorate the section class, like so:  `<section class="telescope-post-content medium-com">`  

![image](https://user-images.githubusercontent.com/48869737/112765438-3a150d00-8fdb-11eb-90be-b88e6f470aba.png)  

**Another example:**  
![image](https://user-images.githubusercontent.com/48869737/112765861-36828580-8fdd-11eb-8e0f-f3126360dad0.png)


This will allow greater CSS customization with each post since each blogging platform styles their blogs/layout differently.
In reference to  the BlogSpot issue (#2039), we can fix it by styling **only** BlogSpot images to not be inline.

## How to Test
1. View the changed files for syntax/logic errors and possible changes/suggestions
2. View Vercel deployment OR pull this pr onto your local machine via `gh pr checkout` (see [here](https://cli.github.com/manual/gh_pr_checkout))
3. Scroll down to any blog post, and right-click the *content* (not the title/author name, aim for the paragraphs) and click inspect
![image](https://user-images.githubusercontent.com/48869737/112765658-261ddb00-8fdc-11eb-9d8c-51e435768f03.png)
4. View the `<section>` tag and see the blogging host platform name within the `className` 
![image](https://user-images.githubusercontent.com/48869737/112765691-51a0c580-8fdc-11eb-8fec-78f61b260567.png)


## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
