### PR TITLE
Closes #2210: Add node 16 to our CI build matrix

### DIFF
--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.6
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/cache@v2.1.6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2.1.6
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/cache@v2.1.6
         with:

--- a/src/backend/data/feed.js
+++ b/src/backend/data/feed.js
@@ -111,7 +111,7 @@ class Feed {
    * Returns a Promise<Boolean>
    */
   async isDelayed() {
-    return (await isDelayed(this.id)) === '1';
+    return (await isDelayed(this.id)) === 1;
   }
 
   /**

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -134,9 +134,9 @@ describe('Post data class tests', () => {
 
     test('Feed.isDelayed() should return true only after Feed.setDelayed() is called', async () => {
       const feed = await Feed.byUrl(data.url);
-      expect(feed.isDelayed()).resolves.toBe(false);
+      expect(await feed.isDelayed()).toBe(false);
       await feed.setDelayed(60);
-      expect(feed.isDelayed()).resolves.toBe(true);
+      expect(await feed.isDelayed()).toBe(true);
     });
 
     test('Updated feed should be different from data', async () => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Closes #2210 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This adds `nodejs v16.x` to our CI build matrix, It also fixes one of the `feed` tests (the test was passing with a warning in v14, but in v16 it was failing).
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
