### PR TITLE
Fix author info hiding when scrolling down

### DIFF
--- a/src/web/src/components/Posts/PostInfo.tsx
+++ b/src/web/src/components/Posts/PostInfo.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
       [theme.breakpoints.up('lg')]: {
         width: '21rem',
       },
+      top: 'unset',
     },
     authorAvatarContainer: {
       shapeOutside: 'circle(50%) border-box',


### PR DESCRIPTION
Fixes #2370 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The author info hides behind the GitHub info because
it was trying to stay sticked.
To avoid the "stickiness," we remove the threshold for the sticky
(unset the top property).

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [X] **Tests**: This PR does not include any tests because it is a styling change
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)

   https://user-images.githubusercontent.com/67607236/138577661-44e1d3ff-9877-4ce9-a04c-d6ce65f94791.mp4

- [X] **Documentation**: This PR does not need a documentation update because it is fixing a styling bug. It does not add any features. 
