### PR TITLE
Update access token with more user details for front-end

### DIFF
--- a/config/simplesamlphp-users.php
+++ b/config/simplesamlphp-users.php
@@ -16,13 +16,13 @@ $config = array(
             'uid' => array('1'),
             'eduPersonAffiliation' => array('group1'),
             /*
-              NOTE: we need both `email` and `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
-              for each user.  The `email` will be used for nameID, the `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`
-              will be added to the profile to match what we get back from Seneca's IdP.  Make sure these
-              match for both fields on every user.
+              NOTE: we add a bunch of claims that we expect to get back from Seneca,
+              and need to simulate here.
             */
             'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress' => 'user1@example.com',
             'email' => 'user1@example.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => 'Johannes',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname' => 'Kepler',
             'http://schemas.microsoft.com/identity/claims/displayname' => 'Johannes Kepler'
         ),
         'user2:user2pass' => array(
@@ -30,6 +30,8 @@ $config = array(
             'eduPersonAffiliation' => array('group2'),
             'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress' => 'user2@example.com',
             'email' => 'user2@example.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => 'Galileo',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname' => 'Galilei',
             'http://schemas.microsoft.com/identity/claims/displayname' => 'Galileo Galilei',
         ),
         'lippersheyh:telescope' => array(
@@ -37,6 +39,8 @@ $config = array(
           'eduPersonAffiliation' => array('group2'),
           'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress' => 'hans-lippershey@example.com',
           'email' => 'hans-lippershey@example.com',
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname' => 'Hans',
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname' => 'Lippershey',
           'http://schemas.microsoft.com/identity/claims/displayname' => 'Hans Lippershey',
       ),
     ),

--- a/src/api/auth/src/authentication.js
+++ b/src/api/auth/src/authentication.js
@@ -103,6 +103,8 @@ const strategy = new SamlStrategy(
      *   "spNameQualifier": "...",
      *   "uid": "1",
      *   "eduPersonAffiliation": "group1",
+     *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname: "Johannes",
+     *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname": "Kepler",
      *   "http://schemas.microsoft.com/identity/claims/displayname": "First Last",
      *   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress": "first.last@email.com"
      *   "email": "first.last@email.com"

--- a/src/api/auth/src/routes.js
+++ b/src/api/auth/src/routes.js
@@ -118,7 +118,14 @@ router.post('/login/callback', passport.authenticate('saml'), (req, res, next) =
 
   // Create a token for this user, setting their authorization roles
   const { user } = req;
-  const token = createToken(user.email, user.displayName, user.roles, user.avatarUrl);
+  const token = createToken(
+    user.email,
+    user.firstName,
+    user.lastName,
+    user.displayName,
+    user.roles,
+    user.avatarUrl
+  );
 
   let url = `${redirectUri}?access_token=${token}`;
   // Add the state we received before, if it was given at all

--- a/src/api/auth/src/token.js
+++ b/src/api/auth/src/token.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const { hash } = require('@senecacdot/satellite');
 
 const { JWT_ISSUER, JWT_AUDIENCE, SECRET, JWT_EXPIRES_IN } = process.env;
 
@@ -10,16 +11,23 @@ const { JWT_ISSUER, JWT_AUDIENCE, SECRET, JWT_EXPIRES_IN } = process.env;
  * @param {string} picture [optional] a URL to the user's picture
  * @returns {string} the JWT for this user
  */
-function createToken(email, name, roles, picture) {
-  // The token we create includes a number of claims in the payload
+function createToken(email, firstName, lastName, name, roles, picture) {
+  // The token we create includes a number of claims in the payload, using the
+  // recommended claims for OpenID, https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims
   const payload = {
     // iss claim: the token is issued by us (e.g., this server)
     iss: JWT_ISSUER,
     // aud claim: it is intended for the services running at this api origin
     aud: JWT_AUDIENCE,
-    // sub claim: the subject of this token (e.g., their email address)
-    sub: email,
-    // name claim: the display name
+    // sub claim: the subject of this token (e.g., their hashed email address)
+    sub: hash(email),
+    // email claim: the user's email address
+    email,
+    // given_name claim: the user's given, or first name(s).
+    given_name: firstName,
+    // family_name: the user's surnames or last name(s).
+    family_name: lastName,
+    // name claim: the user's full display name
     name,
     // roles claim: an Arry of one or more authorization roles. There are various
     // combinations possible. For authenticated users, we currently have the

--- a/src/api/auth/src/user.js
+++ b/src/api/auth/src/user.js
@@ -5,8 +5,16 @@ class User {
   constructor(senecaProfile, telescopeProfile) {
     // All authenticated users are Seneca Users
     this.seneca = {
+      // first name
+      'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname':
+        senecaProfile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'],
+      // last name
+      'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname':
+        senecaProfile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'],
+      // display name
       'http://schemas.microsoft.com/identity/claims/displayname':
         senecaProfile['http://schemas.microsoft.com/identity/claims/displayname'],
+      // email address
       'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress':
         senecaProfile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'],
       nameID: senecaProfile.nameID,
@@ -39,11 +47,17 @@ class User {
   }
 
   get firstName() {
-    return this.telescope?.firstName;
+    return (
+      this.telescope?.firstName ||
+      this.seneca['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname']
+    );
   }
 
   get lastName() {
-    return this.telescope?.lastName;
+    return (
+      this.telescope?.lastName ||
+      this.seneca['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname']
+    );
   }
 
   get isAdmin() {

--- a/src/api/auth/test/e2e/auth-flows.test.js
+++ b/src/api/auth/test/e2e/auth-flows.test.js
@@ -6,7 +6,7 @@ const fetch = require('node-fetch');
 
 // We need to get the URL to the auth service running in docker, and the list
 // of allowed origins, to compare with assumptions in the tests below.
-const { AUTH_URL, ALLOWED_APP_ORIGINS, USERS_URL } = process.env;
+const { AUTH_URL, ALLOWED_APP_ORIGINS } = process.env;
 
 let browser;
 let context;
@@ -21,42 +21,44 @@ let page;
 // | lippersheyh | hans-lippershey@example.com | telescope | Hans Lippershey |
 //
 // Create 2 Telescope accounts, one for user1@example.com and one for hans-lippershey@example.com.
+const users = [
+  {
+    firstName: 'Johannes',
+    lastName: 'Kepler',
+    email: 'user1@example.com',
+    displayName: 'Johannes Kepler',
+    // this is a Telescope admin
+    isAdmin: true,
+    isFlagged: false,
+    feeds: ['https://imaginary.blog.com/feed/johannes'],
+    github: {
+      username: 'jkepler',
+      avatarUrl:
+        'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
+    },
+  },
+  {
+    firstName: 'Hans',
+    lastName: 'Lippershey',
+    email: 'hans-lippershey@example.com',
+    displayName: 'Hans Lippershey',
+    // Regular Telescope user
+    isAdmin: false,
+    isFlagged: false,
+    feeds: ['https://imaginary.blog.com/feed/hans'],
+    github: {
+      username: 'hlippershey',
+      avatarUrl:
+        'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
+    },
+  },
+];
+
 const createTelescopeUsers = () =>
   Promise.all(
-    [
-      {
-        firstName: 'Johannes',
-        lastName: 'Kepler',
-        email: 'user1@example.com',
-        displayName: 'Johannes Kepler',
-        // this is a Telescope admin
-        isAdmin: true,
-        isFlagged: false,
-        feeds: ['https://imaginary.blog.com/feed/johannes'],
-        github: {
-          username: 'jkepler',
-          avatarUrl:
-            'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
-        },
-      },
-      {
-        firstName: 'Hans',
-        lastName: 'Lippershey',
-        email: 'hans-lippershey@example.com',
-        displayName: 'Hans Lippershey',
-        // Regular Telescope user
-        isAdmin: false,
-        isFlagged: false,
-        feeds: ['https://imaginary.blog.com/feed/hans'],
-        github: {
-          username: 'hlippershey',
-          avatarUrl:
-            'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
-        },
-      },
-    ].map((user) =>
-      fetch(`${USERS_URL}/${hash(user.email)}`, {
-        method: 'POST',
+    users.map((user) =>
+      fetch(`http://localhost/v1/users/${hash(user.email)}`, {
+        method: 'post',
         headers: {
           Authorization: `bearer ${createServiceToken()}`,
           'Content-Type': 'application/json',
@@ -72,38 +74,14 @@ const createTelescopeUsers = () =>
 const cleanupTelescopeUsers = () =>
   Promise.all(
     ['user1@example.com', 'hans-lippershey@example.com'].map((email) =>
-      fetch(`${USERS_URL}/${hash(email)}`, {
-        method: 'DELETE',
+      fetch(`http://localhost/v1/users/${hash(email)}`, {
+        method: 'delete',
         headers: {
           Authorization: `bearer ${createServiceToken()}`,
         },
       })
     )
   );
-
-beforeAll(async () => {
-  // We need some Telescope users created in our Users service, so we can try
-  // logging into both the Login service and Users.  In case we somehow have
-  // these users created from some other test, remove then recreate.
-  await cleanupTelescopeUsers();
-  await createTelescopeUsers();
-  // Use launch({ headless: false, slowMo: 500 }) as options to debug
-  browser = await chromium.launch();
-});
-afterAll(async () => {
-  await browser.close();
-  await cleanupTelescopeUsers();
-});
-
-beforeEach(async () => {
-  context = await browser.newContext();
-  page = await browser.newPage();
-  await page.goto(`http://localhost:8888/`);
-});
-afterEach(async () => {
-  await context.close();
-  await page.close();
-});
 
 // Get the access_token and state from the URL, and parse the token as JWT if present
 const getTokenAndState = () => {
@@ -160,87 +138,127 @@ const logout = async () => {
   return getTokenAndState();
 };
 
+beforeAll(async () => {
+  // Use launch({ headless: false, slowMo: 500 }) as options to debug
+  browser = await chromium.launch();
+});
+afterAll(async () => {
+  await browser.close();
+  await cleanupTelescopeUsers();
+});
+
+beforeEach(async () => {
+  // We need some Telescope users created in our Users service, so we can try
+  // logging into both the Login service and Users.  In case we somehow have
+  // these users created from some other test, remove then recreate.
+  await cleanupTelescopeUsers();
+  await createTelescopeUsers();
+
+  context = await browser.newContext();
+  page = await browser.newPage();
+  await page.goto(`http://localhost:8888/`);
+});
+afterEach(async () => {
+  await context.close();
+  await page.close();
+});
+
 it('should use the same origin in .env for ALLOWED_APP_ORIGINS that test cases use', () => {
   const origins = ALLOWED_APP_ORIGINS.split(' ');
   expect(origins).toContain('http://localhost:8888');
 });
 
 it('should use the same AUTH_URL as we have hard-coded in the test HTML', () => {
-  // NOTE: if this fails, make sure your src/api/.env has the same info as ./index.html
   expect(AUTH_URL).toEqual('http://localhost/v1/auth');
 });
 
-describe('Login', () => {
-  it('Login flow preserves state param', async () => {
-    const { state } = await login('user2', 'user2pass');
-    // Expect the state to match what we sent originally (see index.html <a>)
-    expect(state).toEqual('abc123');
-  });
+it('should have all expected Telescope users in Users service for test data accounts', () =>
+  Promise.all(
+    users.map((user) =>
+      fetch(`http://localhost/v1/users/${hash(user.email)}`).then((res) =>
+        expect(res.status).toEqual(200)
+      )
+    )
+  ));
 
-  it('Login flow issues JWT access token with with expected sub claim', async () => {
-    const { jwt } = await login('user2', 'user2pass');
-    // The sub claim should match our user's email
-    expect(typeof jwt === 'object').toBe(true);
-    expect(jwt.sub).toEqual('user2@example.com');
-  });
+it('Login flow preserves state param', async () => {
+  const { state } = await login('user2', 'user2pass');
+  // Expect the state to match what we sent originally (see index.html <a>)
+  expect(state).toEqual('abc123');
+});
 
-  it('Admin user can login, and has expected token payload', async () => {
-    const { jwt } = await login('user1', 'user1pass');
-    expect(jwt.sub).toEqual('user1@example.com');
-    expect(jwt.name).toEqual('Johannes Kepler');
-    expect(Array.isArray(jwt.roles)).toBe(true);
-    expect(jwt.roles.length).toBe(3);
-    expect(jwt.roles).toEqual(['seneca', 'telescope', 'admin']);
-    expect(jwt.picture).toEqual(
-      'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
-    );
-  });
+it('Login flow issues JWT access token with with expected sub claim', async () => {
+  const { jwt } = await login('user2', 'user2pass');
+  // The sub claim should match our user's email
+  expect(typeof jwt === 'object').toBe(true);
+  expect(jwt.sub).toEqual(hash('user2@example.com'));
+});
 
-  it('Telescope user can login, and has expected token payload', async () => {
-    const { jwt } = await login('lippersheyh', 'telescope');
-    expect(jwt.sub).toEqual('hans-lippershey@example.com');
-    expect(jwt.name).toEqual('Hans Lippershey');
-    expect(Array.isArray(jwt.roles)).toBe(true);
-    expect(jwt.roles.length).toBe(2);
-    expect(jwt.roles).toEqual(['seneca', 'telescope']);
-    expect(jwt.picture).toEqual(
-      'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
-    );
-  });
+it('Admin user can login, and has expected token payload', async () => {
+  const { jwt } = await login('user1', 'user1pass');
+  expect(jwt.sub).toEqual(hash('user1@example.com'));
+  expect(jwt.email).toEqual('user1@example.com');
+  expect(jwt.given_name).toEqual('Johannes');
+  expect(jwt.family_name).toEqual('Kepler');
+  expect(jwt.name).toEqual('Johannes Kepler');
+  expect(Array.isArray(jwt.roles)).toBe(true);
+  expect(jwt.roles.length).toBe(3);
+  expect(jwt.roles).toEqual(['seneca', 'telescope', 'admin']);
+  expect(jwt.picture).toEqual(
+    'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
+  );
+});
 
-  it('Seneca user can login, and has expected token payload', async () => {
-    const { jwt } = await login('user2', 'user2pass');
-    expect(jwt.sub).toEqual('user2@example.com');
-    expect(jwt.name).toEqual('Galileo Galilei');
-    expect(Array.isArray(jwt.roles)).toBe(true);
-    expect(jwt.roles.length).toBe(1);
-    expect(jwt.roles).toEqual(['seneca']);
-    expect(jwt.picture).toBe(undefined);
-  });
+it('Telescope user can login, and has expected token payload', async () => {
+  const { jwt } = await login('lippersheyh', 'telescope');
+  expect(jwt.sub).toEqual(hash('hans-lippershey@example.com'));
+  expect(jwt.email).toEqual('hans-lippershey@example.com');
+  expect(jwt.given_name).toEqual('Hans');
+  expect(jwt.family_name).toEqual('Lippershey');
+  expect(jwt.name).toEqual('Hans Lippershey');
+  expect(Array.isArray(jwt.roles)).toBe(true);
+  expect(jwt.roles.length).toBe(2);
+  expect(jwt.roles).toEqual(['seneca', 'telescope']);
+  expect(jwt.picture).toEqual(
+    'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
+  );
+});
 
-  it("Logging in twice doesn't require username and password again", async () => {
-    const firstLogin = await login('user1', 'user1pass');
-    expect(firstLogin.jwt.sub).toEqual('user1@example.com');
+it('Seneca user can login, and has expected token payload', async () => {
+  const { jwt } = await login('user2', 'user2pass');
+  expect(jwt.sub).toEqual(hash('user2@example.com'));
+  expect(jwt.email).toEqual('user2@example.com');
+  expect(jwt.given_name).toEqual('Galileo');
+  expect(jwt.family_name).toEqual('Galilei');
+  expect(jwt.name).toEqual('Galileo Galilei');
+  expect(Array.isArray(jwt.roles)).toBe(true);
+  expect(jwt.roles.length).toBe(1);
+  expect(jwt.roles).toEqual(['seneca']);
+  expect(jwt.picture).toBe(undefined);
+});
 
-    // Click login again, but we should get navigated back to this page right away
-    await Promise.all([
-      page.waitForNavigation({
-        url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
-        waitUtil: 'load',
-      }),
-      page.click('#login'),
-    ]);
+it("Logging in twice doesn't require username and password again", async () => {
+  const firstLogin = await login('user1', 'user1pass');
+  expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
 
-    // The sub claim should be the same as before (we're still logged in)
-    const secondLogin = getTokenAndState();
-    expect(secondLogin.jwt.sub).toEqual(firstLogin.jwt.sub);
-  });
+  // Click login again, but we should get navigated back to this page right away
+  await Promise.all([
+    page.waitForNavigation({
+      url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
+      waitUtil: 'load',
+    }),
+    page.click('#login'),
+  ]);
+
+  // The sub claim should be the same as before (we're still logged in)
+  const secondLogin = getTokenAndState();
+  expect(secondLogin.jwt.sub).toEqual(firstLogin.jwt.sub);
 });
 
 describe('Logout', () => {
   it('Logout works after logging in', async () => {
     const firstLogin = await login('user1', 'user1pass');
-    expect(firstLogin.jwt.sub).toEqual('user1@example.com');
+    expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
 
     // The sub claim should be the same as before (we're still logged in)
     const logoutResult = await logout();
@@ -250,7 +268,7 @@ describe('Logout', () => {
 
   it('Logging in works after logout', async () => {
     const firstLogin = await login('user1', 'user1pass');
-    expect(firstLogin.jwt.sub).toEqual('user1@example.com');
+    expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
 
     // The sub claim should be the same as before (we're still logged in)
     const logoutResult = await logout();
@@ -258,6 +276,6 @@ describe('Logout', () => {
     expect(logoutResult.token).toEqual(undefined);
 
     const secondLogin = await login('user2', 'user2pass');
-    expect(secondLogin.jwt.sub).toEqual('user2@example.com');
+    expect(secondLogin.jwt.sub).toEqual(hash('user2@example.com'));
   });
 });

--- a/src/api/auth/test/user.test.js
+++ b/src/api/auth/test/user.test.js
@@ -66,14 +66,14 @@ describe('User()', () => {
       expect(user.nameIDFormat).toEqual('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress');
     });
 
-    it('should not have a firstName property', () => {
+    it('should have a firstName property', () => {
       const user = new User(createSenecaProfile());
-      expect(user.firstName).toBe(undefined);
+      expect(user.firstName).toBe('First');
     });
 
-    it('should not have a lastName property', () => {
+    it('should have a lastName property', () => {
       const user = new User(createSenecaProfile());
-      expect(user.lastName).toBe(undefined);
+      expect(user.lastName).toBe('Last');
     });
 
     it('should have isAdmin false', () => {
@@ -106,6 +106,10 @@ describe('User()', () => {
       const json = JSON.stringify(user);
       const deserialized = JSON.parse(json);
       expect(deserialized.seneca).toEqual({
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname':
+          profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'],
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname':
+          profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'],
         'http://schemas.microsoft.com/identity/claims/displayname':
           profile['http://schemas.microsoft.com/identity/claims/displayname'],
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress':
@@ -124,8 +128,8 @@ describe('User()', () => {
       expect(user2.email).toEqual('first.last@senecacollege.ca');
       expect(user2.nameID).toEqual('first.last@senecacollege.ca');
       expect(user2.nameIDFormat).toEqual('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress');
-      expect(user2.firstName).toBe(undefined);
-      expect(user2.lastName).toBe(undefined);
+      expect(user2.firstName).toBe('First');
+      expect(user2.lastName).toBe('Last');
       expect(user2.displayName).toEqual('Seneca Display Name');
       expect(user2.isAdmin).toBe(false);
       expect(user2.isFlagged).toBe(false);
@@ -170,6 +174,26 @@ describe('User()', () => {
     it('should respect isFlagged value', () => {
       const user = new User(createSenecaProfile(), createTelescopeProfile({ isFlagged: false }));
       expect(user.isFlagged).toBe(false);
+    });
+
+    it('should prefer the Telescope first name when available', () => {
+      const user = new User(
+        createSenecaProfile({
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': 'seneca',
+        }),
+        createTelescopeProfile({ firstName: 'telescope' })
+      );
+      expect(user.firstName).toBe('telescope');
+    });
+
+    it('should prefer the Telescope display name when available', () => {
+      const user = new User(
+        createSenecaProfile({
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': 'seneca',
+        }),
+        createTelescopeProfile({ lastName: 'telescope' })
+      );
+      expect(user.lastName).toBe('telescope');
     });
 
     it('should prefer the Telescope display name when available', () => {
@@ -223,6 +247,10 @@ describe('User()', () => {
       const json = JSON.stringify(user);
       const deserialized = JSON.parse(json);
       expect(deserialized.seneca).toEqual({
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname':
+          senecaProfile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname'],
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname':
+          senecaProfile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'],
         'http://schemas.microsoft.com/identity/claims/displayname':
           senecaProfile['http://schemas.microsoft.com/identity/claims/displayname'],
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress':

--- a/src/web/src/User.ts
+++ b/src/web/src/User.ts
@@ -1,6 +1,10 @@
+/* eslint-disable camelcase */
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 
 interface TelescopeJwtPayload extends JwtPayload {
+  email: string;
+  given_name: string;
+  family_name: string;
   name: string;
   picture?: string;
   roles: Array<string>;
@@ -11,7 +15,10 @@ const isExpired = (exp?: number) => typeof exp === 'undefined' || new Date().get
 
 export default class User {
   constructor(
+    public id: string,
     public email: string,
+    public firstName: string,
+    public lastName: string,
     public name: string,
     // If the user has a Telescope account
     public isRegistered: boolean,
@@ -37,6 +44,9 @@ export default class User {
     // Otherwise, return a new User based on this data
     return new User(
       decoded.sub,
+      decoded.email,
+      decoded.given_name,
+      decoded.family_name,
       decoded.name,
       decoded.roles.includes('telescope'),
       decoded.roles.includes('admin'),


### PR DESCRIPTION
I was talking with @PedroFonsecaDEV about the signup form, and realized that we'll need to include more user details from the Seneca profile in the initial access token for the signup flow.  This adds the following (NOTE: I'm using names [standardized by OpenID](https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims) for how you include this data in a token):

- `sub` - I switched this to the actual hashed email value, so we don't need to include the hashing function in the front-end
- `email` - I added this, since we wouldn't have the email otherwise (I was on `sub`)
-  `given_name` - the user's first/given name(s)
- `family_name` - the user's last/surname(s)

In the front-end, you can use `useAuth()` and get back a `user` instance that will have `.email`, `.firstName`, `.lastName`, etc.