### PR TITLE
Fixes # 2155: Improved postInfo grid size to fit bigger names on mobile

### DIFF
--- a/src/web/src/components/AdminButtons.tsx
+++ b/src/web/src/components/AdminButtons.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       margin: '-1em .5em 0 0',
     },
     [theme.breakpoints.down(1024)]: {
-      marginTop: '-1.9em',
+      marginTop: '-2.1em',
     },
   },
   iconSpan: {

--- a/src/web/src/components/AdminButtons.tsx
+++ b/src/web/src/components/AdminButtons.tsx
@@ -8,21 +8,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   adminButtons: {
     float: 'right',
     [theme.breakpoints.down(1200)]: {
-      float: 'none',
+      height: '20px',
+      margin: '-1em .5em 0 0',
     },
     [theme.breakpoints.down(1024)]: {
-      float: 'none',
+      marginTop: '-1.9em',
     },
   },
   iconSpan: {
     paddingLeft: '10px',
     paddingRight: '10px',
     [theme.breakpoints.down(1200)]: {
-      paddingLeft: '15px',
       paddingRight: '0px',
-    },
-    [theme.breakpoints.down(1024)]: {
-      paddingLeft: '8px',
+      paddingLeft: '0px',
     },
   },
   icon: {

--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -49,7 +49,8 @@ const useStyles = makeStyles((theme: Theme) =>
     postInfo: {
       [theme.breakpoints.down(1200)]: {
         display: 'grid',
-        gridTemplateAreas: "'avatar title title title''avatar author date .'",
+        gridTemplateAreas: "'avatar title title title''avatar author date date'",
+        gridTemplateColumns: 'auto auto auto auto',
         justifyContent: 'left',
         width: '100%',
         padding: '1em 0 1em 0',
@@ -70,7 +71,7 @@ const useStyles = makeStyles((theme: Theme) =>
       [theme.breakpoints.down(1024)]: {
         width: '80vw',
       },
-      [theme.breakpoints.down(321)]: {
+      [theme.breakpoints.down(600)]: {
         width: '78vw',
       },
     },
@@ -122,7 +123,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
       [theme.breakpoints.down(1024)]: {
         fontSize: '1.1em',
-        marginRight: '1em',
+        marginRight: '.3em',
       },
     },
     link: {
@@ -135,22 +136,25 @@ const useStyles = makeStyles((theme: Theme) =>
     publishedDateContainer: {
       [theme.breakpoints.down(1200)]: {
         gridArea: 'date',
+        display: 'flex',
+        flexWrap: 'nowrap',
+        justifyContent: 'flex-end',
+        alignItems: 'flex-start',
       },
+      [theme.breakpoints.down(1024)]: {},
     },
     published: {
       [theme.breakpoints.down(1200)]: {
-        width: '200px',
         height: '10px',
-        margin: '-.6em 0 -1em 1.5em',
+        margin: '-.6em 1em -1em 1.5em',
         fontSize: '1.3em',
         fontWeight: 'lighter',
         color: theme.palette.text.primary,
       },
       [theme.breakpoints.down(1024)]: {
         fontSize: '1.1em',
-        width: '40vw',
         height: '5px',
-        margin: '-1.6em 0 -1em .5px',
+        margin: '-1.6em 1em -1em .5px',
       },
       '&:hover': {
         textDecorationLine: 'underline',
@@ -291,8 +295,10 @@ const PostComponent = ({ postUrl }: Props) => {
                 <a href={post.url} rel="bookmark" className={classes.link}>
                   {`${formatPublishedDate(post.updated)}`}
                 </a>
-                <AdminButtons />
               </h1>
+              <div>
+                <AdminButtons />
+              </div>
             </div>
           </>
         )}

--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -141,7 +141,9 @@ const useStyles = makeStyles((theme: Theme) =>
         justifyContent: 'flex-end',
         alignItems: 'flex-start',
       },
-      [theme.breakpoints.down(1024)]: {},
+      [theme.breakpoints.down(300)]: {
+        minWidth: '140px',
+      },
     },
     published: {
       [theme.breakpoints.down(1200)]: {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR fixes #2155

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
This PR changes the grid distribution to fit better the `author`.
It also changed the margin of the `AdminButtons` to fit better when visible.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

Before: 
<img width="259" alt="posttitle" src="https://user-images.githubusercontent.com/63076086/115471413-f1c9c300-a205-11eb-8599-bed86071d4b3.png">

After:
<img width="187" alt="authorMobile" src="https://user-images.githubusercontent.com/63076086/115471436-fb532b00-a205-11eb-9f7a-99ab22e42e55.png">

<img width="203" alt="authorMobileAndButtons" src="https://user-images.githubusercontent.com/63076086/115471464-0908b080-a206-11eb-8909-634bb3eaeae4.png">

