### PR TITLE
Increase backoff attempts/delay before marking feed invalid

### DIFF
--- a/config/env.production
+++ b/config/env.production
@@ -192,10 +192,10 @@ ELASTIC_DELAY_MS=10000
 FEED_PROCESSING_DELAY_SEC=3600
 
 # Feed job queue attempts
-FEED_QUEUE_ATTEMPTS=5
+FEED_QUEUE_ATTEMPTS=12
 
-# Feed job queue delay(ms)
-FEED_QUEUE_DELAY_MS=60000
+# Feed job queue delay (ms) = 10 minutes
+FEED_QUEUE_DELAY_MS=600000
 
 # Number of concurrent worker processors to run. Use * if you want to run
 # one per CPU. Use a number if you want to set it manually, up to a max

--- a/config/env.staging
+++ b/config/env.staging
@@ -194,10 +194,10 @@ ELASTIC_DELAY_MS=10000
 FEED_PROCESSING_DELAY_SEC=3600
 
 # Feed job queue attempts
-FEED_QUEUE_ATTEMPTS=5
+FEED_QUEUE_ATTEMPTS=12
 
-# Feed job queue delay(ms)
-FEED_QUEUE_DELAY_MS=60000
+# Feed job queue delay (ms) = 10 minutes
+FEED_QUEUE_DELAY_MS=600000
 
 # Number of concurrent worker processors to run. Use * if you want to run
 # one per CPU. Use a number if you want to set it manually, up to a max


### PR DESCRIPTION
Fixes #2332.

This does two things to help avoid marking (probably) valid feeds as invalid when they fail for some reason (e.g., temporary network outage):

1. Increases the backoff delay to 10 minutes
2. Increases the number of retries to 10

What this means is that if a feed fails, we'll do the following:

1. Try again in 10 minutes
2. Try again in 30 minutes
3. Try again in ~1 hour
4. Try again in ~2.5 hours
5. Try again in ~5 hours
6. Try again in ~10 hours
7. Try again in ~21 hours
8. Try again in ~1.7 days
9. Try again in ~3.5 days
10. Try again in ~7 days
11. Try again in ~14 days
12. Try again in ~28 days

After a month, I think it's safe to assume this site is not coming back online, and we can mark it invalid.