### PR TITLE
Fixes #1983: Improve SearchHelp logic

### DIFF
--- a/src/web/src/components/SearchPage.tsx
+++ b/src/web/src/components/SearchPage.tsx
@@ -21,14 +21,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const SearchPage = () => {
   const classes = useStyles();
-
   const { showHelp } = useSearchValue();
 
   return (
     <div className={classes.searchPage}>
       <SearchBar />
-      <SearchResults />
       {showHelp && <SearchHelp />}
+      <SearchResults />
     </div>
   );
 };

--- a/src/web/src/components/SearchProvider.tsx
+++ b/src/web/src/components/SearchProvider.tsx
@@ -10,6 +10,7 @@ export interface SearchContextInterface {
   textParam: string;
   filter: FilterProp['filter'];
   showHelp: boolean;
+  toggleHelp: (value: boolean) => void;
   onTextChange: (value: string) => void;
   onFilterChange: (value: FilterProp['filter']) => void;
   onSubmitHandler: (value: FormEvent) => void;
@@ -20,6 +21,9 @@ const SearchContext = createContext<SearchContextInterface>({
   textParam: '',
   filter: 'post',
   showHelp: true,
+  toggleHelp() {
+    throw new Error('This context must be wrapped inside SearchProvider');
+  },
   onTextChange() {
     throw new Error('This context must be wrapped inside SearchProvider');
   },
@@ -54,9 +58,10 @@ const SearchProvider = ({ children }: Props) => {
   const onSubmitHandler = (event: FormEvent) => {
     event.preventDefault();
     router.push(`/search?text=${text}&filter=${filter}`);
+  };
 
-    // On form submit, hide help list
-    setShowHelp(false);
+  const toggleHelp = (value: boolean) => {
+    setShowHelp(value);
   };
 
   const onTextChange = (value: string) => {
@@ -74,7 +79,16 @@ const SearchProvider = ({ children }: Props) => {
 
   return (
     <SearchContext.Provider
-      value={{ text, textParam, showHelp, filter, onTextChange, onFilterChange, onSubmitHandler }}
+      value={{
+        text,
+        textParam,
+        showHelp,
+        filter,
+        onTextChange,
+        onFilterChange,
+        onSubmitHandler,
+        toggleHelp,
+      }}
     >
       {children}
     </SearchContext.Provider>

--- a/src/web/src/components/SearchResults.tsx
+++ b/src/web/src/components/SearchResults.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles(() => ({
 
 const SearchResults = () => {
   const classes = useStyles();
-  const { textParam, filter } = useSearchValue();
+  const { textParam, filter, toggleHelp } = useSearchValue();
 
   const prepareUrl = (index: number) =>
     `${searchServiceUrl}?text=${encodeURIComponent(textParam)}&filter=${filter}&page=${index}`;
@@ -74,6 +74,13 @@ const SearchResults = () => {
   // Another page is being loaded when size is incremented but data[size - 1] is still undefined
   const loadingMoreData =
     !isReachingEnd && data && size > 0 && typeof data[size - 1] === 'undefined';
+
+  // If there is no posts or if the search bar is empty, then show the search help, otherwise hide it
+  if (!error && (isEmpty || textParam.length == 0)) {
+    toggleHelp(true);
+  } else {
+    toggleHelp(false);
+  }
 
   if (error) {
     return (


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #1983 

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
Previously, as soon as you hit the submit button the SearchHelp would disappear. The only way to get the SearchHelp to appear again would be to refresh the page.

It would be beneficial if the SearchHelp would appear when the User's search returned no results (case A) or if the search bar was empty (case B).

This is better logically speaking since in those two additional scenarios we can assume that the User either failed their search or are about to search for something, both of which would benefit from seeing the SearchHelp. That is what this PR accomplishes.

Read more [here](https://github.com/Seneca-CDOT/telescope/issues/1983)

## How to Test
1. Search `validation.js` (it should return a timeline of posts)
    - scroll all the way to the end to check if the `SearchHelp` component truly disappeared (it should be hidden)
2. (case A) Search `fasdfsadf` (it should return `No Results Found`)
    - the `SearchHelp` component should be visible
3. (case B) Clear your search bar and hit submit
    - the `SearchHelp` component should be visible

## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
