### PR TITLE
Fixes #2325: Material-UI: The css function is deprecated. Use the styleFunctionSx instead

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@fontsource/pt-serif": "^4.2.2",
     "@fontsource/spartan": "^4.2.2",
-    "@material-ui/core": "4.11.3",
+    "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@next/mdx": "^11.1.0",
     "@types/smoothscroll-polyfill": "^0.3.1",

--- a/src/web/src/components/AboutFooter.tsx
+++ b/src/web/src/components/AboutFooter.tsx
@@ -63,7 +63,7 @@ const AboutFooter = () => {
     <Grid container className={classes.root}>
       <Box width={1} pb={5}>
         {matches ? (
-          <Grid container direction="row" justify="space-between" alignItems="flex-start">
+          <Grid container direction="row" justifyContent="space-between" alignItems="flex-start">
             <Grid container item xs={12} sm={3}>
               <Grid container direction="column" item xs={6}>
                 <Typography variant="h5" className={classes.heading}>
@@ -102,7 +102,7 @@ const AboutFooter = () => {
                 </Typography>
               </Grid>
             </Grid>
-            <Grid container item xs={12} sm={6} justify="center">
+            <Grid container item xs={12} sm={6} justifyContent="center">
               <Logo height={60} width={60} />
             </Grid>
             <Grid container direction="column" item xs={12} sm={3} alignItems="flex-end">
@@ -110,7 +110,7 @@ const AboutFooter = () => {
                 COMMUNITY
               </Typography>
               <Divider className={classes.rightDivider} />
-              <Grid container direction="row" justify="flex-end" spacing={1}>
+              <Grid container direction="row" justifyContent="flex-end" spacing={1}>
                 <Grid item>
                   <a href="https://github.com/Seneca-CDOT/telescope" className={classes.links}>
                     {' '}
@@ -129,8 +129,8 @@ const AboutFooter = () => {
             </Grid>
           </Grid>
         ) : (
-          <Grid container direction="row" justify="space-between" alignItems="flex-start">
-            <Grid container item xs={12} justify="center">
+          <Grid container direction="row" justifyContent="space-between" alignItems="flex-start">
+            <Grid container item xs={12} justifyContent="center">
               <Logo height={60} width={60} />
             </Grid>
             <Grid container item xs={12}>

--- a/src/web/src/components/__snapshots__/AboutFooter.test.tsx.snap
+++ b/src/web/src/components/__snapshots__/AboutFooter.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`renders correctly 1`] = `
       class="MuiBox-root MuiBox-root-8"
     >
       <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-space-between"
+        class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-flex-start MuiGrid-justify-content-xs-space-between"
       >
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-content-xs-center MuiGrid-grid-xs-12"
         >
           <img
             alt="Telescope Logo"

--- a/src/web/src/theme/index.ts
+++ b/src/web/src/theme/index.ts
@@ -1,5 +1,5 @@
 import { red } from '@material-ui/core/colors';
-import { createMuiTheme, Theme } from '@material-ui/core/styles';
+import { createTheme, Theme } from '@material-ui/core/styles';
 
 const commonThemeProps = {
   typography: {
@@ -7,7 +7,7 @@ const commonThemeProps = {
   },
 };
 
-export const lightTheme: Theme = createMuiTheme({
+export const lightTheme: Theme = createTheme({
   ...commonThemeProps,
   palette: {
     type: 'light',
@@ -37,7 +37,7 @@ export const lightTheme: Theme = createMuiTheme({
   },
 });
 
-export const darkTheme: Theme = createMuiTheme({
+export const darkTheme: Theme = createTheme({
   ...commonThemeProps,
   palette: {
     type: 'dark',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
USAGE: Fixes #2325 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The problem is that the current version in Material-UI contains an older version of `Box.js`. `Box.js` contains the `css` instead of the `sx`. To fix this issue I had to update Material-UI to version 4.12.3 and switch the `createMuiTheme` functions to `createTheme`. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
