### PR TITLE
Fixes #2169: Rename blog prop to url in PostAvatar, deal with optional value

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -277,7 +277,7 @@ const PostComponent = ({ postUrl }: Props) => {
         {!desktop && (
           <>
             <div className={classes.authorAvatarContainer}>
-              <PostAvatar name={post.feed.author} blog={post.feed.link} />
+              <PostAvatar name={post.feed.author} url={post.feed.link} />
             </div>
             <div className={classes.authorNameContainer}>
               <h1 className={classes.author}>

--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 type AvatarProps = {
   name: string;
   img?: string;
-  blog?: string;
+  url?: string;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-const PostAvatar = ({ name, img, blog = '' }: AvatarProps) => {
+const PostAvatar = ({ name, img, url }: AvatarProps) => {
   const classes = useStyles();
 
   if (img) {
@@ -58,11 +58,19 @@ const PostAvatar = ({ name, img, blog = '' }: AvatarProps) => {
       )
       .join('');
     return (
-      <a href={blog} className={classes.link}>
-        <Avatar className={classes.avatar}>
-          <p className={classes.text}>{initials}</p>
-        </Avatar>
-      </a>
+      <div>
+        {url?.length ? (
+          <a href={url} className={classes.link}>
+            <Avatar className={classes.avatar}>
+              <p className={classes.text}>{initials}</p>
+            </Avatar>
+          </a>
+        ) : (
+          <Avatar className={classes.avatar}>
+            <p className={classes.text}>{initials}</p>
+          </Avatar>
+        )}
+      </div>
     );
   }
 

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -76,7 +76,7 @@ const PostDesktopInfo = ({ authorName, postDate, blogUrl, postUrl }: Props) => {
   return (
     <ListSubheader className={classes.root}>
       <div className={classes.authorAvatarContainer}>
-        <PostAvatar name={authorName} blog={blogUrl} />
+        <PostAvatar name={authorName} url={blogUrl} />
       </div>
       <div className={classes.authorNameContainer}>
         <p className={classes.author}>

--- a/src/web/src/components/SignUp/Forms/GitHubAccount.tsx
+++ b/src/web/src/components/SignUp/Forms/GitHubAccount.tsx
@@ -171,7 +171,7 @@ const GitHubAccount = connect<{}, SignUpForm>((props) => {
             <div className={classes.avatarPreview}>
               <PostAvatar
                 name={values.github.username || values.displayName}
-                blog={values.github.avatarUrl}
+                url={values.github.avatarUrl}
                 img={values.github?.avatarUrl}
               />
               <h2 className={classes.username}>{values.github.username}</h2>

--- a/src/web/src/components/SignUp/Forms/Review.tsx
+++ b/src/web/src/components/SignUp/Forms/Review.tsx
@@ -101,7 +101,7 @@ const Review = connect<{}, SignUpForm>((props) => {
         <h1 className={classes.titlePage}>Review your Information</h1>
         <div className={classes.contentContainer}>
           <div className={classes.avatar}>
-            <PostAvatar name={displayName} blog={blogUrl} img={github.avatarUrl} />
+            <PostAvatar name={displayName} url={blogUrl} img={github.avatarUrl} />
             <h2>{displayName}</h2>
           </div>
           <div className={classes.senecaBlogInfo}>


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #2169

## Type of Change
- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
Changes the PostAvatar `blog` prop to be named `url`. 
Changes how the PostAvatar is rendered: if there is no url, then PostAvatar is rendered without an `<a>` element wrapped around it.

## How to Test
Pull this branch for testing, go to `components/Posts/Post.tsx` in VSCode (or your editor of choice) and scroll to the bottom - put a `<PostAvatar name="FirstName LastName" />` element somewhere that it can be rendered and seen. 

You should see an Avatar with the initials "FL" and it should also be unclickable (since their is no url prop)

Now add the prop `url="Test"` to the `PostAvatar` (e.g. `<PostAvatar name="FirstName LastName" url="Test"/>`

You should see that same Avatar now be clickable (if clicked it will give you Telescope's 404 because it is an invalid url).

## Checklist
- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
