### PR TITLE
Rework User to use proper JWT payload data

### DIFF
--- a/src/web/src/User.ts
+++ b/src/web/src/User.ts
@@ -1,20 +1,46 @@
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 
+interface TelescopeJwtPayload extends JwtPayload {
+  name: string;
+  picture?: string;
+  roles: Array<string>;
+}
+
+// Check if the expiry time in seconds is missing or has passed.
+const isExpired = (exp?: number) => typeof exp === 'undefined' || new Date().getTime() / 1000 > exp;
+
 export default class User {
   constructor(
-    public id: string,
     public email: string,
     public name: string,
-    public isAdmin: boolean
+    // If the user has a Telescope account
+    public isRegistered: boolean,
+    // If the user is a Telescope admin
+    public isAdmin: boolean,
+    // Not every user has a picture (only registered Telescope users)
+    public avatarUrl?: string
   ) {}
 
   // Will throw InvalidTokenError if accessToken can't be parsed
   static fromToken(token: string): User {
-    const decoded: JwtPayload = jwtDecode(token);
+    // Decode to get payload
+    const decoded: TelescopeJwtPayload = jwtDecode(token);
     if (!decoded.sub) {
       throw new Error('invalid token');
     }
-    // TODO: we need admin info...
-    return new User('id', decoded.sub, 'Username', false);
+
+    // Make sure it hasn't expired
+    if (isExpired(decoded.exp)) {
+      throw new Error('token expired');
+    }
+
+    // Otherwise, return a new User based on this data
+    return new User(
+      decoded.sub,
+      decoded.name,
+      decoded.roles.includes('telescope'),
+      decoded.roles.includes('admin'),
+      decoded.picture
+    );
   }
 }

--- a/src/web/src/components/BannerButtons.tsx
+++ b/src/web/src/components/BannerButtons.tsx
@@ -58,7 +58,7 @@ const LandingButtons = () => {
           >
             Sign out
           </Button>
-          <PostAvatar name={user.name} />
+          <PostAvatar name={user.name} img={user.avatarUrl} />
         </>
       ) : (
         <>


### PR DESCRIPTION
This updates our JWT parser to get the user's name, authorization roles, and avatar image URL (if present) from the access token.  It depends on #2058 for the changes to the JWT payload.

One thing this will also add is the ability to do this:

```js
const { user } = useAuth();

if(user?.isAdmin) {
  // do stuff for an admin
}

if(user?.isRegistered) {
  // do stuff for a Telescope user who isn't an admin
}

if(user) {
  // do stuff for a Seneca SSO user, who hasn't registered yet
}
```