### PR TITLE
Fix how we mock fetch in Jest

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,8 +1,12 @@
+const path = require('path');
+
+// Pull in the default development environment for all tests.  Override as necessary
+require('dotenv').config({ path: path.join(__dirname, './config/env.development') });
+
 // A base config for all our Jest test projects to use
 module.exports = {
   testEnvironment: 'node',
   verbose: true,
-  setupFiles: ['<rootDir>/jest.setup.js'],
   coverageDirectory: '<rootDir>/coverage',
   moduleDirectories: ['node_modules'],
   automock: false,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,0 @@
-/* global jest */
-const path = require('path');
-const fetch = require('jest-fetch-mock');
-
-require('dotenv').config({ path: path.join(__dirname, './config/env.development') });
-
-jest.setMock('node-fetch', fetch);

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -2,6 +2,7 @@ const baseConfig = require('../jest.config.base');
 
 module.exports = {
   ...baseConfig,
+  setupFiles: ['<rootDir>/test/jest.setup.js'],
   rootDir: '../',
   testMatch: ['<rootDir>/test/**/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/backend/**/*.js'],

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,0 +1,4 @@
+const fetch = require('jest-fetch-mock');
+
+// Mock fetch for the Telescope 1.0 back-end tests
+jest.setMock('node-fetch', fetch);


### PR DESCRIPTION
Currently we are silently mocking `fetch()` in all of our tests.  This was necessary in the old tests, but with the new e2e tests, microservivces need to be able to communicate with each other in test cases.

This alters our Jest setup so that the old Telescope 1.0 tests still get mock-fetch, but we don't do it automatically for new tests (any test that needs it can add it, like we now do in `test/jest.setup.js`).

I've also moved the env logic to the base config, and removed the need for any setup in the base configs.  This way, sub-projects can define their own setup with out also pulling in the base.

Thanks to @manekenpix and @chrispinkney who helped me figure this out after pulling my hair out all day.