### PR TITLE
Update web deps + webpack version to 5

### DIFF
--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -49,4 +49,7 @@ module.exports = withMDX({
   poweredByHeader: false,
   reactStrictMode: true,
   trailingSlash: true,
+  future: {
+    webpack5: true,
+  },
 });

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -9,30 +9,30 @@
   },
   "dependencies": {
     "@fontsource/pt-serif": "^4.2.2",
-    "@fontsource/spartan": "^4.2.1",
-    "@material-ui/core": "^4.11.2",
+    "@fontsource/spartan": "^4.2.2",
+    "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@mdx-js/loader": "^1.6.22",
-    "@next/mdx": "^10.0.7",
+    "@next/mdx": "^10.1.3",
     "dotenv": "^8.2.0",
     "highlight.js": "10.7.1",
     "jwt-decode": "^3.1.2",
-    "material-ui-popup-state": "^1.7.1",
+    "material-ui-popup-state": "^1.8.0",
     "nanoid": "^3.1.22",
-    "next": "^10.0.7",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "next": "^10.1.3",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-material-ui-form-validator": "^2.1.4",
-    "react-use": "^17.1.1",
-    "swr": "^0.5.2",
+    "react-use": "^17.2.1",
+    "swr": "^0.5.5",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {
-    "@types/node": "^14.14.28",
-    "@types/react": "^17.0.2",
+    "@types/node": "^14.14.37",
+    "@types/react": "^17.0.3",
     "@types/react-material-ui-form-validator": "^2.1.0",
     "@types/react-test-renderer": "^17.0.1",
     "@types/valid-url": "^1.0.3",
-    "typescript": "^4.1.5"
+    "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
Updates our front-end web deps, and opts into the [new webpack5 stuff in next 10.1](https://nextjs.org/blog/next-10-1#3x-faster-refresh) for faster builds.