### PR TITLE
This PR adresses #2201: Extra width causing horizontal overflow

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) =>
       bottom: '100%',
     },
     postInfo: {
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         display: 'grid',
         gridTemplateAreas: "'avatar title title title''avatar author date date'",
         gridTemplateColumns: 'auto auto auto auto',
@@ -63,7 +63,7 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: '2em 0 1.5em',
       lineHeight: '1.3',
       top: '-1.1em',
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         top: '-1.1em',
         width: '725px',
         padding: '1em 0 .1em',
@@ -82,7 +82,7 @@ const useStyles = makeStyles((theme: Theme) =>
       textOverflow: 'ellipsis',
       textAlign: 'center',
       letterSpacing: '-1.5px',
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         fontSize: '2em',
         fontWeight: 'bold',
         textAlign: 'start',
@@ -108,13 +108,13 @@ const useStyles = makeStyles((theme: Theme) =>
       outline: 'none',
     },
     authorNameContainer: {
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         gridArea: 'author',
         width: '100%',
       },
     },
     author: {
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         fontSize: '2em',
         lineHeight: '1.5em',
         fontWeight: 'bold',
@@ -134,7 +134,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     publishedDateContainer: {
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         gridArea: 'date',
         display: 'flex',
         flexWrap: 'nowrap',
@@ -146,7 +146,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     published: {
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         height: '10px',
         margin: '-.6em 1em -1em 1.5em',
         fontSize: '1.3em',
@@ -163,7 +163,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     authorAvatarContainer: {
-      [theme.breakpoints.down(1200)]: {
+      [theme.breakpoints.down(1205)]: {
         gridArea: 'avatar',
         shapeOutside: 'circle(50%) border-box',
         shapeMargin: '1rem',
@@ -219,7 +219,7 @@ const extractBlogClassName = (url: string) => {
 const PostComponent = ({ postUrl }: Props) => {
   const classes = useStyles();
   const theme = useTheme();
-  const desktop = useMediaQuery(theme.breakpoints.up(1200));
+  const desktop = useMediaQuery(theme.breakpoints.up(1205));
   // We need a ref to our post content, which we inject into a <section> below.
   const sectionEl = useRef<HTMLElement>(null);
   // Grab the post data from our backend so we can render it

--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -5,22 +5,21 @@ import AdminButtons from '../AdminButtons';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      marginLeft: '2rem',
+      margin: '0',
       padding: '0',
       display: 'flex',
       borderLeft: '1.5px solid #999999',
       flexDirection: 'column',
       justifyContent: 'center',
-      width: '100%',
       [theme.breakpoints.up('lg')]: {
-        width: '22rem',
+        width: '21rem',
       },
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',
       shapeMargin: '1rem',
       borderRadius: '50%',
-      marginLeft: '1rem',
+      marginLeft: '.5rem',
     },
     circle: {
       display: 'block',
@@ -33,13 +32,13 @@ const useStyles = makeStyles((theme: Theme) =>
     authorNameContainer: {
       width: '100%',
       height: '3rem',
-      marginLeft: '1.5rem',
+      marginLeft: '1rem',
     },
     author: {
       width: '100%',
       wordWrap: 'break-word',
       fontSize: '1.6em',
-      lineHeight: '1em',
+      lineHeight: '1.3em',
       fontWeight: 'bold',
       color: theme.palette.text.primary,
     },
@@ -51,7 +50,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     published: {
-      marginLeft: '1.5rem',
+      marginLeft: '1rem',
       fontSize: '1.2em',
       fontWeight: 'lighter',
       textDecoration: 'none',


### PR DESCRIPTION
- Reduced marginLeft of elements and width of PostInfo on screens
bigger than 'lg' [PonstInfo.tsx]

Co-authored-by: PedroFonsecaDEV

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR fixes #2201 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
- Reduced `marginLeft` of elements and the width of the `root` in the `PostInfo.tsx`
- Changed the `Post.tsx breakpoints` from 1200px to 1205px
Together, these changes eliminated the overflow.
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
Before:
<img width="959" alt="overflow" src="https://user-images.githubusercontent.com/63076086/115780174-d5a15f80-a386-11eb-9d41-01622d10435e.png">


After:
<img width="957" alt="overflow-after" src="https://user-images.githubusercontent.com/63076086/115778876-43e52280-a385-11eb-9bc8-0f06a2bc6645.png">

