### PR TITLE
Closes #2265:  Update to next.js v11 + bump typescript to v4.3.5

### DIFF
--- a/src/web/next-env.d.ts
+++ b/src/web/next-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/web/next.config.js
+++ b/src/web/next.config.js
@@ -67,9 +67,6 @@ const nextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
   trailingSlash: true,
-  future: {
-    webpack5: true,
-  },
 };
 
 // Compose all plugins

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -20,7 +20,7 @@
     "highlight.js": "11.0.1",
     "jwt-decode": "^3.1.2",
     "nanoid": "^3.1.22",
-    "next": "^10.1.3",
+    "next": "^11.1.0",
     "next-compose-plugins": "^2.2.1",
     "next-pwa": "^5.2.14",
     "react": "^17.0.2",
@@ -39,6 +39,6 @@
     "@types/react": "^17.0.3",
     "babel-loader": "^8.2.2",
     "terser-webpack-plugin": "^5.1.1",
-    "typescript": "^4.2.3"
+    "typescript": "^4.3.5"
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Closes #2265

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR bumps `next.js` to version v11.1.0 and `typescript` to v4.3.5 (suggested version for nex.js 11).
The main reason is [this alert](https://github.com/Seneca-CDOT/telescope/security/dependabot/src/web/package.json/next/open). We can try to take advantage of the `next.js` new features in future iterations.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
