### PR TITLE
Add authorization middlware to parser service

### DIFF
--- a/src/api/parser/src/index.js
+++ b/src/api/parser/src/index.js
@@ -1,4 +1,4 @@
-const { Satellite } = require('@senecacdot/satellite');
+const { Satellite, isAuthenticated, isAuthorized } = require('@senecacdot/satellite');
 const { router } = require('bull-board');
 // const startParserQueue = require('./parser-queue');
 
@@ -7,6 +7,12 @@ const service = new Satellite();
 // We're commenting startParserQueue() for now so it doesn't clash with our current backend, will uncomment when tests go in and we remove the backend.
 // startParserQueue();
 
-service.router.use('/', router);
+// Only authenticated Telescope users, or other services, can hit this route
+service.router.get(
+  '/',
+  isAuthenticated(),
+  isAuthorized((req, user) => user.roles.includes('telescope') || user.roles.includes('service')),
+  router
+);
 
 module.exports = service;


### PR DESCRIPTION
This updates the parser service so that only authenticated Telescope users (e.g., vs. the general public or Seneca-only users) can see the Bull-Board UI.  I don't think it's smart to expose this to the world, but it's probably OK to let our users see it, since they might want to hack on Telescope with us, and this way they can help debug if job's aren't happening correctly.

See the docs on how Satellite's middleware works, if you're not familiar with this: https://github.com/Seneca-CDOT/satellite#middleware