### PR TITLE
Expose JWT_ISSUER, JWT_AUDIENCE, and SECRET env vars to all services

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -40,7 +40,7 @@ services:
       - ELASTIC_PORT=9200
       - ELASTIC_URL=http://elasticsearch
       # Environment values we expect from our legacy .env file
-      - NODE_ENV
+      - NODE_ENV=production
       - PORT
       - POSTS_URL
       - API_URL
@@ -84,7 +84,15 @@ services:
       context: ../src/api/status
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV=production
       - STATUS_PORT
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
+      # TODO - add APM monitoring support for Satellite
+      # - ELASTIC_APM_SERVER_URL
+      # - ELASTIC_APM_SERVICE_NAME
     ports:
       - '${STATUS_PORT}'
     depends_on:
@@ -107,10 +115,13 @@ services:
     environment:
       - NODE_ENV=production
       - IMAGE_PORT
-      # TODO
-      # - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      # - ELASTIC_APM_SERVICE_NAME=image
-      # - ELASTIC_APM_SERVER_URL=http://apm:8200
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
+      # TODO - add APM monitoring support for Satellite
+      # - ELASTIC_APM_SERVER_URL
+      # - ELASTIC_APM_SERVICE_NAME
 
   # auth service
   auth:
@@ -119,7 +130,6 @@ services:
       - NODE_ENV=production
       - AUTH_PORT
       # TODO
-      # - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       # - ELASTIC_APM_SERVICE_NAME=auth
       # - ELASTIC_APM_SERVER_URL=http://apm:8200
 
@@ -129,20 +139,26 @@ services:
     environment:
       - NODE_ENV=production
       - POSTS_PORT
-      # TODO
-      # - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      # - ELASTIC_APM_SERVICE_NAME=posts
-      # - ELASTIC_APM_SERVER_URL=http://apm:8200
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
+      # TODO - add APM monitoring support for Satellite
+      # - ELASTIC_APM_SERVER_URL
+      # - ELASTIC_APM_SERVICE_NAME
 
   # users service
   users:
     restart: unless-stopped
     environment:
       - NODE_ENV=production
-      # TODO
-      # - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      # - ELASTIC_APM_SERVICE_NAME=user
-      # - ELASTIC_APM_SERVER_URL=http://apm:8200
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
+      # TODO - add APM monitoring support for Satellite
+      # - ELASTIC_APM_SERVER_URL
+      # - ELASTIC_APM_SERVICE_NAME
     volumes:
       # This will take care of copying the serviceAccountKey.json file needed by firestore.js
       - ../../firebase/serviceAccountKey.json:/app/serviceAccountKey.json


### PR DESCRIPTION
In Satellite we have `isAutenticated()` middleware that depends on a service knowing some info about our JWT setup.  Also, we're [adding the ability for a service token to be created in each service](https://github.com/Seneca-CDOT/satellite/pull/10), which means we need to share even more details with the services.  To do this, we expect environment variables to be set in Satellite.  Previously we weren't doing this, but this PR adds them in.

Future services will also require this (FYI @c3ho for Parser and @izhuravlev for Search).

We were also missing some `NODE_ENV=production` variables, which I've added.  They will always need to be `production` in production, so it's best to do it in the docker-compose file vs. the env.

Finally, I've stubbed out (with comments) the APM values we'll need later on when we add those, so it's clear what's missing.