### PR TITLE
Fixes #1801 Code Highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "cors": "2.8.5",
     "date-fns": "2.19.0",
     "docker-compose": "0.23.6",
+    "dompurify": "2.2.7",
     "dotenv": "8.2.0",
     "entities": "2.2.0",
     "express": "4.17.1",
@@ -91,7 +92,7 @@
     "pino": "6.11.2",
     "pino-elasticsearch": "5.4.0",
     "pino-pretty": "4.7.1",
-    "sanitize-html": "2.3.2",
+    "sanitize-html-react": "1.13.0",
     "set-interval-async": "1.0.34",
     "stoppable": "1.1.0",
     "valid-url": "1.0.9"

--- a/src/backend/utils/html/sanitize.js
+++ b/src/backend/utils/html/sanitize.js
@@ -1,12 +1,10 @@
 // Sanitize HTML and prevent XSS attacks
 // <img src=x onerror=alert(1)> becomes <img src="x">
 
-const sanitizeHtml = require('sanitize-html');
-
+const sanitizeHtml = require('dompurify');
 module.exports = function (dirty) {
-  return sanitizeHtml(dirty, {
-    // https://github.com/apostrophecms/sanitize-html#what-are-the-default-options
-    allowedTags: [
+  var e = sanitizeHtml.sanitize(dirty, {
+    ALLOWED_TAGS: [
       'a',
       'b',
       'blockquote',
@@ -40,19 +38,23 @@ module.exports = function (dirty) {
       'thread',
       'tr',
       'ul',
+      'MDXPageBase',
     ],
-    allowedSchemesByTag: { img: ['http', 'https', 'data'] },
-    allowedAttributes: {
-      iframe: ['src'],
-      img: ['src'],
-      a: ['href'],
-    },
-    allowedIframeHostnames: [
-      'www.youtube.com',
-      'player.vimeo.com',
-      'giphy.com',
-      'cdn.embedly.com',
-      'open.spotify.com',
+    ADD_TAGS: ['iframe', 'MDXPageBase'],
+    ADD_ATTR: ['src'],
+    FORBID_TAGS: ['style', 'class', 'cellspacing', 'align', 'cellpadding'],
+    FORBID_ATTR: [
+      'style',
+      'class',
+      'width',
+      'height',
+      'cellspacing',
+      'align',
+      'cellpadding',
+      'border',
+      'alt',
     ],
+    RETURN_DOM: true,
   });
+  return e.getElementsByTagName('body');
 };

--- a/test/sanitize-html.test.js
+++ b/test/sanitize-html.test.js
@@ -134,4 +134,10 @@ describe('Sanitize HTML', () => {
       '<table><tbody><tr><td><a href="www.senecacollege.ca"><img src="https://1.bp.blogspot.com/11.JPG" /></a></td></tr><tr><td>The Final Product</td></tr></tbody></table>'
     );
   });
+
+  test('test unique HTML Bug from Chris', () => {
+    const h = sanitizeHTML(`<><MDXPageBase title='About Us'><About /></MDXPageBase></>`);
+
+    expect(h).toBe(`<><MDXPageBase title="About Us"><About /></MDXPageBase></>`);
+  });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1801, Code Escaping Bug
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
So, we've discussed about fixing this bug for quite a while.
Last week, I've audited the code, and described how the bug works, and went through it's call stacks to get an understanding of how the code works. 

@chrispinkney had the suggestion to use a fork of our `sanitize-html` tool specifically for React, however there's some really bad vulnerabilities that hasn't been patched, so we can't use it.

I then decided that the best solution was to use the DOMPurify tool instead:
https://www.npmjs.com/package/dompurify

There are quite a few problems though:
I needed to use the `RETURN_DOM` option in order for the sanitizer to NOT remove escape characters. Unfortunately, it wraps everything into a `<body>` tag. 

Since we're using DOMPurify, there's no option to whitelist `iframe` links, so we should find an npm package that will allow us to add our whitelist.

Screencaps of what I'm talking about:

Without Returning the String as a DOM (wrapping it with the `body` tag), the escape character is removed.
![Screenshot_424](https://user-images.githubusercontent.com/58116522/115159478-441daf00-a061-11eb-803d-ce61557da1ad.png)

When we use the `RETURN_DOM` option to wrap everything, notice the Escape Characters not being removed, but the `body` tag remains.
![Screenshot_425](https://user-images.githubusercontent.com/58116522/115159505-6c0d1280-a061-11eb-9471-5f5e4185971d.png)



## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
