### PR TITLE
Don't crash on SAML logout error, log and redirect

### DIFF
--- a/src/api/auth/src/routes/logout.js
+++ b/src/api/auth/src/routes/logout.js
@@ -55,10 +55,8 @@ router.get(
       passport._strategy('saml').logout(req, (error, requestUrl) => {
         if (error) {
           logger.error({ error }, 'logout error - unable to generate logout URL');
-          next(createError(500, `unable to logout`));
-        } else {
-          res.redirect(requestUrl);
         }
+        res.redirect(requestUrl);
       });
     } catch (error) {
       logger.error({ error }, 'logout error');


### PR DESCRIPTION
Fixes #2162

If the SAML logout fails, we currently send a 500 and don't redirect back to the front-end.  This isn't a great user experience, and always redirecting back again is probably the better move.