### PR TITLE
Fixes #2284: Margin-top in About page

### DIFF
--- a/src/web/src/pages/layouts/MDXPageBase.tsx
+++ b/src/web/src/pages/layouts/MDXPageBase.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles((theme) => {
         color: theme.palette.text.secondary,
         fontSize: 24,
         transition: 'color 1s',
+        marginTop: 0,
         padding: '2vh 22vw',
         [theme.breakpoints.down(1024)]: {
           padding: '1vh 8vw',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2284
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR removes the extra margin at the top of the about page, caused by an `h1` element.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
