### PR TITLE
Fix #2138: iat should be less than or equal to now

### DIFF
--- a/src/api/auth/test/token.test.js
+++ b/src/api/auth/test/token.test.js
@@ -76,9 +76,9 @@ describe('createToken()', () => {
   it('should return a JWT with an issued at claim', () => {
     const { iat } = jwt.verify(token(), SECRET);
     expect(typeof iat === 'number').toBe(true);
-    // The issued at time should be in the past
+    // The issued at time should be in the past (or now)
     const nowSeconds = Date.now() / 1000;
-    expect(iat).toBeLessThan(nowSeconds);
+    expect(iat).toBeLessThanOrEqual(nowSeconds);
   });
 
   it('should return a JWT without the picture claim, if picture not defined', () => {


### PR DESCRIPTION
Fixes #2138, setting the expected iat claim time to be less than **or equal to** now, which fixes the extremely rare case that the token is issued and the test run at the same second.