### PR TITLE
Add auth middleware to Users service

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     'plugin:promise/recommended',
     'plugin:react-hooks/recommended',
     'plugin:import/typescript',
+    'plugin:jest-playwright/recommended',
   ],
   plugins: ['prettier', 'promise', 'react', 'react-hooks', 'jest'],
   settings: {

--- a/docker/development.yml
+++ b/docker/development.yml
@@ -79,3 +79,4 @@ services:
   search:
     environment:
       - ELASTIC_URL=http://localhost
+      - ELASTIC_PORT=9200

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,12 @@ services:
       context: ../src/api/image
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - IMAGE_PORT
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     ports:
       - ${IMAGE_PORT}
     depends_on:
@@ -40,6 +45,7 @@ services:
       context: ../src/api/auth
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - AUTH_PORT
       - SSO_LOGIN_URL
       - SSO_LOGIN_CALLBACK_URL
@@ -47,12 +53,14 @@ services:
       - SLO_LOGOUT_CALLBACK_URL
       - SSO_IDP_PUBLIC_KEY_CERT
       - SAML_ENTITY_ID
-      - SECRET
       - ADMINISTRATORS
       - ALLOWED_APP_ORIGINS
-      - JWT_ISSUER
       - JWT_EXPIRES_IN
       - USERS_URL
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     ports:
       - ${AUTH_PORT}
     depends_on:
@@ -76,10 +84,13 @@ services:
       context: ../src/api/search
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - SEARCH_PORT
       - ELASTIC_MAX_RESULTS_PER_PAGE
-      - ELASTIC_URL
-      - ELASTIC_PORT
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     depends_on:
       - elasticsearch
       - traefik
@@ -104,8 +115,13 @@ services:
       context: ../src/api/posts
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - POSTS_PORT
       - POSTS_URL
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     ports:
       - ${POSTS_PORT}
     depends_on:
@@ -130,7 +146,12 @@ services:
       context: ../src/api/feed-discovery
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - FEED_DISCOVERY_PORT
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     ports:
       - ${FEED_DISCOVERY_PORT}
     depends_on:
@@ -154,8 +175,13 @@ services:
       context: ../src/api/users
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - USERS_PORT
       - USERS_URL
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     ports:
       - ${USERS_PORT}
     depends_on:
@@ -179,8 +205,13 @@ services:
       context: ../src/api/parser
       dockerfile: Dockerfile
     environment:
+      - NODE_ENV
       - PARSER_PORT
       - USERS_URL
+      # Satellite authentication/authorization support
+      - JWT_ISSUER
+      - JWT_AUDIENCE
+      - SECRET
     ports:
       - ${PARSER_PORT}
     depends_on:

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -87,7 +87,7 @@ services:
       context: ../src/api/status
       dockerfile: Dockerfile
     environment:
-      - NODE_ENV=production
+      - NODE_ENV
       - STATUS_PORT
       # Satellite authentication/authorization support
       - JWT_ISSUER
@@ -115,53 +115,18 @@ services:
   # image service
   image:
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - IMAGE_PORT
-      # Satellite authentication/authorization support
-      - JWT_ISSUER
-      - JWT_AUDIENCE
-      - SECRET
-      # TODO - add APM monitoring support for Satellite
-      # - ELASTIC_APM_SERVER_URL
-      # - ELASTIC_APM_SERVICE_NAME
 
   # auth service
   auth:
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - AUTH_PORT
-      # TODO
-      # - ELASTIC_APM_SERVICE_NAME=auth
-      # - ELASTIC_APM_SERVER_URL=http://apm:8200
 
   # posts service
   posts:
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - POSTS_PORT
-      # Satellite authentication/authorization support
-      - JWT_ISSUER
-      - JWT_AUDIENCE
-      - SECRET
-      # TODO - add APM monitoring support for Satellite
-      # - ELASTIC_APM_SERVER_URL
-      # - ELASTIC_APM_SERVICE_NAME
 
   # users service
   users:
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      # Satellite authentication/authorization support
-      - JWT_ISSUER
-      - JWT_AUDIENCE
-      - SECRET
-      # TODO - add APM monitoring support for Satellite
-      # - ELASTIC_APM_SERVER_URL
-      # - ELASTIC_APM_SERVICE_NAME
     volumes:
       # This will take care of copying the serviceAccountKey.json file needed by firestore.js
       - ../../firebase/serviceAccountKey.json:/app/serviceAccountKey.json
@@ -169,19 +134,11 @@ services:
   # users service
   parser:
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - PARSER_PORT
-      # TODO
-      # - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      # - ELASTIC_APM_SERVICE_NAME=user
-      # - ELASTIC_APM_SERVER_URL=http://apm:8200
 
   # search service
   search:
     restart: unless-stopped
     environment:
-      - NODE_ENV=production
       - ELASTIC_URL=http://elasticsearch
       - ELASTIC_PORT=9200
 

--- a/jest-playwright.config.js
+++ b/jest-playwright.config.js
@@ -2,6 +2,10 @@
 // seen to know how to find it if I put it there.  It has to be at the root.
 module.exports = {
   launchOptions: {
+    // NOTE: if you need to debug, change these so you can see the browsers running
+    // and slow them down, so there is time to read error messages:
+    // headless: false,
+    // slowMo: 1000,
     headless: true,
   },
   browsers: ['chromium', 'firefox', 'webkit'],

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -5,10 +5,9 @@ require('dotenv').config({ path: path.join(__dirname, './config/env.development'
 
 // A base config for all our Jest test projects to use
 module.exports = {
-  testEnvironment: 'node',
   verbose: true,
   coverageDirectory: '<rootDir>/coverage',
   moduleDirectories: ['node_modules'],
   automock: false,
-  testTimeout: 30000,
+  testTimeout: 10000,
 };

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-jest-playwright": "0.2.1",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-promise": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pretest": "npm run lint",
     "test": "npm run jest",
     "jest": "cross-env NODE_ENV=test LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest -c jest.config.js --",
-    "jest:e2e": "jest -c jest.config.e2e.js --",
+    "jest:e2e": "jest -c jest.config.e2e.js --runInBand --",
     "coverage": "cross-env NODE_ENV=test LOG_LEVEL=silent MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest -c jest.config.js --collectCoverage --",
     "jest-watch": "cross-env MOCK_REDIS=1 jest -c jest.config.js --watch --",
     "jest-update": "cross-env MOCK_REDIS=1 jest -c jest.config.js --updateSnapshot --",

--- a/src/api/auth/jest-playwright.config.js
+++ b/src/api/auth/jest-playwright.config.js
@@ -1,2 +1,2 @@
 // Due to https://github.com/playwright-community/jest-playwright/issues/446
-// we put our jest-playwright config in the Telescope root, see ./jest-playwright.confing.js
+// we put our jest-playwright config in the Telescope root, see ./jest-playwright.config.js

--- a/src/api/auth/test/e2e/auth-flows.test.js
+++ b/src/api/auth/test/e2e/auth-flows.test.js
@@ -1,5 +1,4 @@
 // NOTE: you need to run the auth and login services in docker for these to work
-const { chromium } = require('playwright');
 const { decode } = require('jsonwebtoken');
 const { createServiceToken, hash } = require('@senecacdot/satellite');
 const fetch = require('node-fetch');
@@ -7,10 +6,6 @@ const fetch = require('node-fetch');
 // We need to get the URL to the auth service running in docker, and the list
 // of allowed origins, to compare with assumptions in the tests below.
 const { AUTH_URL, ALLOWED_APP_ORIGINS } = process.env;
-
-let browser;
-let context;
-let page;
 
 // We have 3 SSO user accounts in the login service (see config/simplesamlphp-users.php):
 //
@@ -138,144 +133,140 @@ const logout = async () => {
   return getTokenAndState();
 };
 
-beforeAll(async () => {
-  // Use launch({ headless: false, slowMo: 500 }) as options to debug
-  browser = await chromium.launch();
-});
-afterAll(async () => {
-  await browser.close();
-  await cleanupTelescopeUsers();
-});
+describe('Authentication Flows', () => {
+  beforeEach(async () => {
+    await cleanupTelescopeUsers();
+    await createTelescopeUsers();
 
-beforeEach(async () => {
-  // We need some Telescope users created in our Users service, so we can try
-  // logging into both the Login service and Users.  In case we somehow have
-  // these users created from some other test, remove then recreate.
-  await cleanupTelescopeUsers();
-  await createTelescopeUsers();
-
-  context = await browser.newContext();
-  page = await browser.newPage();
-  await page.goto(`http://localhost:8888/`);
-});
-afterEach(async () => {
-  await context.close();
-  await page.close();
-});
-
-it('should use the same origin in .env for ALLOWED_APP_ORIGINS that test cases use', () => {
-  const origins = ALLOWED_APP_ORIGINS.split(' ');
-  expect(origins).toContain('http://localhost:8888');
-});
-
-it('should use the same AUTH_URL as we have hard-coded in the test HTML', () => {
-  expect(AUTH_URL).toEqual('http://localhost/v1/auth');
-});
-
-it('should have all expected Telescope users in Users service for test data accounts', () =>
-  Promise.all(
-    users.map((user) =>
-      fetch(`http://localhost/v1/users/${hash(user.email)}`).then((res) =>
-        expect(res.status).toEqual(200)
-      )
-    )
-  ));
-
-it('Login flow preserves state param', async () => {
-  const { state } = await login('user2', 'user2pass');
-  // Expect the state to match what we sent originally (see index.html <a>)
-  expect(state).toEqual('abc123');
-});
-
-it('Login flow issues JWT access token with with expected sub claim', async () => {
-  const { jwt } = await login('user2', 'user2pass');
-  // The sub claim should match our user's email
-  expect(typeof jwt === 'object').toBe(true);
-  expect(jwt.sub).toEqual(hash('user2@example.com'));
-});
-
-it('Admin user can login, and has expected token payload', async () => {
-  const { jwt } = await login('user1', 'user1pass');
-  expect(jwt.sub).toEqual(hash('user1@example.com'));
-  expect(jwt.email).toEqual('user1@example.com');
-  expect(jwt.given_name).toEqual('Johannes');
-  expect(jwt.family_name).toEqual('Kepler');
-  expect(jwt.name).toEqual('Johannes Kepler');
-  expect(Array.isArray(jwt.roles)).toBe(true);
-  expect(jwt.roles.length).toBe(3);
-  expect(jwt.roles).toEqual(['seneca', 'telescope', 'admin']);
-  expect(jwt.picture).toEqual(
-    'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
-  );
-});
-
-it('Telescope user can login, and has expected token payload', async () => {
-  const { jwt } = await login('lippersheyh', 'telescope');
-  expect(jwt.sub).toEqual(hash('hans-lippershey@example.com'));
-  expect(jwt.email).toEqual('hans-lippershey@example.com');
-  expect(jwt.given_name).toEqual('Hans');
-  expect(jwt.family_name).toEqual('Lippershey');
-  expect(jwt.name).toEqual('Hans Lippershey');
-  expect(Array.isArray(jwt.roles)).toBe(true);
-  expect(jwt.roles.length).toBe(2);
-  expect(jwt.roles).toEqual(['seneca', 'telescope']);
-  expect(jwt.picture).toEqual(
-    'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
-  );
-});
-
-it('Seneca user can login, and has expected token payload', async () => {
-  const { jwt } = await login('user2', 'user2pass');
-  expect(jwt.sub).toEqual(hash('user2@example.com'));
-  expect(jwt.email).toEqual('user2@example.com');
-  expect(jwt.given_name).toEqual('Galileo');
-  expect(jwt.family_name).toEqual('Galilei');
-  expect(jwt.name).toEqual('Galileo Galilei');
-  expect(Array.isArray(jwt.roles)).toBe(true);
-  expect(jwt.roles.length).toBe(1);
-  expect(jwt.roles).toEqual(['seneca']);
-  expect(jwt.picture).toBe(undefined);
-});
-
-it("Logging in twice doesn't require username and password again", async () => {
-  const firstLogin = await login('user1', 'user1pass');
-  expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
-
-  // Click login again, but we should get navigated back to this page right away
-  await Promise.all([
-    page.waitForNavigation({
-      url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
-      waitUtil: 'load',
-    }),
-    page.click('#login'),
-  ]);
-
-  // The sub claim should be the same as before (we're still logged in)
-  const secondLogin = getTokenAndState();
-  expect(secondLogin.jwt.sub).toEqual(firstLogin.jwt.sub);
-});
-
-describe('Logout', () => {
-  it('Logout works after logging in', async () => {
-    const firstLogin = await login('user1', 'user1pass');
-    expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
-
-    // The sub claim should be the same as before (we're still logged in)
-    const logoutResult = await logout();
-    expect(logoutResult.state).toEqual('abc123');
-    expect(logoutResult.token).toEqual(undefined);
+    context = await browser.newContext();
+    page = await browser.newPage();
+    await page.goto(`http://localhost:8888/`);
   });
 
-  it('Logging in works after logout', async () => {
+  afterEach(async () => {
+    await cleanupTelescopeUsers();
+
+    await context.close();
+    await page.close();
+  });
+
+  it('should use the same origin in .env for ALLOWED_APP_ORIGINS that test cases use', () => {
+    const origins = ALLOWED_APP_ORIGINS.split(' ');
+    expect(origins).toContain('http://localhost:8888');
+  });
+
+  it('should use the same AUTH_URL as we have hard-coded in the test HTML', () => {
+    expect(AUTH_URL).toEqual('http://localhost/v1/auth');
+  });
+
+  it('should have all expected Telescope users in Users service for test data accounts', () =>
+    Promise.all(
+      users.map((user) =>
+        fetch(`http://localhost/v1/users/${hash(user.email)}`, {
+          headers: {
+            Authorization: `bearer ${createServiceToken()}`,
+            'Content-Type': 'application/json',
+          },
+        }).then((res) => expect(res.status).toEqual(200))
+      )
+    ));
+
+  it('Login flow preserves state param', async () => {
+    const { state } = await login('user2', 'user2pass');
+    // Expect the state to match what we sent originally (see index.html <a>)
+    expect(state).toEqual('abc123');
+  });
+
+  it('Login flow issues JWT access token with with expected sub claim', async () => {
+    const { jwt } = await login('user2', 'user2pass');
+    // The sub claim should match our user's email
+    expect(typeof jwt === 'object').toBe(true);
+    expect(jwt.sub).toEqual(hash('user2@example.com'));
+  });
+
+  it('Admin user can login, and has expected token payload', async () => {
+    const { jwt } = await login('user1', 'user1pass');
+    expect(jwt.sub).toEqual(hash('user1@example.com'));
+    expect(jwt.email).toEqual('user1@example.com');
+    expect(jwt.given_name).toEqual('Johannes');
+    expect(jwt.family_name).toEqual('Kepler');
+    expect(jwt.name).toEqual('Johannes Kepler');
+    expect(Array.isArray(jwt.roles)).toBe(true);
+    expect(jwt.roles.length).toBe(3);
+    expect(jwt.roles).toEqual(['seneca', 'telescope', 'admin']);
+    expect(jwt.picture).toEqual(
+      'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
+    );
+  });
+
+  it('Telescope user can login, and has expected token payload', async () => {
+    const { jwt } = await login('lippersheyh', 'telescope');
+    expect(jwt.sub).toEqual(hash('hans-lippershey@example.com'));
+    expect(jwt.email).toEqual('hans-lippershey@example.com');
+    expect(jwt.given_name).toEqual('Hans');
+    expect(jwt.family_name).toEqual('Lippershey');
+    expect(jwt.name).toEqual('Hans Lippershey');
+    expect(Array.isArray(jwt.roles)).toBe(true);
+    expect(jwt.roles.length).toBe(2);
+    expect(jwt.roles).toEqual(['seneca', 'telescope']);
+    expect(jwt.picture).toEqual(
+      'https://avatars.githubusercontent.com/u/33902374?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4'
+    );
+  });
+
+  it('Seneca user can login, and has expected token payload', async () => {
+    const { jwt } = await login('user2', 'user2pass');
+    expect(jwt.sub).toEqual(hash('user2@example.com'));
+    expect(jwt.email).toEqual('user2@example.com');
+    expect(jwt.given_name).toEqual('Galileo');
+    expect(jwt.family_name).toEqual('Galilei');
+    expect(jwt.name).toEqual('Galileo Galilei');
+    expect(Array.isArray(jwt.roles)).toBe(true);
+    expect(jwt.roles.length).toBe(1);
+    expect(jwt.roles).toEqual(['seneca']);
+    expect(jwt.picture).toBe(undefined);
+  });
+
+  it("Logging in twice doesn't require username and password again", async () => {
     const firstLogin = await login('user1', 'user1pass');
     expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
 
-    // The sub claim should be the same as before (we're still logged in)
-    const logoutResult = await logout();
-    expect(logoutResult.state).toEqual('abc123');
-    expect(logoutResult.token).toEqual(undefined);
+    // Click login again, but we should get navigated back to this page right away
+    await Promise.all([
+      page.waitForNavigation({
+        url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
+        waitUtil: 'load',
+      }),
+      page.click('#login'),
+    ]);
 
-    const secondLogin = await login('user2', 'user2pass');
-    expect(secondLogin.jwt.sub).toEqual(hash('user2@example.com'));
+    // The sub claim should be the same as before (we're still logged in)
+    const secondLogin = getTokenAndState();
+    expect(secondLogin.jwt.sub).toEqual(firstLogin.jwt.sub);
+  });
+
+  describe('Logout', () => {
+    it('Logout works after logging in', async () => {
+      const firstLogin = await login('user1', 'user1pass');
+      expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
+
+      // The sub claim should be the same as before (we're still logged in)
+      const logoutResult = await logout();
+      expect(logoutResult.state).toEqual('abc123');
+      expect(logoutResult.token).toEqual(undefined);
+    });
+
+    it('Logging in works after logout', async () => {
+      const firstLogin = await login('user1', 'user1pass');
+      expect(firstLogin.jwt.sub).toEqual(hash('user1@example.com'));
+
+      // The sub claim should be the same as before (we're still logged in)
+      const logoutResult = await logout();
+      expect(logoutResult.state).toEqual('abc123');
+      expect(logoutResult.token).toEqual(undefined);
+
+      const secondLogin = await login('user2', 'user2pass');
+      expect(secondLogin.jwt.sub).toEqual(hash('user2@example.com'));
+    });
   });
 });

--- a/src/api/users/src/routes/users.js
+++ b/src/api/users/src/routes/users.js
@@ -1,4 +1,4 @@
-const { Router, createError } = require('@senecacdot/satellite');
+const { Router, createError, isAuthenticated, isAuthorized } = require('@senecacdot/satellite');
 const { errors } = require('celebrate');
 
 const {
@@ -15,120 +15,183 @@ const router = Router();
 
 // get a user with a supplied id, validated by the schema
 // rejected if a user could not be found, otherwise user returned
-router.get('/:id', validateId(), async (req, res, next) => {
-  const { id } = req.params;
-
-  try {
-    const userRef = db.doc(id);
-    const doc = await userRef.get();
-
-    if (!doc.exists) {
-      next(createError(404, `user ${id} not found.`));
-    } else {
-      res.status(200).json(doc.data());
+router.get(
+  '/:id',
+  isAuthenticated(),
+  validateId(),
+  isAuthorized((req, user) => {
+    // A user can request their own data
+    if (user.sub === req.param.id) {
+      return true;
     }
-  } catch (err) {
-    next(err);
+    // Or an admin, or another authorized microservice
+    return user.roles.includes('admin') || user.roles.includes('service');
+  }),
+  async (req, res, next) => {
+    const { id } = req.params;
+
+    try {
+      const userRef = db.doc(id);
+      const doc = await userRef.get();
+
+      if (!doc.exists) {
+        next(createError(404, `user ${id} not found.`));
+      } else {
+        res.status(200).json(doc.data());
+      }
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
 
 // get all users
 // rejected if the users collection is empty
 // otherwise perPage (specified via params) users are returned, starting at
 // the beginning of the users collection or the provided document path id (if present)
-router.get('/', validatePagingParams(), async (req, res, next) => {
-  /*
-   *  schema.js performs data validation via validatePagingParams() middleware
-   *  per_page is an integer validated to have a range between 1 and 100
-   *  start_after is the id (hashed email) of the user to begin after
-   */
-  const { per_page: perPage, start_after: startAfter } = req.query;
+router.get(
+  '/',
+  isAuthenticated(),
+  // Only an admin or another authorized microservice can request this
+  isAuthorized((req, user) => user.roles.includes('admin') || user.roles.includes('service')),
+  validatePagingParams(),
+  async (req, res, next) => {
+    /*
+     *  schema.js performs data validation via validatePagingParams() middleware
+     *  per_page is an integer validated to have a range between 1 and 100
+     *  start_after is the id (hashed email) of the user to begin after
+     */
+    const { per_page: perPage, start_after: startAfter } = req.query;
 
-  try {
-    let query = db.orderBy(documentId()).limit(perPage);
+    try {
+      let query = db.orderBy(documentId()).limit(perPage);
 
-    // If we were given a user ID to start after, use that document path to add .startAfter()
-    if (startAfter) {
-      query = query.startAfter(startAfter);
+      // If we were given a user ID to start after, use that document path to add .startAfter()
+      if (startAfter) {
+        query = query.startAfter(startAfter);
+      }
+
+      const snapshot = await query.get();
+      const users = snapshot.docs.map((doc) => doc.data());
+
+      // Add paging link header if necessary, so caller can request next page
+      addNextLinkHeader(res, users, perPage);
+      res.status(200).json(users);
+    } catch (err) {
+      next(err);
     }
-
-    const snapshot = await query.get();
-    const users = snapshot.docs.map((doc) => doc.data());
-
-    // Add paging link header if necessary, so caller can request next page
-    addNextLinkHeader(res, users, perPage);
-    res.status(200).json(users);
-  } catch (err) {
-    next(err);
   }
-});
+);
 
 // post a user with supplied info, validated by the schema
 // rejected if a user already exists with that id, otherwise user created
-router.post('/:id', validateId(), validateUser(), validateEmailHash(), async (req, res, next) => {
-  const { id } = req.params;
-  const { body } = req;
-
-  try {
-    const userRef = db.doc(id);
-    const doc = await userRef.get();
-
-    if (doc.exists) {
-      next(createError(400, `user with id ${id} already exists.`));
-    } else {
-      const user = new User(body);
-      await db.doc(id).set(user);
-      res.status(201).json({ msg: `Added user with id: ${id}` });
+router.post(
+  '/:id',
+  isAuthenticated(),
+  validateId(),
+  validateUser(),
+  validateEmailHash(),
+  isAuthorized((req, user) => {
+    // A user can add their own data (signup)
+    if (user.sub === req.param.id) {
+      return true;
     }
-  } catch (err) {
-    next(err);
+    // Or an admin, or another authorized microservice
+    return user.roles.includes('admin') || user.roles.includes('service');
+  }),
+  async (req, res, next) => {
+    const { id } = req.params;
+    const { body } = req;
+
+    try {
+      const userRef = db.doc(id);
+      const doc = await userRef.get();
+
+      if (doc.exists) {
+        next(createError(400, `user with id ${id} already exists.`));
+      } else {
+        const user = new User(body);
+        await db.doc(id).set(user);
+        res.status(201).json({ msg: `Added user with id: ${id}` });
+      }
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
 
 // put (update) a user with a supplied id, validated by the schema
 // rejected if a user could not be found, otherwise user updated
-router.put('/:id', validateId(), validateUser(), validateEmailHash(), async (req, res, next) => {
-  const { id } = req.params;
-  const { body } = req;
-
-  try {
-    const userRef = db.doc(id);
-    const doc = await userRef.get();
-
-    if (!doc.exists) {
-      next(createError(404, `user ${id} not found.`));
-    } else {
-      const user = new User(body);
-      // NOTE: doc().update() doesn't use the converter, we have to make a plain object.
-      await db.doc(id).update(user.toJSON());
-      res.status(200).json({ msg: `Updated user ${id}` });
+router.put(
+  '/:id',
+  isAuthenticated(),
+  validateId(),
+  validateUser(),
+  validateEmailHash(),
+  isAuthorized((req, user) => {
+    // A user can update their own data
+    if (user.sub === req.param.id) {
+      return true;
     }
-  } catch (err) {
-    next(err);
+    // Or an admin, or another authorized microservice
+    return user.roles.includes('admin') || user.roles.includes('service');
+  }),
+  async (req, res, next) => {
+    const { id } = req.params;
+    const { body } = req;
+
+    try {
+      const userRef = db.doc(id);
+      const doc = await userRef.get();
+
+      if (!doc.exists) {
+        next(createError(404, `user ${id} not found.`));
+      } else {
+        const user = new User(body);
+        // NOTE: doc().update() doesn't use the converter, we have to make a plain object.
+        await db.doc(id).update(user.toJSON());
+        res.status(200).json({ msg: `Updated user ${id}` });
+      }
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
 
 // delete a user with a supplied id, validated by the schema
 // rejected if a user could not be found, otherwise user deleted
-router.delete('/:id', validateId(), async (req, res, next) => {
-  const { id } = req.params;
-
-  try {
-    const userRef = db.doc(id);
-    const doc = await userRef.get();
-
-    if (!doc.exists) {
-      next(createError(404, `user ${id} not found.`));
-    } else {
-      await db.doc(id).delete();
-      res.status(200).json({
-        msg: `user ${id} was removed.`,
-      });
+router.delete(
+  '/:id',
+  isAuthenticated(),
+  validateId(),
+  isAuthorized((req, user) => {
+    // A user can delete their own data
+    if (user.sub === req.param.id) {
+      return true;
     }
-  } catch (err) {
-    next(err);
+    // Or an admin, or another authorized microservice
+    return user.roles.includes('admin') || user.roles.includes('service');
+  }),
+  async (req, res, next) => {
+    const { id } = req.params;
+
+    try {
+      const userRef = db.doc(id);
+      const doc = await userRef.get();
+
+      if (!doc.exists) {
+        next(createError(404, `user ${id} not found.`));
+      } else {
+        await db.doc(id).delete();
+        res.status(200).json({
+          msg: `user ${id} was removed.`,
+        });
+      }
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
 
 router.use(errors());
 


### PR DESCRIPTION
This adds *authentication* (makes sure the user has a valid JWT token) and *authorization* (makes sure their token matches what we expect per route) middleware from Satellite to the Users service.  It depends on https://github.com/Seneca-CDOT/satellite/pull/12 for some changes to the `isAuthorized()` middleware in Satellite.

I'm adding middleware to all of the routes, but it's different in each case:

- `GET /` this can be done only by an admin or another microservice (e.g., Parser service).  A regular user can't request this, nor can an anonymous, unauthenticated user.
- `GET /:id` this can be done by the user who owns the data (e.g., I can request my own data),  or by an admin or another microservice.  A user can't request someone else's data, nor can an anonymous, unauthenticated user.
- `POST /:id` this can be done by the user who owns the data (e.g., I can register my own data),  or by an admin or another microservice.  A user can't register someone else's data, nor can an anonymous, unauthenticated user.
- `PUT /:id` this can be done by the user who owns the data (e.g., I can update my own data),  or by an admin or another microservice.  A user can't update someone else's data, nor can an anonymous, unauthenticated user.
- `DELETE /:id` this can be done by the user who owns the data (e.g., I can delete my own data),  or by an admin or another microservice.  A user can't delete someone else's data, nor can an anonymous, unauthenticated user.

I haven't written pure e2e tests here, which would also test things like trying to hit the various routes as different users.  That would require the tests to be updated to full e2e tests first, so we'll have to come back to this.

A note about Satellite's middleware: a route **must** call `isAuthenticated()` **before** `isAuthorized()`, since the latter uses the parsed token created by the former.

The tests are going to fail until the Satellite fix is included.