### PR TITLE
Add e2e test for signup flow in auth + user services

### DIFF
--- a/src/api/auth/test/e2e/signup-flow.test.js
+++ b/src/api/auth/test/e2e/signup-flow.test.js
@@ -1,0 +1,187 @@
+// NOTE: you need to run the auth and login services in docker for these to work
+const { chromium } = require('playwright');
+const { decode } = require('jsonwebtoken');
+const { createServiceToken, hash } = require('@senecacdot/satellite');
+const fetch = require('node-fetch');
+
+const { USERS_URL } = process.env;
+
+// Delete the Telescope user we created in the Users service.
+const cleanupTelescopeUser = () =>
+  Promise.all(
+    ['user1@example.com', 'hans-lippershey@example.com'].map((email) =>
+      fetch(`${USERS_URL}/${hash(email)}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `bearer ${createServiceToken()}`,
+        },
+      })
+    )
+  );
+
+describe('Signup Flow', () => {
+  let browser;
+  let context;
+  let page;
+
+  beforeAll(async () => {
+    // Make sure the user account we want to use for signup isn't already there.
+    await cleanupTelescopeUser();
+    // Use launch({ headless: false, slowMo: 500 }) as options to debug
+    browser = await chromium.launch();
+  });
+  afterAll(async () => {
+    await browser.close();
+    await cleanupTelescopeUser();
+  });
+
+  beforeEach(async () => {
+    context = await browser.newContext();
+    page = await browser.newPage();
+    await page.goto(`http://localhost:8888/`);
+  });
+  afterEach(async () => {
+    await context.close();
+    await page.close();
+  });
+
+  // Get the access_token and state from the URL, and parse the token as JWT if present
+  const getTokenAndState = () => {
+    const params = new URL(page.url()).searchParams;
+    const accessToken = params.get('access_token');
+    const state = params.get('state');
+
+    return { accessToken, state, jwt: accessToken ? decode(accessToken) : null };
+  };
+
+  // Do a complete login flow with the username/password and return token and state
+  const login = async (username, password) => {
+    // Click login button and then wait for the login page to load
+    await Promise.all([
+      page.waitForNavigation({
+        url: /simplesaml\/module\.php\/core\/loginuserpass\.php/,
+        waitUtil: 'networkidle',
+      }),
+      page.click('#login'),
+    ]);
+
+    // Fill the login form, star with username
+    await page.click('input[name="username"]');
+    await page.fill('input[name="username"]', username);
+    // Now enter the password
+    await page.click('input[name="password"]');
+    await page.fill('input[name="password"]', password);
+
+    // Click login button and then wait for the new page to load
+    await Promise.all([
+      page.waitForNavigation({
+        url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
+        waitUtil: 'load',
+      }),
+      page.click('text=/.*Login.*/'),
+    ]);
+
+    // The token and state will get returned on the query string
+    return getTokenAndState();
+  };
+
+  // Logout flow, assumes user is logged in already
+  const logout = async () => {
+    // Click logout and we should get navigated back to this page right away
+    await Promise.all([
+      page.waitForNavigation({
+        url: /^http:\/\/localhost:\d+\/\?state=/,
+        waitUtil: 'load',
+      }),
+      page.click('#logout'),
+    ]);
+
+    // The token and state will get returned on the query string
+    return getTokenAndState();
+  };
+
+  it('signup flow works to login and register a new Telescope user', async () => {
+    // The user info we'll use to register. We have the following user in our login
+    // SSO already:
+    //
+    // | Username    | Email                       | Password  | Display Name    |
+    // |-------------|-----------------------------|-----------|-----------------|
+    // | lippersheyh | hans-lippershey@example.com | telescope | Hans Lippershey |
+    const user = {
+      firstName: 'Hans',
+      lastName: 'Lippershey',
+      email: 'hans-lippershey@example.com',
+      displayName: 'Hans Lippershey',
+      isAdmin: false,
+      isFlagged: false,
+      feeds: ['https://imaginary.blog.com/feed/hans'],
+      github: {
+        username: 'hlippershey',
+        avatarUrl:
+          'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
+      },
+    };
+
+    // Part 1: login using SSO, as a user who does not have a Telescope account.
+    // Confirm that the payload of the token we get back matches what we expect.
+    // NOTE: the data comes from config/simplesamlphp-users.php.
+    async function partOne() {
+      const { accessToken, jwt } = await login('lippersheyh', 'telescope');
+
+      // Step 2: confirm the token's payload for this user
+      expect(jwt.sub).toEqual(user.email);
+      expect(jwt.name).toEqual(user.displayName);
+      expect(jwt.roles).toEqual(['seneca']);
+      expect(jwt.picture).toBe(undefined);
+
+      return { accessToken, jwt };
+    }
+
+    // Part 2: use the access token to POST to the Users service in order to
+    // register with Telescope.
+    async function partTwo(accessToken, jwt) {
+      const res = await fetch(`${USERS_URL}/${hash(jwt.sub)}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(user),
+      });
+      expect(res.ok).toBe(true);
+    }
+
+    // Part 3: logout so we can try logging in again as a registered user.
+    // Confirm that the token payload matches our upgraded user status.
+    // Confirm that the data in the Users service for this user
+    // matches what we expect, and that our token allows us to access it.
+    async function partThree() {
+      // Logout
+      await logout();
+
+      // Login again
+      const { accessToken, jwt } = await login('lippersheyh', 'telescope');
+
+      // Check token payload, make sure it matches what we expect
+      expect(jwt.sub).toEqual(user.email);
+      expect(jwt.name).toEqual(user.displayName);
+      expect(jwt.roles).toEqual(['seneca', 'telescope']);
+      expect(jwt.picture).toEqual(user.github.avatarUrl);
+
+      // See if we can use this token to talk to the Users service, confirm our data.
+      const res = await fetch(`${USERS_URL}/${hash(jwt.sub)}`, {
+        headers: {
+          Authorization: `bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(res.ok).toBe(true);
+      const data = await res.json();
+      expect(data).toEqual(user);
+    }
+
+    const { accessToken, jwt } = await partOne();
+    await partTwo(accessToken, jwt);
+    await partThree();
+  });
+});

--- a/src/api/auth/test/e2e/utils.js
+++ b/src/api/auth/test/e2e/utils.js
@@ -1,0 +1,106 @@
+// Common utility functions and data for the auth tests
+const { decode } = require('jsonwebtoken');
+const { createServiceToken, hash } = require('@senecacdot/satellite');
+const fetch = require('node-fetch');
+
+// In tests, we need to hit this via a public URL like the front-end would
+// vs. the internal Docker URL, which the services use from the regular env value.
+const USERS_URL = `http://localhost/v1/users`;
+
+const createTelescopeUsers = (users) =>
+  Promise.all(
+    users.map((user) =>
+      fetch(`${USERS_URL}/${hash(user.email)}`, {
+        method: 'post',
+        headers: {
+          Authorization: `bearer ${createServiceToken()}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(user),
+      })
+        .then((res) => {
+          // We should get a 201 (created), but if the user exists, a 400 (which is fine here)
+          if (!(res.status === 201 || res.status === 400)) {
+            throw new Error(`got unexpected status ${res.status}`);
+          }
+        })
+        .catch((err) => {
+          console.error('Unable to create user with Users service', { err });
+        })
+    )
+  );
+
+// Delete the Telescope users we created in the Users service.
+const cleanupTelescopeUsers = (users) =>
+  Promise.all(
+    users.map((user) =>
+      fetch(`${USERS_URL}/${hash(user.email)}`, {
+        method: 'delete',
+        headers: {
+          Authorization: `bearer ${createServiceToken()}`,
+        },
+      })
+    )
+  );
+
+// Get the access_token and state from the URL, and parse the token as JWT if present
+const getTokenAndState = (page) => {
+  const params = new URL(page.url()).searchParams;
+  const accessToken = params.get('access_token');
+  const state = params.get('state');
+
+  return { accessToken, state, jwt: accessToken ? decode(accessToken) : null };
+};
+
+// Do a complete login flow with the username/password and return token and state
+const login = async (page, username, password) => {
+  // Click login button and then wait for the login page to load
+  await Promise.all([
+    page.waitForNavigation({
+      url: /simplesaml\/module\.php\/core\/loginuserpass\.php/,
+      waitUtil: 'networkidle',
+    }),
+    page.click('#login'),
+  ]);
+
+  // Fill the login form, star with username
+  await page.click('input[name="username"]');
+  await page.fill('input[name="username"]', username);
+  // Now enter the password
+  await page.click('input[name="password"]');
+  await page.fill('input[name="password"]', password);
+
+  // Click login button and then wait for the new page to load
+  await Promise.all([
+    page.waitForNavigation({
+      url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
+      waitUtil: 'load',
+    }),
+    page.click('text=/.*Login.*/'),
+  ]);
+
+  // The token and state will get returned on the query string
+  return getTokenAndState(page);
+};
+
+// Logout flow, assumes user is logged in already
+const logout = async (page) => {
+  // Click logout and we should get navigated back to this page right away
+  await Promise.all([
+    page.waitForNavigation({
+      url: /^http:\/\/localhost:\d+\/\?state=/,
+      waitUtil: 'load',
+    }),
+    page.click('#logout'),
+  ]);
+
+  // The token and state will get returned on the query string
+  return getTokenAndState(page);
+};
+
+module.exports.USERS_URL = USERS_URL;
+module.exports.createTelescopeUsers = createTelescopeUsers;
+module.exports.cleanupTelescopeUsers = cleanupTelescopeUsers;
+module.exports.getTokenAndState = getTokenAndState;
+module.exports.login = login;
+module.exports.logout = logout;

--- a/src/api/users/package.json
+++ b/src/api/users/package.json
@@ -13,7 +13,7 @@
     "http-link-header": "^1.0.3"
   },
   "devDependencies": {
-    "@firebase/rules-unit-testing": "^1.2.8",
+    "@firebase/rules-unit-testing": "^1.2.9",
     "env-cmd": "^10.1.0",
     "firebase-tools": "^9.9.0",
     "nodemon": "^2.0.7",

--- a/src/api/users/src/routes/users.js
+++ b/src/api/users/src/routes/users.js
@@ -21,7 +21,7 @@ router.get(
   validateId(),
   isAuthorized((req, user) => {
     // A user can request their own data
-    if (user.sub === req.param.id) {
+    if (user.sub === req.params.id) {
       return true;
     }
     // Or an admin, or another authorized microservice
@@ -93,7 +93,7 @@ router.post(
   validateEmailHash(),
   isAuthorized((req, user) => {
     // A user can add their own data (signup)
-    if (user.sub === req.param.id) {
+    if (user.sub === req.params.id) {
       return true;
     }
     // Or an admin, or another authorized microservice
@@ -130,7 +130,7 @@ router.put(
   validateEmailHash(),
   isAuthorized((req, user) => {
     // A user can update their own data
-    if (user.sub === req.param.id) {
+    if (user.sub === req.params.id) {
       return true;
     }
     // Or an admin, or another authorized microservice
@@ -166,7 +166,7 @@ router.delete(
   validateId(),
   isAuthorized((req, user) => {
     // A user can delete their own data
-    if (user.sub === req.param.id) {
+    if (user.sub === req.params.id) {
       return true;
     }
     // Or an admin, or another authorized microservice


### PR DESCRIPTION
We're getting really close to being able to support login + signup in the microservices.  I wanted to get a complete e2e test written that would allow us to see if it's working properly.

This test won't pass yet, since it requires a few more pieces (authenticated routes, #2058, etc).  However, I wanted to get it written before I forgot and while I had time.