### PR TITLE
Fix path issus in production

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -144,7 +144,7 @@ services:
       # - ELASTIC_APM_SERVER_URL=http://apm:8200
     volumes:
       # This will take care of copying the serviceAccountKey.json file needed by firestore.js
-      - ../../config/firebase:/app
+      - ../../firebase/serviceAccountKey.json:/app/serviceAccountKey.json
 
   ##############################################################################
   # Third-Party Dependencies and Support Services
@@ -238,8 +238,8 @@ services:
       - 9000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ../../config:/data
-      - ../../config/portainer:/data/portainer
+      - ../../portainer:/data
+      - ../../portainer/portainer:/data/portainer
     depends_on:
       - nginx
 


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This changes the path to the mapped directories used for the `portainer` and `users` services in `production.yml`. Instead of having everything in `config`, I think it's better to have separate directories.
Also, I added to `volumes` the name of the file where the settings for `firestore` are stored. It seems that mapping only the directory is not enough, it needs the name of the file.
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
