### PR TITLE
Use Redis for auth service session storage in production

### DIFF
--- a/src/api/auth/package.json
+++ b/src/api/auth/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@senecacdot/satellite": "^1.x",
     "celebrate": "^14.0.0",
+    "connect-redis": "^5.1.0",
     "express-session": "^1.17.1",
     "http-errors": "^1.8.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/api/auth/src/index.js
+++ b/src/api/auth/src/index.js
@@ -1,6 +1,7 @@
-const { Satellite } = require('@senecacdot/satellite');
+const { Satellite, Redis } = require('@senecacdot/satellite');
 const passport = require('passport');
 const session = require('express-session');
+const RedisStore = require('connect-redis')(session);
 
 // Setup SAML SSO-based Authentication
 require('./authentication');
@@ -10,10 +11,11 @@ const routes = require('./routes');
 const service = new Satellite({
   router: routes,
   beforeRouter(app) {
-    // Initialize and use Session and Passport middleware on the app
+    // Initialize and use Session and Passport middleware on the app. In production
+    // we use Redis for session storage, and in-memory otherwise.
     app.use(
-      // TODO: should use RedisStore in prod
       session({
+        store: process.env.NODE_ENV === 'production' && new RedisStore({ client: Redis() }),
         secret: process.env.SECRET || `telescope-has-many-secrets-${Date.now()}!`,
         resave: false,
         saveUninitialized: false,


### PR DESCRIPTION
I was waiting for Redis to get added to Satellite before I could do this, and now that it's here, I'm switch our auth service to use Redis-backed session storage in production.  Similar to [what we do now in the back-end](https://github.com/Seneca-CDOT/telescope/blob/c385eaae08d20f806d4b1ef6363b81c8fc5f4a60/src/backend/web/app.js#L58).