### PR TITLE
chore: bump passport-saml to v3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "normalize-url": "6.0.1",
     "opml-generator": "1.1.1",
     "passport": "0.4.1",
-    "passport-saml": "2.0.5",
+    "passport-saml": "3.1.2",
     "pino": "6.11.2",
     "pino-elasticsearch": "5.4.0",
     "pino-pretty": "4.7.1",

--- a/src/api/auth/package.json
+++ b/src/api/auth/package.json
@@ -22,7 +22,7 @@
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.1",
     "passport": "^0.4.1",
-    "passport-saml": "^3.0.0"
+    "passport-saml": "^3.1.2"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   rootDir: '../',
   testMatch: ['<rootDir>/test/**/*.test.js'],
   collectCoverageFrom: ['<rootDir>/src/backend/**/*.js'],
+  testEnvironment: 'node',
 };


### PR DESCRIPTION
## Description

This bumps `passport-saml` to version 3.1.2 to get rid of [this depandabot alert](https://github.com/Seneca-CDOT/telescope/security/dependabot/package.json/passport-saml/open).

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
