### PR TITLE
Add users container to depends_on for auth docker service

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - ${AUTH_PORT}
     depends_on:
       - traefik
+      - users
     labels:
       # Enable Traefik
       - 'traefik.enable=true'


### PR DESCRIPTION
We've updated the Auth service to talk to the Users service, so we need to make sure that the Users service starts when we start Auth in docker.