### PR TITLE
Add microservices status page link to main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Telescope <img align="left" width="100" height="100" src=https://github.com/Seneca-CDOT/telescope/blob/master/src/web/public/logo.svg>
+# Telescope <img align="left" width="130" height="130" src=https://github.com/Seneca-CDOT/telescope/blob/master/src/web/public/logo.svg>
 
 [![js-airbnb/prettier-style](https://img.shields.io/badge/code%20style-airbnb%2Fprettier-blue)](https://github.com/airbnb/javascript)
 ![Node.js CI](https://github.com/Seneca-CDOT/telescope/workflows/node-js-ci/badge.svg)
+
+[![Prod API Status](https://img.shields.io/badge/Prod_API_Status-informational)](https://api.telescope.cdot.systems/v1/status)
+[![Dev API Status](https://img.shields.io/badge/Dev_API_Status-informational)](https://dev.api.telescope.cdot.systems/v1/status)
 
 ## What is Telescope?
 

--- a/src/web/src/components/Banner.tsx
+++ b/src/web/src/components/Banner.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { BsInfoCircle } from 'react-icons/bs';
 import {
   makeStyles,
   Theme,
@@ -51,7 +52,7 @@ const useStyles = makeStyles((theme: Theme) =>
       position: 'absolute',
       opacity: 0.85,
       bottom: theme.spacing(3),
-      left: theme.spacing(3),
+      left: theme.spacing(6.5),
       fontFamily: 'Spartan',
       fontSize: '1.3em',
       color: 'white',
@@ -59,6 +60,12 @@ const useStyles = makeStyles((theme: Theme) =>
       '&:hover': {
         textDecorationLine: 'underline',
       },
+    },
+    infoIcon: {
+      position: 'absolute',
+      bottom: theme.spacing(3),
+      left: theme.spacing(3),
+      color: 'white',
     },
     icon: {
       display: 'flex',
@@ -191,6 +198,13 @@ export default function Banner({ onVisibilityChange }: BannerProps) {
         </Typography>
       </div>
       <div className={classes.icon}>
+        <a
+          className={classes.infoIcon}
+          href="https://api.telescope.cdot.systems/v1/status"
+          title="API Status"
+        >
+          <BsInfoCircle size="15" />
+        </a>
         <a
           href={`${gitInfo.gitHubUrl}`}
           title={`git commit ${gitInfo.sha}`}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #2347 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

This PR adds an informational icon on the left to the version number so we can easily access the status of the micro-services by clicking on that icon.  It also updates the README file with a status icon linking to the same page.

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR does not include tests because it was a UI styling change.
- [x] **Screenshots**: 
![Main page](https://user-images.githubusercontent.com/67607236/137051140-1d90c539-cadd-48d3-aab5-907d78d9f949.png)
- [x] **Documentation**: This PR changes the README file for the user to know the status of the micro-services.

