### PR TITLE
env.development fix: ELASTIC_PORT was commented.

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -189,7 +189,7 @@ MOCK_REDIS=
 
 # Elasticsearch info
 ELASTIC_URL=http://127.0.0.1
-#ELASTIC_PORT=9200
+ELASTIC_PORT=9200
 # Max number of results per query
 #ELASTIC_MAX_RESULTS_PER_PAGE=5
 # Delay to check connectivity with Elasticsearch in ms


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
When we need to run the services connected with our backend ( `npm start` ) the connection with elasticsearch is not established because on our `env.development` file the elastic search port line is commented.


<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
