### PR TITLE
Don't assume https:// for WEB_URL

### DIFF
--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -38,7 +38,7 @@ envVarsToForward.forEach((envVar) => forwardToNext(envVar));
 // NOTE: on Vercel, the value we get from VERCEL_URL for the WEB_URL will be
 // missing the leading https://.  If it's not there, add it now so the front-end
 // can count on it always being an absolute URL.
-process.env.NEXT_PUBLIC_WEB_URL = process.env.NEXT_PUBLIC_WEB_URL.startsWith('https://')
+process.env.NEXT_PUBLIC_WEB_URL = /^https?:\/\//.test(process.env.NEXT_PUBLIC_WEB_URL)
   ? process.env.NEXT_PUBLIC_WEB_URL
   : `https://${process.env.NEXT_PUBLIC_WEB_URL}`;
 


### PR DESCRIPTION
My Vercel fix is once again wrong, and now breaks local dev:

```
Using NEXT_PUBLIC_WEB_URL=https://http://localhost:8000
```

This will allow `http://` prefix for local dev.