### PR TITLE
Improve contrast ratio in contributor card and search results message

### DIFF
--- a/src/web/src/components/GitHubContributorCard.tsx
+++ b/src/web/src/components/GitHubContributorCard.tsx
@@ -7,7 +7,8 @@ const contributionsCount = (contributions: number) =>
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    backgroundColor: theme.palette.secondary.main,
+    backgroundColor:
+      theme.palette.type === 'light' ? theme.palette.secondary.main : theme.palette.secondary.dark,
   },
   typography: {
     color: theme.palette.text.primary,

--- a/src/web/src/components/Posts/Timeline.tsx
+++ b/src/web/src/components/Posts/Timeline.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme: Theme) =>
       alignItems: 'center',
       flexDirection: 'column',
       margin: '2rem',
+      color: theme.palette.primary.main,
     },
   })
 );

--- a/src/web/src/components/SearchResults.tsx
+++ b/src/web/src/components/SearchResults.tsx
@@ -1,6 +1,6 @@
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import { useSWRInfinite } from 'swr';
-import { Container, Box } from '@material-ui/core';
+import { Container, Box, createStyles } from '@material-ui/core';
 
 import { searchServiceUrl } from '../config';
 import Timeline from './Posts/Timeline';
@@ -9,45 +9,48 @@ import useSearchValue from '../hooks/use-search-value';
 
 const NoResultsImg = '/noResults.svg';
 
-const useStyles = makeStyles(() => ({
-  spinner: {
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  searchResults: {
-    padding: 0,
-    width: '100%',
-    justifyContent: 'center',
-  },
-  errorBackground: {
-    position: 'relative',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: '10px',
-    background: '#353F61',
-    boxShadow: '0 15px 30px rgba(0,0,0,.5)',
-    lineHeight: '1rem',
-  },
-  errorTitle: {
-    textAlign: 'center',
-    fontSize: '5rem',
-    color: '#fff',
-  },
-  errorMessage: {
-    lineHeight: '2rem',
-    fontSize: '2rem',
-    textAlign: 'center',
-    margin: '2rem',
-    color: '#96C1E7',
-  },
-  noResults: {
-    display: 'flex',
-    alignItems: 'center',
-    flexDirection: 'column',
-    margin: '2rem',
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    spinner: {
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    searchResults: {
+      padding: 0,
+      width: '100%',
+      justifyContent: 'center',
+    },
+    errorBackground: {
+      position: 'relative',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: '10px',
+      background: '#353F61',
+      boxShadow: '0 15px 30px rgba(0,0,0,.5)',
+      lineHeight: '1rem',
+    },
+    errorTitle: {
+      textAlign: 'center',
+      fontSize: '5rem',
+      color: '#fff',
+    },
+    errorMessage: {
+      lineHeight: '2rem',
+      fontSize: '2rem',
+      textAlign: 'center',
+      margin: '2rem',
+      color: '#96C1E7',
+    },
+    noResults: {
+      display: 'flex',
+      alignItems: 'center',
+      flexDirection: 'column',
+      margin: '2rem',
+      color: theme.palette.primary.main,
+    },
+  })
+);
 
 const SearchResults = () => {
   const classes = useStyles();

--- a/src/web/src/theme/index.ts
+++ b/src/web/src/theme/index.ts
@@ -44,6 +44,7 @@ export const darkTheme: Theme = createMuiTheme({
     },
     secondary: {
       main: '#4f96d8',
+      dark: '#121d59',
     },
     error: {
       main: red.A400,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes: #2049 
Fixes: #2168 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Current contributor card in about page (dark mode) doesn't meet AAA rating in WCAG. I change the color to make it meet the requirement.
**Before**
![image](https://user-images.githubusercontent.com/50813726/115329651-95f92e80-a160-11eb-94fa-494190f4a8fb.png)
**After**
![image](https://user-images.githubusercontent.com/50813726/115330223-a362e880-a161-11eb-92f7-5a01460f10de.png)

-----

The messages in search result, "No more posts" and "No results found" has same font and background color, which makes it invisible. I change the font color to make it visible. Please let me know if you have other suggestion of the color choosing, appreciate it.

**No more posts**
![chrome-capture (4)](https://user-images.githubusercontent.com/50813726/115330070-5ed74d00-a161-11eb-87fc-67f3231c8fed.gif)

**No results found**
![chrome-capture (5)](https://user-images.githubusercontent.com/50813726/115330082-6565c480-a161-11eb-897b-2196cb0ff2d0.gif)



## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
