### PR TITLE
Increase letter-spacing for telescope-post-content

### DIFF
--- a/src/web/src/styles/telescope-post-content.css
+++ b/src/web/src/styles/telescope-post-content.css
@@ -6,6 +6,7 @@
   word-wrap: break-word;
   hyphens: auto;
   font-family: PT Serif, Serif;
+  letter-spacing: 0.5px;
 }
 
 .telescope-post-content p {


### PR DESCRIPTION
When I recommended `PT Serif`, I had seen it on Time.com, where they also use a bit more space between the letters.  I think this is a nice look, for example: https://time.com/5951490/covid-fourth-wave/

<img width="665" alt="Screen Shot 2021-03-31 at 4 04 12 PM" src="https://user-images.githubusercontent.com/427398/113204033-c2451d80-923a-11eb-9b4d-85fd4dafce87.png">

This duplicates the look for our text.