### PR TITLE
Fix search page for vercel.

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -42,6 +42,7 @@ services:
       # Environment values we expect from our legacy .env file
       - NODE_ENV
       - PORT
+      - POSTS_URL
       - API_URL
       - LOG_LEVEL
       - FEED_URL

--- a/src/backend/utils/indexer.js
+++ b/src/backend/utils/indexer.js
@@ -2,7 +2,7 @@ require('../lib/config');
 
 const { setIntervalAsync, clearIntervalAsync } = require('set-interval-async/dynamic');
 
-const { ELASTIC_MAX_RESULTS_PER_PAGE = 5 } = process.env;
+const { ELASTIC_MAX_RESULTS_PER_PAGE = 5, POSTS_URL = 'http://localhost/v1/posts' } = process.env;
 const { client } = require('../lib/elastic');
 const { logger } = require('./logger');
 
@@ -120,7 +120,7 @@ const search = async (
 
   return {
     results: hits.total.value,
-    values: hits.hits.map(({ _id }) => ({ id: _id, url: `/posts/${_id}` })),
+    values: hits.hits.map(({ _id }) => ({ id: _id, url: `${POSTS_URL}/${_id}` })),
   };
 };
 


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
[This change](https://github.com/Seneca-CDOT/telescope/commit/4536030133ae9390abcffc1c7cbdc027a0d16ed6) in `Timeline` is the reason why search doesn't work with `vercel`. The `posts` microservice send a full url to the front-end, but the search feature in the old back-end only sends `/posts/{id}`. This is a temporary fix until the search microservice is ready (#1802).

I tested this on our staging server and the search page works for all the rebased PRs.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
