### PR TITLE
Fix typo in users URL for status service

### DIFF
--- a/src/api/status/src/services.js
+++ b/src/api/status/src/services.js
@@ -31,8 +31,8 @@ const services = [
   },
   {
     name: 'user',
-    staging: stagingUrl('/user/healthcheck'),
-    production: prodUrl('/user/healthcheck'),
+    staging: stagingUrl('/users/healthcheck'),
+    production: prodUrl('/users/healthcheck'),
   },
   {
     name: 'search',


### PR DESCRIPTION
I notice that the Users service is [always down in the status service](https://dev.api.telescope.cdot.systems/v1/status).  I checked why, and I was missing an 's'.