### PR TITLE
Closes #2083: Migrate legacy accounts away from wiki

### DIFF
--- a/tools/migrate/.gitignore
+++ b/tools/migrate/.gitignore
@@ -1,0 +1,1 @@
+legacy_users.json

--- a/tools/migrate/README.md
+++ b/tools/migrate/README.md
@@ -1,0 +1,24 @@
+# Planet CDOT Feed List migration tool
+
+This tool downloads all users from the wiki page and dumps them into a JSON file.
+
+## Customization
+
+In `migrage.js` you can find the following two variables: `FEED_URL` and `FILE_NAME`.
+
+- `FEED_URL` points to the current location of the [Planet CDOT Feed List](https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List#Feeds)
+- `FILE_NAME` allows users to specify the desired filename of the output file
+
+## Install Dependencies
+
+```
+cd src/tools/migrate
+npm install
+```
+
+## Usage
+
+```
+cd src/tools/migrate
+npm start
+```

--- a/tools/migrate/migrate.js
+++ b/tools/migrate/migrate.js
@@ -1,0 +1,65 @@
+const fetch = require('node-fetch');
+const jsdom = require('jsdom');
+const { isWebUri } = require('valid-url');
+const fs = require('fs');
+
+const { JSDOM } = jsdom;
+const URL = 'https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List';
+const FILE = 'legacy_users.json';
+
+const getWikiText = async (url) => {
+  try {
+    const response = await fetch(url);
+    const data = await response.text();
+
+    const dom = new JSDOM(data);
+    return dom.window.document.querySelector('pre').textContent;
+  } catch {
+    throw new Error(`Unable to download wiki feed data from url ${url}`);
+  }
+};
+
+(async () => {
+  let wikiText;
+
+  // Try to fetch the feed list from 'FEED_URL'
+  try {
+    wikiText = await getWikiText(URL);
+    console.info(`Extracting users from ${URL}`);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+
+  // store every line in an array
+  const lines = wikiText.split(/\r\n|\r|\n/);
+  const commentRegex = /^\s*#/;
+
+  let firstName;
+  let lastName;
+  let feed;
+  const users = [];
+
+  // Iterate through all lines and find url/name pairs, then parse them.
+  lines.forEach((line, index) => {
+    if (!commentRegex.test(line) && line.startsWith('[')) {
+      feed = line.replace(/[[\]']/g, '');
+
+      if (feed.length && isWebUri(feed)) {
+        [firstName, lastName] = lines[index + 1].replace(/^\s*name\s*=\s*/, '').split(' ');
+        users.push({ firstName, lastName, feed });
+      } else {
+        console.error(`Skipping invalid wiki feed url ${feed} for author ${firstName} ${lastName}`);
+      }
+    }
+  });
+
+  try {
+    fs.writeFileSync(`${FILE}`, JSON.stringify(users));
+    console.log(
+      `Processed ${users.length} records. Legacy users were successfully written to file: ${FILE}.`
+    );
+  } catch (err) {
+    console.error(err);
+  }
+})();

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "migrate",
+  "version": "1.0.0",
+  "description": "Migrates users from the planet feed wiki list to a JSON file.",
+  "main": "migrate.js",
+  "scripts": {
+    "start": "node migrate.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jsdom": "^16.5.2",
+    "node-fetch": "^2.6.1",
+    "valid-url": "^1.0.9"
+  }
+}


### PR DESCRIPTION
Co-authored-by: Josue <manekenpix@users.noreply.github.com>

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #2083
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This tool fetches legacy users from the planet feed wiki list, parses them, and dumps to a JSON file for later use (in the parsing service).

## How to test
1. `gh pr checkout 2096`
2. `cd src\api\users\tools\migrate`
3. `npm install`
4. `npm start`

The users are dumped to `src\api\users\tools\migrate\legacy_users.json`
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
