### PR TITLE
Don't run unit tests on npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "server": "node src/backend/web/server",
     "test-ci": "run-s prettier-check test",
     "pre-commit": "pretty-quick --staged",
-    "preversion": "npm run test-ci",
     "postversion": "git push upstream master --tags",
     "services:start": "node bin/services-start.js --",
     "services:stop": "node bin/services-stop.js",


### PR DESCRIPTION
Currently, whenever we run `npm version ...` to create a release, the unit tests are run.  This wastes time, and also requires the local dev env to be properly set up, which isn't really necessary to create a tag.

Passing unit tests doesn't mean the commit is good, as you need to run e2e tests as well.  Also, before we tag a commit on `master`, it has to have passed a) in the PR CI checks; and b) when it lands on `master`; and c) when we build it for staging.  If we've let a failed commit make it all the way through those stages, something is wrong already.