### PR TITLE
Fix: Modify nginx config file to renew api host certificate

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -161,6 +161,11 @@ http {
       # We run Traefik via Docker on port 8888
       proxy_pass        http://traefik:8888;
     }
+
+    # Let's Encrypt route
+    location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+    }
   }
 
   # Default server redirects traffic on 80 to 443, prefer secure connection


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR changes the `nginx` config file so [Let's Encrypt](https://letsencrypt.org/) can validate our API domains (`dev.api.telescope`, `api.telescope`) using [their challenges](https://letsencrypt.org/docs/challenge-types/) (the current settings in our `nginx` config file only allow host domain validation).

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
