### PR TITLE
Fixes #2001: Added bottom padding to improve visual break

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -24,6 +24,9 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       padding: '0',
+      paddingBottom: '2em',
+      marginBottom: '3em',
+      borderBottom: '1.5px solid #cccccc',
       fontSize: '1.5rem',
       width: '100%',
       backgroundColor: theme.palette.background.default,


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #2001

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
I've thought about how to improve the visual break between posts. I've looked at how Instagram separates their infinite timeline of posts and it turns out that they don't (unlike tumblr). I think that the easiest solution would just to simply give it more space, see below:

https://user-images.githubusercontent.com/48869737/114341111-fe278f00-9b26-11eb-857c-7494dfe24f7f.mp4

From my reasoning, the next post's title looks like a subtitle for the current post is because the spacing is basically equal and the user struggles to identify who the title belongs to. By adding more space between, it'll be easier to see the title belongs to the post below rather than the previous post above. 

Let me know if we want a more drastic design change to improve the visual break or if the gap should be shortened or made larger.

## How to Test
1. View the file change, ask the following:
    - should I change the unit of measurement? (`px` instead of `rem`?)
2. View deployment, ask the following:
    - is the extra space enough? too little?
    - should this warrant a more drastic design change?

## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
