### PR TITLE
Fix #653 - Modifying error passing to invalidation code

### DIFF
--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -47,11 +47,10 @@ async function updateFeed(feedData) {
  * Invalidates a feed
  * @param feedData - Object containing feed data
  */
-async function invalidateFeed(id) {
+async function invalidateFeed(id, error) {
   const feed = await Feed.byId(id);
-  // TODO: we need to bubble up the reason for the failure
-  await feed.setInvalid('unknown reason');
-  logger.info(`Invalidating feed ${feed.url} for the following reason: ${'unknown reason'}`);
+  await feed.setInvalid(error.message);
+  logger.info(`Invalidating feed ${feed.url} for the following reason: ${error.message}`);
 }
 
 /**
@@ -101,8 +100,10 @@ feedQueue.on('drained', loadFeedsIntoQueue);
  * If there is a failure in the queue for a job, set the feed to invalid
  * and save to Redis
  */
-feedQueue.on('failed', (job) =>
-  invalidateFeed(job.data.id).catch((error) => logger.error({ error }, 'Unable to invalidate feed'))
+feedQueue.on('failed', (job, err) =>
+  invalidateFeed(job.data.id, err).catch((error) =>
+    logger.error({ error }, 'Unable to invalidate feed')
+  )
 );
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #653 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR modifies the invalidateFeed code to receive and store the error message thrown when a parsing job fails into the database.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: Changes can be viewed in the commit [47dd9da](https://github.com/Seneca-CDOT/telescope/pull/2388/commits/47dd9da2015d3a0f58d22ce1c9a60545ee46307f)
- [x] **Documentation**: Changes were made to backend and did not modify existing variables/configurations.
