### PR TITLE
Update autodeployment deps to clear netmask security vulnerability

### DIFF
--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -9,7 +9,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "merge-stream": "^2.0.0",
-    "pm2": "^4.5.5",
+    "pm2": "^4.5.6",
     "shelljs": "^0.8.4"
   },
   "scripts": {


### PR DESCRIPTION
Running `npm install` fails with security vulnerabilities in the autodeployment server.  Updating `pm2` fixes.  There are some other updates we could take, but they require API changes I don't have time to do right now.

This clears our security issue.