### PR TITLE
Update all deps related to Babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,9 +97,9 @@
     "valid-url": "1.0.9"
   },
   "devDependencies": {
-    "@babel/core": "7.13.10",
+    "@babel/core": "7.13.16",
     "@babel/plugin-transform-runtime": "7.13.15",
-    "@babel/preset-env": "7.13.10",
+    "@babel/preset-env": "7.13.15",
     "@babel/preset-react": "7.13.13",
     "@babel/preset-typescript": "7.13.0",
     "@types/jest": "26.0.20",
@@ -123,7 +123,7 @@
     "husky": "5.1.3",
     "jest": "26.6.3",
     "jest-fetch-mock": "3.0.3",
-    "jest-playwright-preset": "1.5.1",
+    "jest-playwright-preset": "1.5.2",
     "nock": "13.0.11",
     "npm-run-all": "4.1.5",
     "playwright": "1.9.2",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -22,7 +22,7 @@
     "nanoid": "^3.1.22",
     "next": "^10.1.3",
     "next-compose-plugins": "^2.2.1",
-    "next-pwa": "^5.1.3",
+    "next-pwa": "^5.2.14",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-use": "^17.2.1",


### PR DESCRIPTION
We can't seem to get CI to pass with what looks like a failed npm cache.  I'm trying to disable it.