### PR TITLE
Fix #1868: Use ADMINISTRATORS env var in auth service

### DIFF
--- a/src/api/auth/src/roles.js
+++ b/src/api/auth/src/roles.js
@@ -2,3 +2,4 @@
 module.exports.seneca = () => ['seneca'];
 module.exports.telescope = () => ['seneca', 'telescope'];
 module.exports.admin = () => ['seneca', 'telescope', 'admin'];
+module.exports.superUser = () => ['seneca', 'admin'];

--- a/src/api/auth/test/e2e/auth-flows.test.js
+++ b/src/api/auth/test/e2e/auth-flows.test.js
@@ -1,6 +1,5 @@
 // NOTE: you need to run the auth and login services in docker for these to work
-const { createServiceToken, hash } = require('@senecacdot/satellite');
-const fetch = require('node-fetch');
+const { hash } = require('@senecacdot/satellite');
 
 // We need to get the URL to the auth service running in docker, and the list
 // of allowed origins, to compare with assumptions in the tests below.
@@ -8,10 +7,10 @@ const { AUTH_URL, ALLOWED_APP_ORIGINS } = process.env;
 const {
   login,
   logout,
-  USERS_URL,
   getTokenAndState,
   createTelescopeUsers,
   cleanupTelescopeUsers,
+  ensureUsers,
 } = require('./utils');
 
 // We have 3 SSO user accounts in the login service (see config/simplesamlphp-users.php):
@@ -88,18 +87,7 @@ describe('Authentication Flows', () => {
   });
 
   it('should have all expected Telescope users in Users service for test data accounts', () =>
-    Promise.all(
-      users.map((user) =>
-        fetch(`${USERS_URL}/${hash(user.email)}`, {
-          headers: {
-            Authorization: `bearer ${createServiceToken()}`,
-            'Content-Type': 'application/json',
-          },
-        }).then((res) => {
-          expect(res.status).toEqual(200);
-        })
-      )
-    ));
+    ensureUsers(users));
 
   it('Login flow preserves state param', async () => {
     const { state } = await login(page, 'user1', 'user1pass');

--- a/src/api/auth/test/e2e/signup-flow.test.js
+++ b/src/api/auth/test/e2e/signup-flow.test.js
@@ -1,11 +1,11 @@
 // NOTE: you need to run the auth and login services in docker for these to work
-const { createServiceToken, hash } = require('@senecacdot/satellite');
+const { hash } = require('@senecacdot/satellite');
 const { decode } = require('jsonwebtoken');
 const fetch = require('node-fetch');
 
 // We need to get the URL to the auth service running in docker, and the list
 // of allowed origins, to compare with assumptions in the tests below.
-const { login, logout, USERS_URL, cleanupTelescopeUsers } = require('./utils');
+const { login, logout, USERS_URL, cleanupTelescopeUsers, ensureUsers } = require('./utils');
 
 const { AUTH_URL, FEED_DISCOVERY_URL } = process.env;
 
@@ -50,18 +50,7 @@ describe('Signup Flow', () => {
   });
 
   it('should have none of the users in the Users service for test data accounts', () =>
-    Promise.all(
-      users.map((user) =>
-        fetch(`${USERS_URL}/${hash(user.email)}`, {
-          headers: {
-            Authorization: `bearer ${createServiceToken()}`,
-            'Content-Type': 'application/json',
-          },
-        }).then((res) => {
-          expect(res.status).toEqual(404);
-        })
-      )
-    ));
+    ensureUsers(users, 404));
 
   it('signup flow works to login and register a new Telescope user', async () => {
     // Part 1: login using SSO, as a user who does not have a Telescope account.

--- a/src/api/auth/test/e2e/super-user.test.js
+++ b/src/api/auth/test/e2e/super-user.test.js
@@ -1,0 +1,131 @@
+// NOTE: you need to run the auth and login services in docker for these to work
+const { hash } = require('@senecacdot/satellite');
+
+const { login, createTelescopeUsers, cleanupTelescopeUsers, ensureUsers } = require('./utils');
+
+// We have 3 SSO user accounts in the login service (see config/simplesamlphp-users.php):
+//
+// | Username    | Email                       | Password  | Display Name    |
+// |-------------|-----------------------------|-----------|-----------------|
+// | user1       | user1@example.com           | user1pass | Johannes Kepler |
+// | user2       | user2@example.com           | user2pass | Galileo Galilei |
+// | lippersheyh | hans-lippershey@example.com | telescope | Hans Lippershey |
+
+describe('Super User Authentication', () => {
+  describe('Seneca Super User', () => {
+    beforeEach(async () => {
+      context = await browser.newContext();
+      page = await browser.newPage();
+      await page.goto(`http://localhost:8888/auth.html`);
+    });
+
+    afterEach(async () => {
+      await context.close();
+      await page.close();
+    });
+
+    it('Super user can login, and has expected token payload', async () => {
+      const email = 'user1@example.com';
+      const { jwt } = await login(page, 'user1', 'user1pass');
+      expect(jwt.sub).toEqual(hash(email));
+      expect(jwt.email).toEqual(email);
+      expect(Array.isArray(jwt.roles)).toBe(true);
+      expect(jwt.roles.length).toBe(2);
+      // A Seneca Super User will have `seneca` and `admin` only
+      expect(jwt.roles).toEqual(['seneca', 'admin']);
+    });
+  });
+
+  describe('Telescope Admin User', () => {
+    const johannesKepler = {
+      firstName: 'Johannes',
+      lastName: 'Kepler',
+      email: 'user1@example.com',
+      displayName: 'Johannes Kepler',
+      // Set this to `true` so we can test having it set in db
+      isAdmin: true,
+      isFlagged: false,
+      feeds: ['https://imaginary.blog.com/feed/johannes'],
+      github: {
+        username: 'jkepler',
+        avatarUrl:
+          'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
+      },
+    };
+    const users = [johannesKepler];
+
+    beforeEach(async () => {
+      await createTelescopeUsers(users);
+
+      context = await browser.newContext();
+      page = await browser.newPage();
+      await page.goto(`http://localhost:8888/auth.html`);
+    });
+
+    afterEach(async () => {
+      await cleanupTelescopeUsers(users);
+      await context.close();
+      await page.close();
+    });
+
+    it('should have all expected Telescope users in Users service for test data accounts', () =>
+      ensureUsers(users));
+
+    it('Super user can login, and has expected token payload', async () => {
+      const { jwt } = await login(page, 'user1', 'user1pass');
+      expect(jwt.sub).toEqual(hash(johannesKepler.email));
+      expect(jwt.email).toEqual(johannesKepler.email);
+      expect(Array.isArray(jwt.roles)).toBe(true);
+      expect(jwt.roles.length).toBe(3);
+      // `admin` is the one we really care about here
+      expect(jwt.roles).toEqual(['seneca', 'telescope', 'admin']);
+    });
+  });
+
+  describe('Telescope Non-Admin, Super User', () => {
+    const johannesKepler = {
+      firstName: 'Johannes',
+      lastName: 'Kepler',
+      email: 'user1@example.com',
+      displayName: 'Johannes Kepler',
+      // Force this to false, so we can test overriding via ADMINISTRATORS variable
+      // in `config/env.development`
+      isAdmin: false,
+      isFlagged: false,
+      feeds: ['https://imaginary.blog.com/feed/johannes'],
+      github: {
+        username: 'jkepler',
+        avatarUrl:
+          'https://avatars.githubusercontent.com/u/7242003?s=460&u=733c50a2f50ba297ed30f6b5921a511c2f43bfee&v=4',
+      },
+    };
+    const users = [johannesKepler];
+
+    beforeEach(async () => {
+      await createTelescopeUsers(users);
+
+      context = await browser.newContext();
+      page = await browser.newPage();
+      await page.goto(`http://localhost:8888/auth.html`);
+    });
+
+    afterEach(async () => {
+      await cleanupTelescopeUsers(users);
+      await context.close();
+      await page.close();
+    });
+
+    it('should have all expected Telescope users in Users service for test data accounts', () =>
+      ensureUsers(users));
+
+    it('Super user can login, and has expected token payload', async () => {
+      const { jwt } = await login(page, 'user1', 'user1pass');
+      expect(jwt.sub).toEqual(hash(johannesKepler.email));
+      expect(jwt.email).toEqual(johannesKepler.email);
+      expect(Array.isArray(jwt.roles)).toBe(true);
+      expect(jwt.roles.length).toBe(3);
+      // `admin` is the one we really care about here
+      expect(jwt.roles).toEqual(['seneca', 'telescope', 'admin']);
+    });
+  });
+});

--- a/src/api/auth/test/e2e/utils.js
+++ b/src/api/auth/test/e2e/utils.js
@@ -98,9 +98,26 @@ const logout = async (page) => {
   return getTokenAndState(page);
 };
 
+// Given an array of users, make sure they all respond with the expected HTTP
+// result via the Users Service.
+const ensureUsers = (users, result = 200) =>
+  Promise.all(
+    users.map((user) =>
+      fetch(`${USERS_URL}/${hash(user.email)}`, {
+        headers: {
+          Authorization: `bearer ${createServiceToken()}`,
+          'Content-Type': 'application/json',
+        },
+      }).then((res) => {
+        expect(res.status).toEqual(result);
+      })
+    )
+  );
+
 module.exports.USERS_URL = USERS_URL;
 module.exports.createTelescopeUsers = createTelescopeUsers;
 module.exports.cleanupTelescopeUsers = cleanupTelescopeUsers;
 module.exports.getTokenAndState = getTokenAndState;
 module.exports.login = login;
 module.exports.logout = logout;
+module.exports.ensureUsers = ensureUsers;

--- a/src/api/auth/test/roles.test.js
+++ b/src/api/auth/test/roles.test.js
@@ -12,4 +12,8 @@ describe('roles', () => {
   it('should return correct roles for Admin user', () => {
     expect(roles.admin()).toEqual(['seneca', 'telescope', 'admin']);
   });
+
+  it('should return correct roles for a Super user', () => {
+    expect(roles.superUser()).toEqual(['seneca', 'admin']);
+  });
 });

--- a/src/api/auth/test/user.test.js
+++ b/src/api/auth/test/user.test.js
@@ -42,14 +42,23 @@ describe('User()', () => {
   describe('All users', () => {
     it('should have an id property that returns the hashed email in the form we expect', () => {
       const email = 'first.last@senecacollege.ca';
-      const user = new User(createSenecaProfile({ email }));
+      const user = new User(
+        createSenecaProfile({
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': email,
+        })
+      );
       const expectedId = hash(email);
       expect(user.id).toEqual(expectedId);
     });
 
     it('should have an email property', () => {
-      const user = new User(createSenecaProfile({ email: 'first.last@senecacollege.ca' }));
-      expect(user.email).toEqual('first.last@senecacollege.ca');
+      const email = 'first.last@senecacollege.ca';
+      const user = new User(
+        createSenecaProfile({
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': email,
+        })
+      );
+      expect(user.email).toEqual(email);
     });
 
     it('should have a nameID property', () => {
@@ -58,12 +67,13 @@ describe('User()', () => {
     });
 
     it('should have a nameIDFormat property', () => {
+      const nameIDFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress';
       const user = new User(
         createSenecaProfile({
-          nameIDFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+          nameIDFormat,
         })
       );
-      expect(user.nameIDFormat).toEqual('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress');
+      expect(user.nameIDFormat).toEqual(nameIDFormat);
     });
 
     it('should have a firstName property', () => {
@@ -284,6 +294,21 @@ describe('User()', () => {
       });
       expect(user2.isTelescopeUser).toBe(true);
       expect(user2.roles).toEqual(['seneca', 'telescope', 'admin']);
+    });
+  });
+
+  describe('Seneca super user', () => {
+    it('should have isAdmin for user in ADMINISTRATORS env', () => {
+      const email = 'user1@example.com';
+      const { ADMINISTRATORS } = process.env;
+      const user = new User(
+        createSenecaProfile({
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': email,
+        })
+      );
+      expect(ADMINISTRATORS).toEqual(email);
+      expect(user.isAdmin).toBe(true);
+      expect(user.roles).toEqual(['seneca', 'admin']);
     });
   });
 });


### PR DESCRIPTION
Fixes #1868.  This adds support for using the Telescope super user accounts defined in the `ADMINISTRATORS` env variable.  We did this previously with the old backend, but never ported it over to the auth service.  I haven't tested this fully yet, so I'll do it as a draft until I know tests are OK.