### PR TITLE
Fixes: #2062: Search bar fires a request on every entered letter

### DIFF
--- a/src/web/src/components/SearchProvider.tsx
+++ b/src/web/src/components/SearchProvider.tsx
@@ -7,6 +7,7 @@ type FilterProp = {
 
 export interface SearchContextInterface {
   text: string;
+  textParam: string;
   filter: FilterProp['filter'];
   showHelp: boolean;
   onTextChange: (value: string) => void;
@@ -16,6 +17,7 @@ export interface SearchContextInterface {
 
 const SearchContext = createContext<SearchContextInterface>({
   text: '',
+  textParam: '',
   filter: 'post',
   showHelp: true,
   onTextChange() {
@@ -72,7 +74,7 @@ const SearchProvider = ({ children }: Props) => {
 
   return (
     <SearchContext.Provider
-      value={{ text, showHelp, filter, onTextChange, onFilterChange, onSubmitHandler }}
+      value={{ text, textParam, showHelp, filter, onTextChange, onFilterChange, onSubmitHandler }}
     >
       {children}
     </SearchContext.Provider>

--- a/src/web/src/components/SearchResults.tsx
+++ b/src/web/src/components/SearchResults.tsx
@@ -51,13 +51,13 @@ const useStyles = makeStyles(() => ({
 
 const SearchResults = () => {
   const classes = useStyles();
-  const { text, filter } = useSearchValue();
+  const { textParam, filter } = useSearchValue();
 
   const prepareUrl = (index: number) =>
-    `${telescopeUrl}/query?text=${encodeURIComponent(text)}&filter=${filter}&page=${index}`;
+    `${telescopeUrl}/query?text=${encodeURIComponent(textParam)}&filter=${filter}&page=${index}`;
 
   // We only bother doing the request if we have something to search for.
-  const shouldFetch = () => text.length > 0;
+  const shouldFetch = () => textParam.length > 0;
   const { data, size, setSize, error } = useSWRInfinite(
     (index) => (shouldFetch() ? prepareUrl(index) : null),
     async (u) => {
@@ -92,7 +92,7 @@ const SearchResults = () => {
     );
   }
 
-  if (text.length && loading) {
+  if (textParam.length && loading) {
     return (
       <Container className={classes.searchResults}>
         <h1 className={classes.spinner}>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2062 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

I landed #2046 to create a search context. There was a bug I didn't catch where it would create a request on every entered letter instead of just waiting until the user press the enter key or clicks the search button. 

I included the textParam as a value in the SearchProvider which will ensure that SearchResults.tsx uses that property instead of text. Since the text value gets updated everytime a letter is entered, it would fire the async request to search for a post.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
