### PR TITLE
Update DynamicImage

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -32,7 +32,6 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
-    "@material-ui/types": "^5.1.0",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/mdx": "^1.6.22",
     "@testing-library/react": "^11.2.6",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -32,6 +32,7 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
+    "@material-ui/types": "^5.1.0",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/mdx": "^1.6.22",
     "@testing-library/react": "^11.2.6",

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,7 +21,13 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage />
+      <DynamicImage filter />
+      <Typography variant="caption" className={classes.stats}>
+        This year 83 of us have written over 250K words and counting.{' '}
+        <Link href="/myfeeds">
+          <a className={classes.addYours}>Add yours!</a>
+        </Link>
+      </Typography>
     </div>
   );
 };

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,7 +21,7 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage filter />
+      <DynamicImage filter color="#000000" />
     </div>
   );
 };

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,13 +21,7 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage filter />
-      <Typography variant="caption" className={classes.stats}>
-        This year 83 of us have written over 250K words and counting.{' '}
-        <Link href="/myfeeds">
-          <a className={classes.addYours}>Add yours!</a>
-        </Link>
-      </Typography>
+      <DynamicImage />
     </div>
   );
 };

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,7 +21,7 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage />
+      <DynamicImage filter backgroundMode />
     </div>
   );
 };

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,7 +21,7 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage filter backgroundMode />
+      <DynamicImage />
     </div>
   );
 };

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,7 +21,7 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage />
+      <DynamicImage filter />
     </div>
   );
 };

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -21,7 +21,7 @@ const BannerDynamicText = () => {
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage filter color="#000000" />
+      <DynamicImage filter color="#000000" opacity=".75" />
     </div>
   );
 };

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -1,16 +1,16 @@
 import { makeStyles, useTheme } from '@material-ui/core';
-
 import { imageServiceUrl } from '../config';
-import { ThemeContext } from './ThemeProvider';
 
 type DynamicImageProps = {
   filter?: boolean;
   color?: string;
+  opacity?: string;
 };
 
 type DynamicImageStyles = {
   filter: string;
   color: string;
+  opacity: string;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -43,16 +43,17 @@ const useStyles = makeStyles((theme) => ({
     boxSizing: 'border-box',
     margin: 0,
     backgroundColor: ({ color }: DynamicImageStyles) => color,
-    opacity: '.75',
+    opacity: ({ opacity }: DynamicImageStyles) => opacity,
   },
 }));
 
-const DynamicImage = ({ filter, color }: DynamicImageProps) => {
+const DynamicImage = ({ filter, color, opacity }: DynamicImageProps) => {
   const theme = useTheme();
 
   const styles: DynamicImageStyles = {
     filter: filter ? 'block' : 'none',
     color: color ? color : theme.palette.background.default,
+    opacity: opacity ? opacity : '0',
   };
 
   const classes = useStyles(styles);

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -2,6 +2,12 @@ import { makeStyles } from '@material-ui/core/styles';
 
 import { imageServiceUrl } from '../config';
 
+type DynamicImageProps = {
+  filter?: boolean;
+  color?: string;
+  backgroundMode?: boolean;
+};
+
 const useStyles = makeStyles((theme) => ({
   img: {
     visibility: 'inherit',

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -1,39 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
+
 import { imageServiceUrl } from '../config';
-
-type DynamicImageProps = {
-  filter?: boolean;
-  color?: string;
-  backgroundMode?: boolean;
-};
-
-type StyleProps = {
-  customColor: boolean;
-  isBackground: boolean;
-  display: string;
-  backgroundColor: string;
-  zIndex: number;
-};
-
-const buildStyleProps = (propsToStyle: DynamicImageProps) => {
-  const stylesProps: StyleProps = {
-    customColor: false,
-    isBackground: false,
-    display: 'none',
-    backgroundColor: '',
-    zIndex: -1,
-  };
-  if (propsToStyle.filter) {
-    stylesProps.display = 'block';
-  }
-  if (propsToStyle.color) {
-    stylesProps.backgroundColor = propsToStyle.color;
-    stylesProps.customColor = true;
-  }
-  if (propsToStyle.backgroundMode) stylesProps.isBackground = true;
-
-  return stylesProps;
-};
 
 const useStyles = makeStyles((theme) => ({
   img: {
@@ -52,13 +19,9 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '100%',
     maxHeight: '100%',
     objectFit: 'cover',
-    zIndex: (stylesProps: StyleProps) => {
-      if (stylesProps.isBackground) return stylesProps.zIndex;
-      return { zIndex: 0 };
-    },
   },
   backdrop: {
-    display: (stylesProps) => stylesProps.display,
+    display: 'block',
     height: '100%',
     overflow: 'hidden',
     position: 'absolute',
@@ -68,21 +31,13 @@ const useStyles = makeStyles((theme) => ({
     right: 0,
     boxSizing: 'border-box',
     margin: 0,
-    backgroundColor: (stylesProps) => {
-      if (stylesProps.customColor) return stylesProps.backgroundColor;
-      return theme.palette.type === 'light' ? '#E5E5E5' : '#000000';
-    },
-    opacity: '.35',
-    zIndex: (stylesProps) => {
-      if (stylesProps.isBackground) return stylesProps.zIndex;
-      return { zIndex: 0 };
-    },
+    backgroundColor: '#000000',
+    opacity: '.75',
   },
 }));
 
-const DynamicImage = (dynamicImageProps: DynamicImageProps) => {
-  const stylesProps = buildStyleProps(dynamicImageProps);
-  const classes = useStyles(stylesProps);
+const DynamicImage = () => {
+  const classes = useStyles();
 
   return (
     <picture>

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -45,11 +45,11 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const DynamicImage = ({ filter }: DynamicImageProps) => {
-  const dynamicImageStyles: DynamicImageStyles = {
+  const styles: DynamicImageStyles = {
     filter: filter ? 'block' : 'none',
   };
 
-  const classes = useStyles(dynamicImageStyles);
+  const classes = useStyles(styles);
 
   return (
     <picture>

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -7,8 +7,16 @@ type DynamicImageProps = {
   backgroundMode?: boolean;
 };
 
+type StyleProps = {
+  customColor: boolean;
+  isBackground: boolean;
+  display: string;
+  backgroundColor: string;
+  zIndex: number;
+};
+
 const buildStyleProps = (propsToStyle: DynamicImageProps) => {
-  const stylesProps = {
+  const stylesProps: StyleProps = {
     customColor: false,
     isBackground: false,
     display: 'none',
@@ -44,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '100%',
     maxHeight: '100%',
     objectFit: 'cover',
-    zIndex: (stylesProps) => {
+    zIndex: (stylesProps: StyleProps) => {
       if (stylesProps.isBackground) return stylesProps.zIndex;
       return { zIndex: 0 };
     },

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -1,6 +1,31 @@
 import { makeStyles } from '@material-ui/core/styles';
-
 import { imageServiceUrl } from '../config';
+
+type DynamicImageProps = {
+  filter?: boolean;
+  color?: string;
+  backgroundMode?: boolean;
+};
+
+const buildStyleProps = (propsToStyle: DynamicImageProps) => {
+  const stylesProps = {
+    customColor: false,
+    isBackground: false,
+    display: 'none',
+    backgroundColor: '',
+    zIndex: -1,
+  };
+  if (propsToStyle.filter) {
+    stylesProps.display = 'block';
+  }
+  if (propsToStyle.color) {
+    stylesProps.backgroundColor = propsToStyle.color;
+    stylesProps.customColor = true;
+  }
+  if (propsToStyle.backgroundMode) stylesProps.isBackground = true;
+
+  return stylesProps;
+};
 
 const useStyles = makeStyles((theme) => ({
   img: {
@@ -19,9 +44,13 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '100%',
     maxHeight: '100%',
     objectFit: 'cover',
+    zIndex: (stylesProps) => {
+      if (stylesProps.isBackground) return stylesProps.zIndex;
+      return { zIndex: 0 };
+    },
   },
   backdrop: {
-    display: 'block',
+    display: (stylesProps) => stylesProps.display,
     height: '100%',
     overflow: 'hidden',
     position: 'absolute',
@@ -31,13 +60,21 @@ const useStyles = makeStyles((theme) => ({
     right: 0,
     boxSizing: 'border-box',
     margin: 0,
-    backgroundColor: '#000000',
-    opacity: '.75',
+    backgroundColor: (stylesProps) => {
+      if (stylesProps.customColor) return stylesProps.backgroundColor;
+      return theme.palette.type === 'light' ? '#E5E5E5' : '#000000';
+    },
+    opacity: '.35',
+    zIndex: (stylesProps) => {
+      if (stylesProps.isBackground) return stylesProps.zIndex;
+      return { zIndex: 0 };
+    },
   },
 }));
 
-const DynamicImage = () => {
-  const classes = useStyles();
+const DynamicImage = (dynamicImageProps: DynamicImageProps) => {
+  const stylesProps = buildStyleProps(dynamicImageProps);
+  const classes = useStyles(stylesProps);
 
   return (
     <picture>

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -1,11 +1,13 @@
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core';
 
 import { imageServiceUrl } from '../config';
 
 type DynamicImageProps = {
   filter?: boolean;
-  color?: string;
-  backgroundMode?: boolean;
+};
+
+type DynamicImageStyles = {
+  filter: string;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -27,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
     objectFit: 'cover',
   },
   backdrop: {
-    display: 'block',
+    display: ({ filter }: DynamicImageStyles) => filter,
     height: '100%',
     overflow: 'hidden',
     position: 'absolute',
@@ -42,8 +44,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const DynamicImage = () => {
-  const classes = useStyles();
+const DynamicImage = ({ filter }: DynamicImageProps) => {
+  const dynamicImageStyles: DynamicImageStyles = {
+    filter: filter ? 'block' : 'none',
+  };
+
+  const classes = useStyles(dynamicImageStyles);
 
   return (
     <picture>

--- a/src/web/src/components/DynamicImage.tsx
+++ b/src/web/src/components/DynamicImage.tsx
@@ -1,13 +1,16 @@
 import { makeStyles, useTheme } from '@material-ui/core';
 
 import { imageServiceUrl } from '../config';
+import { ThemeContext } from './ThemeProvider';
 
 type DynamicImageProps = {
   filter?: boolean;
+  color?: string;
 };
 
 type DynamicImageStyles = {
   filter: string;
+  color: string;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -39,14 +42,17 @@ const useStyles = makeStyles((theme) => ({
     right: 0,
     boxSizing: 'border-box',
     margin: 0,
-    backgroundColor: '#000000',
+    backgroundColor: ({ color }: DynamicImageStyles) => color,
     opacity: '.75',
   },
 }));
 
-const DynamicImage = ({ filter }: DynamicImageProps) => {
+const DynamicImage = ({ filter, color }: DynamicImageProps) => {
+  const theme = useTheme();
+
   const styles: DynamicImageStyles = {
     filter: filter ? 'block' : 'none',
+    color: color ? color : theme.palette.background.default,
   };
 
   const classes = useStyles(styles);

--- a/src/web/src/pages/signup.tsx
+++ b/src/web/src/pages/signup.tsx
@@ -246,7 +246,7 @@ const SignUpPage = () => {
       </Button>
       <div className={classes.root}>
         <div className={classes.imageContainer}>
-          <DynamicImage />
+          <DynamicImage filter color="#000000" />
         </div>
         {telescopeAccount.error && (
           <PopUp

--- a/src/web/src/pages/signup.tsx
+++ b/src/web/src/pages/signup.tsx
@@ -246,7 +246,7 @@ const SignUpPage = () => {
       </Button>
       <div className={classes.root}>
         <div className={classes.imageContainer}>
-          <DynamicImage filter color="#000000" />
+          <DynamicImage filter color="#000000" opacity=".75" />
         </div>
         {telescopeAccount.error && (
           <PopUp


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
No open issue. 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
As we move towards 2.0, in order to achieve best results for our UI this PR will upgrade our `<DynamicImage>`.

Right now `<DynamicImage>` is only used on our old landing page, but in order to use it properly in other pages or components I made some upgrades, now `<DynamicImage>` accepts some args.


 filter?: boolean;
  color?:string;
  ~~backgroundMode?: boolean;~~

`<DynamicImage filter>` will render the DynamicImage that we use now the filter will use the theme color.
~~`<DynamicImage backgroundMode>` will render the DynamicImage without a filter and it will set the `Zindex:-1` so we can use the image for backgrounds easier.~~
`<DynamicImage filter color="<string>">` will render the DynamicImage with the filter set to the color that you are passing as a string, it can be something like `'yellow'` or a color HEX value.

You can combine the arguments like `<DynamicImage filter color="blue">`

To test you can pull the PR and create a page and play with the `<DynamicImage>`

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
