### PR TITLE
Fix login on localhost, add WEB_URL env variable support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ ARG API_URL
 ARG IMAGE_URL
 ARG AUTH_URL
 ARG POSTS_URL
+# Front-end Web URL, set via ENV in docker or next build
+ARG WEB_URL
 
 # Context: Build Context
 FROM node:lts-alpine as build
@@ -43,6 +45,7 @@ ARG API_URL
 ARG IMAGE_URL
 ARG AUTH_URL
 ARG POSTS_URL
+ARG WEB_URL
 
 # Install Production Modules!
 # Disable postinstall hook in this case since we are being explict with installs
@@ -69,6 +72,9 @@ ENV NEXT_PUBLIC_AUTH_URL ${AUTH_URL}
 
 ARG POSTS_URL
 ENV NEXT_PUBLIC_POSTS_URL ${POSTS_URL}
+
+ARG WEB_URL
+ENV NEXT_PUBLIC_WEB_URL ${WEB_URL}
 
 COPY ./src/web ./src/web
 COPY ./.git ./.git

--- a/config/env.development
+++ b/config/env.development
@@ -20,6 +20,11 @@ TELESCOPE_HOST=http://localhost:3000
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=http://localhost
 
+# Front-end web URL (entry point to the next.js app). Make sure that the
+# ALLOWED_APP_ORIGINS variable below includes this URL, so that the Auth
+# service will allow redirects back to this origin.
+WEB_URL=http://localhost:8000
+
 # The API Version, used as a prefix on all routes: /v1
 API_VERSION=v1
 

--- a/config/env.production
+++ b/config/env.production
@@ -20,6 +20,11 @@ TELESCOPE_HOST=telescope.cdot.systems
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=api.telescope.cdot.systems
 
+# Front-end web URL (entry point to the next.js app). Make sure that the
+# ALLOWED_APP_ORIGINS variable below includes this URL, so that the Auth
+# service will allow redirects back to this origin.
+WEB_URL=https://telescope.cdot.systems
+
 # Path to certificates
 PATH_TO_CERTS=
 

--- a/config/env.staging
+++ b/config/env.staging
@@ -20,6 +20,11 @@ TELESCOPE_HOST=dev.telescope.cdot.systems
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=dev.api.telescope.cdot.systems
 
+# Front-end web URL (entry point to the next.js app). Make sure that the
+# ALLOWED_APP_ORIGINS variable below includes this URL, so that the Auth
+# service will allow redirects back to this origin.
+WEB_URL=https://dev.telescope.cdot.systems
+
 # Path to certificates
 PATH_TO_CERTS=
 

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -21,6 +21,8 @@ services:
       dockerfile: Dockerfile
       # next.js needs build-time access to a number of API URL values, forward as ARGs
       args:
+        # Web front-end URL
+        - WEB_URL=${WEB_URL}
         # Telescope 1.0 API URL
         - API_URL=${API_URL}
         # Telescope 2.0 Microservice URLs
@@ -44,6 +46,7 @@ services:
       - PORT
       - POSTS_URL
       - API_URL
+      - WEB_URL
       - LOG_LEVEL
       - FEED_URL
       - FEED_URL_INTERVAL_MS

--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -13,7 +13,7 @@ const dotenv = require('dotenv');
 const loadApiUrlFromEnv = (envFile) => dotenv.config({ path: envFile });
 
 // ENV Variables we need to forward to next by prefix with NEXT_PUBLIC_*
-const envVarsToForward = ['API_URL', 'IMAGE_URL', 'POSTS_URL', 'AUTH_URL'];
+const envVarsToForward = ['WEB_URL', 'API_URL', 'IMAGE_URL', 'POSTS_URL', 'AUTH_URL'];
 
 // Copy an existing ENV Var so it's visible to next: API_URL -> NEXT_PUBLIC_API_URL
 const forwardToNext = (envVar) => {

--- a/src/web/src/components/AuthProvider.tsx
+++ b/src/web/src/components/AuthProvider.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import { nanoid } from 'nanoid';
 
 import User from '../User';
-import { loginUrl, logoutUrl, telescopeUrl } from '../config';
+import { loginUrl, logoutUrl, webUrl } from '../config';
 
 export interface AuthContextInterface {
   login: (returnTo?: string) => void;
@@ -98,7 +98,7 @@ const AuthProvider = ({ children }: Props) => {
     setAuthState(loginState);
 
     // Set our return URL
-    const url = new URL(returnTo || '', telescopeUrl);
+    const url = new URL(returnTo || '', webUrl);
     window.location.href = `${loginUrl}?redirect_uri=${url.href}&state=${loginState}`;
   };
 
@@ -108,7 +108,7 @@ const AuthProvider = ({ children }: Props) => {
     removeAuthState();
 
     // Redirect to logout
-    window.location.href = `${logoutUrl}?redirect_uri=${telescopeUrl}`;
+    window.location.href = `${logoutUrl}?redirect_uri=${webUrl}`;
   };
 
   return (

--- a/src/web/src/components/SEO.tsx
+++ b/src/web/src/components/SEO.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { telescopeUrl } from '../config';
+import { webUrl } from '../config';
 
 type SEOProps = {
   pageTitle: string;
@@ -8,8 +8,8 @@ type SEOProps = {
 
 const SEO = ({ pageTitle }: SEOProps) => {
   const { pathname } = useRouter();
-  const currentUrl = `${telescopeUrl}${pathname}`;
-  // This variable explicitly points to our production API_URL.
+  const currentUrl = `${webUrl}${pathname}`;
+  // This variable explicitly points to our production web URL.
   // For reference, see https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#rel-canonical-header-method
   const canonicalUrl = `https://telescope.cdot.systems${pathname}`;
 

--- a/src/web/src/config.ts
+++ b/src/web/src/config.ts
@@ -1,6 +1,20 @@
 // This comes via the top level .env and its API_URL value,
 // and gets set in next.config.js at build time.
+
+// The URL to use when accessing the Telescope 1.0 backend APIs
 const telescopeUrl = process.env.NEXT_PUBLIC_API_URL;
+
+// The URL where our front-end is being hosted. If we don't have a URL,
+// we use the current page's, and include a fallback of '/' for server-side rendering.
+const webUrl =
+  // Either we have it defined via Docker env,
+  process.env.NEXT_PUBLIC_WEB_URL ||
+  // Or we're in Vercel, and the host provides it,
+  process.env.VERCEL_URL ||
+  // Or we need to make a guess.
+  (typeof window !== 'undefined' ? window.location.href : '/');
+
+// The various Telescope 2.0 microservice endpoints we use
 const imageServiceUrl = process.env.NEXT_PUBLIC_IMAGE_URL;
 const authServiceUrl = process.env.NEXT_PUBLIC_AUTH_URL;
 const postsServiceUrl = process.env.NEXT_PUBLIC_POSTS_URL;
@@ -22,6 +36,7 @@ export {
   description,
   author,
   telescopeUrl,
+  webUrl,
   imageServiceUrl,
   loginUrl,
   logoutUrl,

--- a/src/web/src/pages/error.tsx
+++ b/src/web/src/pages/error.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { Card, CardActions, CardContent, Fab, Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import ArrowBack from '@material-ui/icons/ArrowBack';
-import { telescopeUrl } from '../config';
+import { webUrl } from '../config';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -141,7 +141,7 @@ const ErrorPage = () => {
   const classes = useStyles();
   const router = useRouter();
 
-  const location = new URL(router.asPath, telescopeUrl);
+  const location = new URL(router.asPath, webUrl);
   const params = new URLSearchParams(location.search);
 
   const status = params.get('status') ? Number(params.get('status')) : null;


### PR DESCRIPTION
@PedroFonsecaDEV let me know about a bug locally with login/logout.  Currently, the auth redirect logic is using the Telescope 1.0 API backend URL (http://localhost:3000) as the front-end, but when you run the front-end on http://localhost:8000 it breaks.

This adds a new variable to our environment, `WEB_URL`, allowing us to explicitly set the URL where our front-end is hosted.