### PR TITLE
Update auth tests to more closely match signup requirements

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -52,6 +52,17 @@ services:
       # Cloud Firestore
       - '8088:8088'
 
+  # Static Web Content for tests, hosting the contents of test/test-web-content.
+  # The host can use http://localhost:8888 to access these files, and Docker
+  # containers can use http://test-web-content instead.
+  test-web-content:
+    container_name: 'test-web-content'
+    image: 'nginx:stable-alpine'
+    ports:
+      - '8888:80'
+    volumes:
+      - ../test/test-web-content:/usr/share/nginx/html:ro
+
   redis:
     ports:
       - '6379:6379'
@@ -69,6 +80,8 @@ services:
       # We development and testing, the Auth service needs to contact the users
       # service directly via Docker vs through the http://localhost domain.
       - USERS_URL=http://users:6666
+    depends_on:
+      - test-web-content
 
   parser:
     environment:

--- a/jest-playwright.config.js
+++ b/jest-playwright.config.js
@@ -9,11 +9,4 @@ module.exports = {
     headless: true,
   },
   browsers: ['chromium', 'firefox', 'webkit'],
-  serverOptions: {
-    command: 'npx http-server src/api/auth/test/e2e -p 8888',
-    port: 8888,
-    launchTimeout: 30000,
-    usedPortAction: 'kill',
-    debug: true,
-  },
 };

--- a/jest.config.e2e.js
+++ b/jest.config.e2e.js
@@ -3,4 +3,8 @@ const baseConfig = require('./jest.config.base');
 module.exports = {
   ...baseConfig,
   projects: ['<rootDir>/src/api/**/jest.config.e2e.js'],
+  // Some tests depend on auth state, which can get out of sync if we run tests
+  // in parallel. Run only one e2e test at a time.
+  maxConcurrency: 1,
+  maxWorkers: 1,
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pretest": "npm run lint",
     "test": "npm run jest",
     "jest": "cross-env NODE_ENV=test LOG_LEVEL=error MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest -c jest.config.js --",
-    "jest:e2e": "jest -c jest.config.e2e.js --runInBand --",
+    "jest:e2e": "jest -c jest.config.e2e.js --",
     "coverage": "cross-env NODE_ENV=test LOG_LEVEL=silent MOCK_REDIS=1 FEED_URL_INTERVAL_MS=200 jest -c jest.config.js --collectCoverage --",
     "jest-watch": "cross-env MOCK_REDIS=1 jest -c jest.config.js --watch --",
     "jest-update": "cross-env MOCK_REDIS=1 jest -c jest.config.js --updateSnapshot --",

--- a/src/api/auth/jest.config.e2e.js
+++ b/src/api/auth/jest.config.e2e.js
@@ -8,4 +8,7 @@ module.exports = {
   // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright
   // See the jest-playwright config in the Telescope root ./jest-playwright.config.js
   preset: 'jest-playwright-preset',
+  // Try reducing the number of tests that can run at once down to 1
+  maxConcurrency: 1,
+  maxWorkers: 1,
 };

--- a/src/api/auth/package.json
+++ b/src/api/auth/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "description": "An Authorization Service",
   "scripts": {
-    "test:manual": "http-server test/manual -p 8888",
     "dev": "env-cmd -f env.local nodemon src/server.js",
     "start": "node src/server.js"
   },
@@ -31,7 +30,6 @@
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",
-    "http-server": "^0.12.3",
     "nodemon": "^2.0.7"
   }
 }

--- a/src/api/auth/test/e2e/auth-flows.test.js
+++ b/src/api/auth/test/e2e/auth-flows.test.js
@@ -5,7 +5,14 @@ const fetch = require('node-fetch');
 // We need to get the URL to the auth service running in docker, and the list
 // of allowed origins, to compare with assumptions in the tests below.
 const { AUTH_URL, ALLOWED_APP_ORIGINS } = process.env;
-const { login, logout, USERS_URL, getTokenAndState, createTelescopeUsers } = require('./utils');
+const {
+  login,
+  logout,
+  USERS_URL,
+  getTokenAndState,
+  createTelescopeUsers,
+  cleanupTelescopeUsers,
+} = require('./utils');
 
 // We have 3 SSO user accounts in the login service (see config/simplesamlphp-users.php):
 //
@@ -62,10 +69,11 @@ describe('Authentication Flows', () => {
 
     context = await browser.newContext();
     page = await browser.newPage();
-    await page.goto(`http://localhost:8888/`);
+    await page.goto(`http://localhost:8888/auth.html`);
   });
 
   afterEach(async () => {
+    await cleanupTelescopeUsers(users);
     await context.close();
     await page.close();
   });
@@ -152,7 +160,7 @@ describe('Authentication Flows', () => {
     // Click login again, but we should get navigated back to this page right away
     await Promise.all([
       page.waitForNavigation({
-        url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
+        url: /^http:\/\/localhost:\d+\/auth\.html\?access_token=[^&]+&state=/,
         waitUtil: 'load',
       }),
       page.click('#login'),

--- a/src/api/auth/test/e2e/auth-flows.test.js
+++ b/src/api/auth/test/e2e/auth-flows.test.js
@@ -1,19 +1,11 @@
 // NOTE: you need to run the auth and login services in docker for these to work
-const { decode } = require('jsonwebtoken');
 const { createServiceToken, hash } = require('@senecacdot/satellite');
 const fetch = require('node-fetch');
 
 // We need to get the URL to the auth service running in docker, and the list
 // of allowed origins, to compare with assumptions in the tests below.
 const { AUTH_URL, ALLOWED_APP_ORIGINS } = process.env;
-const {
-  login,
-  logout,
-  USERS_URL,
-  getTokenAndState,
-  createTelescopeUsers,
-  cleanupTelescopeUsers,
-} = require('./utils');
+const { login, logout, USERS_URL, getTokenAndState, createTelescopeUsers } = require('./utils');
 
 // We have 3 SSO user accounts in the login service (see config/simplesamlphp-users.php):
 //
@@ -22,7 +14,6 @@ const {
 // | user1       | user1@example.com           | user1pass | Johannes Kepler |
 // | user2       | user2@example.com           | user2pass | Galileo Galilei |
 // | lippersheyh | hans-lippershey@example.com | telescope | Hans Lippershey |
-//
 
 // Admin Telescope user
 const johannesKepler = {
@@ -30,7 +21,6 @@ const johannesKepler = {
   lastName: 'Kepler',
   email: 'user1@example.com',
   displayName: 'Johannes Kepler',
-  // this is a Telescope admin
   isAdmin: true,
   isFlagged: false,
   feeds: ['https://imaginary.blog.com/feed/johannes'],

--- a/src/api/auth/test/e2e/blog.html
+++ b/src/api/auth/test/e2e/blog.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="alternate" type="application/rss+xml" href="https://hans.blog.com/feed" />
+    <title>Fake Blog for Testing</title>
+  </head>
+  <body>
+    <h1>Fake Blog</h1>
+    <p>
+      This page is used in the signup-flow.test.js file to simulate a blog with feed URL in head.
+    </p>
+  </body>
+</html>

--- a/src/api/auth/test/e2e/signup-flow.test.js
+++ b/src/api/auth/test/e2e/signup-flow.test.js
@@ -2,14 +2,16 @@
 const { createServiceToken, hash } = require('@senecacdot/satellite');
 const fetch = require('node-fetch');
 
-const { cleanupTelescopeUsers, login, logout, USERS_URL } = require('./utils');
+// We need to get the URL to the auth service running in docker, and the list
+// of allowed origins, to compare with assumptions in the tests below.
+const { login, logout, USERS_URL, cleanupTelescopeUsers } = require('./utils');
 
 // The user info we'll use to register. We have the following user in our login
 // SSO already:
 //
 // | Username    | Email                       | Password  | Display Name    |
 // |-------------|-----------------------------|-----------|-----------------|
-// | user2 | user2@example.com | user2pass | Galileo Galilei |
+// | user2       | user2@example.com           | user2pass | Galileo Galilei |
 const galileoGalilei = {
   firstName: 'Galileo',
   lastName: 'Galilei',
@@ -17,7 +19,7 @@ const galileoGalilei = {
   displayName: 'Galileo Galilei',
   isAdmin: false,
   isFlagged: false,
-  feeds: ['https://imaginary.blog.com/feed/hans'],
+  feeds: ['https://hans.blog.com/feed'],
   github: {
     username: 'hlippershey',
     avatarUrl:
@@ -69,32 +71,61 @@ describe('Signup Flow', () => {
 
       // Step 2: confirm the token's payload for this user
       expect(jwt.sub).toEqual(hash(galileoGalilei.email));
+      expect(jwt.email).toEqual(galileoGalilei.email);
+      expect(jwt.given_name).toEqual(galileoGalilei.firstName);
+      expect(jwt.family_name).toEqual(galileoGalilei.lastName);
       expect(jwt.name).toEqual(galileoGalilei.displayName);
       expect(jwt.roles).toEqual(['seneca']);
+      // There shouldn't be a picture
       expect(jwt.picture).toBe(undefined);
 
       return { accessToken, jwt };
     }
 
-    // Part 2: use the access token to POST to the Users service in order to
+    // Part 2: use the access token to POST to the feed-discovery service in order to
+    // get a list of feed URLs.
+    async function partTwo(accessToken) {
+      // See the file blog.html in this same folder.  NOTE: the blog is hosted
+      // on port 8888 running on the host, and the feed-discovery service needs
+      // to access :8888 on the docker host vs. it's own localhost, so we use
+      // host.docker.internal vs. localhost.
+      const blogUrl = 'http://host.docker.internal:8888/blog.html';
+      const feedUrl = 'https://hans.blog.com/feed';
+
+      const res = await fetch('http://localhost/v1/feed-discovery', {
+        method: 'POST',
+        headers: {
+          Authorization: `bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ blogUrl }),
+      });
+      expect(res.status).toBe(200);
+      const result = await res.json();
+      expect(result).toEqual({ feedUrls: [feedUrl] });
+      return feedUrl;
+    }
+
+    // Part 3: use the access token to POST to the Users service in order to
     // register with Telescope.
-    async function partTwo(accessToken, jwt) {
+    async function partThree(feedUrl, accessToken, jwt) {
+      const user = { ...galileoGalilei, feeds: [feedUrl] };
       const res = await fetch(`${USERS_URL}/${jwt.sub}`, {
         method: 'POST',
         headers: {
           Authorization: `bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(galileoGalilei),
+        body: JSON.stringify(user),
       });
-      expect(res.ok).toBe(true);
+      expect(res.status).toBe(201);
     }
 
-    // Part 3: logout so we can try logging in again as a registered user.
+    // Part 4: logout so we can try logging in again as a registered user.
     // Confirm that the token payload matches our upgraded user status.
     // Confirm that the data in the Users service for this user
     // matches what we expect, and that our token allows us to access it.
-    async function partThree() {
+    async function partFour() {
       // Logout
       await logout(page);
 
@@ -103,6 +134,9 @@ describe('Signup Flow', () => {
 
       // Check token payload, make sure it matches what we expect
       expect(jwt.sub).toEqual(hash(galileoGalilei.email));
+      expect(jwt.email).toEqual(galileoGalilei.email);
+      expect(jwt.given_name).toEqual(galileoGalilei.firstName);
+      expect(jwt.family_name).toEqual(galileoGalilei.lastName);
       expect(jwt.name).toEqual(galileoGalilei.displayName);
       expect(jwt.roles).toEqual(['seneca', 'telescope']);
       expect(jwt.picture).toEqual(galileoGalilei.github.avatarUrl);
@@ -120,7 +154,8 @@ describe('Signup Flow', () => {
     }
 
     const { accessToken, jwt } = await partOne();
-    await partTwo(accessToken, jwt);
-    await partThree();
+    const feedUrl = await partTwo(accessToken);
+    await partThree(feedUrl, accessToken, jwt);
+    await partFour();
   });
 });

--- a/src/api/auth/test/e2e/utils.js
+++ b/src/api/auth/test/e2e/utils.js
@@ -73,7 +73,7 @@ const login = async (page, username, password) => {
   // Click login button and then wait for the new page to load
   await Promise.all([
     page.waitForNavigation({
-      url: /^http:\/\/localhost:\d+\/\?access_token=[^&]+&state=/,
+      url: /^http:\/\/localhost:\d+\/auth\.html\?access_token=[^&]+&state=/,
       waitUtil: 'load',
     }),
     page.click('text=/.*Login.*/'),
@@ -88,7 +88,7 @@ const logout = async (page) => {
   // Click logout and we should get navigated back to this page right away
   await Promise.all([
     page.waitForNavigation({
-      url: /^http:\/\/localhost:\d+\/\?state=/,
+      url: /^http:\/\/localhost:\d+\/auth\.html\?state=/,
       waitUtil: 'load',
     }),
     page.click('#logout'),

--- a/test/test-web-content/auth.html
+++ b/test/test-web-content/auth.html
@@ -6,12 +6,12 @@
   </head>
   <body>
     <a
-      href="http://localhost/v1/auth/login?redirect_uri=http://localhost:8888/&state=abc123"
+      href="http://localhost/v1/auth/login?redirect_uri=http://localhost:8888/auth.html&state=abc123"
       id="login"
       >Login</a
     >
     <a
-      href="http://localhost/v1/auth/logout?redirect_uri=http://localhost:8888/&state=abc123"
+      href="http://localhost/v1/auth/logout?redirect_uri=http://localhost:8888/auth.html&state=abc123"
       id="logout"
       >Logout</a
     >

--- a/test/test-web-content/blog.html
+++ b/test/test-web-content/blog.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="alternate" type="application/rss+xml" href="https://hans.blog.com/feed" />
+    <link rel="alternate" type="application/rss+xml" href="http://localhost:8888/feed.xml" />
     <title>Fake Blog for Testing</title>
   </head>
   <body>

--- a/test/test-web-content/feed.xml
+++ b/test/test-web-content/feed.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<rss version="2.0">
+  <channel>
+    <title>FeedForAll Sample Feed</title>
+    <description>RSS is a fascinating technology. The uses for RSS are expanding daily. Take a closer look at how various industries are using the benefits of RSS in their businesses.</description>
+    <link>http://www.feedforall.com/industry-solutions.htm</link>
+    <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+    <copyright>Copyright 2004 NotePage, Inc.</copyright>
+    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 19 Oct 2004 13:39:14 -0400</lastBuildDate>
+    <managingEditor>marketing@feedforall.com</managingEditor>
+    <pubDate>Tue, 19 Oct 2004 13:38:55 -0400</pubDate>
+    <webMaster>webmaster@feedforall.com</webMaster>
+    <generator>FeedForAll Beta1 (0.0.1.8)</generator>
+    <image>
+      <url>http://www.feedforall.com/ffalogo48x48.gif</url>
+      <title>FeedForAll Sample Feed</title>
+      <link>http://www.feedforall.com/industry-solutions.htm</link>
+      <description>FeedForAll Sample Feed</description>
+      <width>48</width>
+      <height>48</height>
+    </image>
+    <item>
+      <title>RSS Solutions for Restaurants</title>
+      <description>&lt;b&gt;FeedForAll &lt;/b&gt;helps Restaurant&apos;s communicate with customers. Let your customers know the latest specials or events.&lt;br&gt;
+&lt;br&gt;
+RSS feed uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#FF0000&quot;&gt;Daily Specials &lt;br&gt;
+Entertainment &lt;br&gt;
+Calendar of Events &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/restaurant.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:11 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Schools and Colleges</title>
+      <description>FeedForAll helps Educational Institutions communicate with students about school wide activities, events, and schedules.&lt;br&gt;
+&lt;br&gt;
+RSS feed uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Homework Assignments &lt;br&gt;
+School Cancellations &lt;br&gt;
+Calendar of Events &lt;br&gt;
+Sports Scores &lt;br&gt;
+Clubs/Organization Meetings &lt;br&gt;
+Lunches Menus &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/schools.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:09 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Computer Service Companies</title>
+      <description>FeedForAll helps Computer Service Companies communicate with clients about cyber security and related issues. &lt;br&gt;
+&lt;br&gt;
+Uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Cyber Security Alerts &lt;br&gt;
+Specials&lt;br&gt;
+Job Postings &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/computer-service.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:07 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Governments</title>
+      <description>FeedForAll helps Governments communicate with the general public about positions on various issues, and keep the community aware of changes in important legislative issues. &lt;b&gt;&lt;i&gt;&lt;br&gt;
+&lt;/b&gt;&lt;/i&gt;&lt;br&gt;
+RSS uses Include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#00FF00&quot;&gt;Legislative Calendar&lt;br&gt;
+Votes&lt;br&gt;
+Bulletins&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/government.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:05 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Politicians</title>
+      <description>FeedForAll helps Politicians communicate with the general public about positions on various issues, and keep the community notified of their schedule. &lt;br&gt;
+&lt;br&gt;
+Uses Include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#FF0000&quot;&gt;Blogs&lt;br&gt;
+Speaking Engagements &lt;br&gt;
+Statements&lt;br&gt;
+ &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/politics.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:03 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Meteorologists</title>
+      <description>FeedForAll helps Meteorologists communicate with the general public about storm warnings and weather alerts, in specific regions. Using RSS meteorologists are able to quickly disseminate urgent and life threatening weather warnings. &lt;br&gt;
+&lt;br&gt;
+Uses Include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Weather Alerts&lt;br&gt;
+Plotting Storms&lt;br&gt;
+School Cancellations &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/weather.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:01 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Realtors &amp; Real Estate Firms</title>
+      <description>FeedForAll helps Realtors and Real Estate companies communicate with clients informing them of newly available properties, and open house announcements. RSS helps to reach a targeted audience and spread the word in an inexpensive, professional manner. &lt;font color=&quot;#0000FF&quot;&gt;&lt;br&gt;
+&lt;/font&gt;&lt;br&gt;
+Feeds can be used for:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#FF0000&quot;&gt;Open House Dates&lt;br&gt;
+New Properties For Sale&lt;br&gt;
+Mortgage Rates&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/real-estate.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:08:59 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Banks / Mortgage Companies</title>
+      <description>FeedForAll helps &lt;b&gt;Banks, Credit Unions and Mortgage companies&lt;/b&gt; communicate with the general public about rate changes in a prompt and professional manner. &lt;br&gt;
+&lt;br&gt;
+Uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Mortgage Rates&lt;br&gt;
+Foreign Exchange Rates &lt;br&gt;
+Bank Rates&lt;br&gt;
+Specials&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/banks.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:08:57 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Law Enforcement</title>
+      <description>&lt;b&gt;FeedForAll&lt;/b&gt; helps Law Enforcement Professionals communicate with the general public and other agencies in a prompt and efficient manner. Using RSS police are able to quickly disseminate urgent and life threatening information. &lt;br&gt;
+&lt;br&gt;
+Uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Amber Alerts&lt;br&gt;
+Sex Offender Community Notification &lt;br&gt;
+Weather Alerts &lt;br&gt;
+Scheduling &lt;br&gt;
+Security Alerts &lt;br&gt;
+Police Report &lt;br&gt;
+Meetings&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/law-enforcement.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:08:56 -0400</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/test/test-web-content/index.html
+++ b/test/test-web-content/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Test Web Content</title>
+  </head>
+  <body>
+    <h1>Test Web Content</h1>
+    <p>
+      This site contains static web content needed for testing. You can access it using one of two
+      domains:
+    </p>
+    <ol>
+      <li>From a Docker container: <code>http://test-web-content/</code></li>
+      <li>From the Host system: <code>http://localhost:8888/</code></li>
+    </ol>
+    <p>In your tests, if one isn't accessible, the other probably is.</p>
+    <h2>Test Files</h2>
+    <p>The following files are available:</p>
+    <ul>
+      <li><a href="index.html">index.html</a></li>
+      <li><a href="blog.html">blog.html</a></li>
+      <li><a href="feed.xml">feed.xml</a></li>
+      <li><a href="auth.html">auth.html</a></li>
+      <li><a href="manual-auth/index.html">manual-auth/index.html</a></li>
+    </ul>
+  </body>
+</html>

--- a/test/test-web-content/manual-auth/index.html
+++ b/test/test-web-content/manual-auth/index.html
@@ -14,21 +14,17 @@
     <h1>Telescope Auth Service Test</h1>
     <p>
       This is a small client web app used to help test the auth service setup. It assumes you are
-      using the docker-compose setup in <code>/src/api/docker-compose.yml</code> to run the
-      <code>login</code> and <code>auth</code> microservices via Traefik. If you haven't done so
-      already, you should do the following in the root of the Telescope project:
+      running the microservices. If you haven't done so already, you should do the following in the
+      root of the Telescope project:
     </p>
 
     <code>
       <pre>
-        npm run services:start auth login
+        npm run services:start
       </pre>
     </code>
 
-    <p>
-      That will star the <code>auth</code> and <code>login</code> services that you need for this
-      demo to work.
-    </p>
+    <p>That will start the necessary services for this demo to work.</p>
 
     <nav>
       <ul>

--- a/test/test-web-content/manual-auth/script.js
+++ b/test/test-web-content/manual-auth/script.js
@@ -5,8 +5,8 @@
 import { nanoid } from 'https://cdn.jsdelivr.net/npm/nanoid/nanoid.js';
 import jwtDecode from 'https://cdn.jsdelivr.net/npm/jwt-decode@3.1.2/build/jwt-decode.esm.js';
 
-// Use same URL as your env.local
-const authServer = 'http://localhost:7777';
+const authServer = 'http://localhost/v1/auth';
+const frontEnd = 'http://localhost:8888/manual-auth/index.html';
 
 function printToken(token) {
   const jwtElem = document.querySelector('#jwt');
@@ -48,7 +48,7 @@ window.onload = function () {
   login.onclick = () => {
     localStorage.setItem('state', expectedState);
     window.location.href = `${authServer}/login?redirect_uri=${encodeURIComponent(
-      `${url.origin}/`
+      frontEnd
     )}&state=${expectedState}`;
   };
 
@@ -56,7 +56,7 @@ window.onload = function () {
   logout.onclick = () => {
     localStorage.setItem('state', expectedState);
     window.location.href = `${authServer}/logout?redirect_uri=${encodeURIComponent(
-      `${url.origin}/`
+      frontEnd
     )}&state=${expectedState}`;
   };
 };


### PR DESCRIPTION
Debugging the new signup flow with @PedroFonsecaDEV and @DukeManh last night made me realize I should expand the signup e2e test to better match what we do in the front-end.

I'm not 100% sure if this will work on all platforms, since I have to use http://host.docker.internal vs. http://localhost in the test.  I want to see how it performs on CI.