### PR TITLE
Fix docker environment for search service

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -88,8 +88,3 @@ services:
       # For development and testing, the Parser service needs to contact the users
       # service directly via Docker vs through the http://localhost domain.
       - USERS_URL=http://users:6666
-
-  search:
-    environment:
-      - ELASTIC_URL=http://localhost
-      - ELASTIC_PORT=9200

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,7 +87,10 @@ services:
     environment:
       - NODE_ENV
       - SEARCH_PORT
+      - POSTS_URL
       - ELASTIC_MAX_RESULTS_PER_PAGE
+      - ELASTIC_URL=http://elasticsearch
+      - ELASTIC_PORT=9200
       # Satellite authentication/authorization support
       - JWT_ISSUER
       - JWT_AUDIENCE


### PR DESCRIPTION
We need a few tweaks to our environment for the Search service.  The search service needs to be able to talk to Elasticserach via the Docker network, so the domain name has to be the `elasticsearch` container vs. `localhost`, or it can't reach outside of its own container.  Also, we need to do this in all configurations, not just in dev or production, so I've moved it to `docker-compose.yml`.  Finally, we need to expose the `POSTS_URL` to the environment of the search service, so that it can construct URLs.