### PR TITLE
Moving current build to prev when a new build is started

### DIFF
--- a/tools/autodeployment/builds.js
+++ b/tools/autodeployment/builds.js
@@ -76,7 +76,7 @@ function run() {
     { silent: true },
     (code) => {
       build.finish(code);
-      builds.current = builds.previous;
+      builds.previous = builds.current;
       builds.current = null;
 
       // See if there's another build ready to go


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2384 (Autodeployment server not remembering previous build info).
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Assigning the `current` build to `previous` in so that the previous build information is not `null`.

![image](https://user-images.githubusercontent.com/52294825/138622677-20a921fd-38a5-47d6-97a9-04744e6f8391.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not; **N/A for this pr**
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
