### PR TITLE
Disable parser service until we fix #2111

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -93,11 +93,12 @@ services:
     depends_on:
       - test-web-content
 
-  parser:
-    environment:
-      # For development and testing, the Parser service needs to contact the users
-      # service directly via Docker vs through the http://localhost domain.
-      - USERS_URL=http://users:7000
+  # TODO: https://github.com/Seneca-CDOT/telescope/issues/2111
+  # parser:
+  #   environment:
+  #     # For development and testing, the Parser service needs to contact the users
+  #     # service directly via Docker vs through the http://localhost domain.
+  #     - USERS_URL=http://users:7000
 
   planet:
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -220,36 +220,36 @@ services:
       - 'traefik.http.middlewares.strip_users_prefix.stripprefix.forceSlash=true'
       - 'traefik.http.routers.users.middlewares=strip_users_prefix'
 
-  # parser service
-  parser:
-    container_name: 'parser'
-    build:
-      context: ../src/api/parser
-      dockerfile: Dockerfile
-    environment:
-      - NODE_ENV
-      - PARSER_PORT
-      - USERS_URL
-      # Satellite authentication/authorization support
-      - JWT_ISSUER
-      - JWT_AUDIENCE
-      - SECRET
-    depends_on:
-      - traefik
-      - redis
-      - users
-      - elasticsearch
-    labels:
-      # Enable Traefik
-      - 'traefik.enable=true'
-      # Traefik routing for the parser service at /v1/parser
-      - 'traefik.http.routers.parser.rule=PathPrefix(`/${API_VERSION}/parser`)'
-      # Specify the parser service port
-      - 'traefik.http.services.parser.loadbalancer.server.port=${PARSER_PORT}'
-      # Add middleware to this route to strip the /v1/parser prefix
-      - 'traefik.http.middlewares.strip_parser_prefix.stripprefix.prefixes=/${API_VERSION}/parser'
-      - 'traefik.http.middlewares.strip_parser_prefix.stripprefix.forceSlash=true'
-      - 'traefik.http.routers.parser.middlewares=strip_parser_prefix'
+  # parser service - disabled, https://github.com/Seneca-CDOT/telescope/issues/2111
+  # parser:
+  #   container_name: 'parser'
+  #   build:
+  #     context: ../src/api/parser
+  #     dockerfile: Dockerfile
+  #   environment:
+  #     - NODE_ENV
+  #     - PARSER_PORT
+  #     - USERS_URL
+  #     # Satellite authentication/authorization support
+  #     - JWT_ISSUER
+  #     - JWT_AUDIENCE
+  #     - SECRET
+  #   depends_on:
+  #     - traefik
+  #     - redis
+  #     - users
+  #     - elasticsearch
+  #   labels:
+  #     # Enable Traefik
+  #     - 'traefik.enable=true'
+  #     # Traefik routing for the parser service at /v1/parser
+  #     - 'traefik.http.routers.parser.rule=PathPrefix(`/${API_VERSION}/parser`)'
+  #     # Specify the parser service port
+  #     - 'traefik.http.services.parser.loadbalancer.server.port=${PARSER_PORT}'
+  #     # Add middleware to this route to strip the /v1/parser prefix
+  #     - 'traefik.http.middlewares.strip_parser_prefix.stripprefix.prefixes=/${API_VERSION}/parser'
+  #     - 'traefik.http.middlewares.strip_parser_prefix.stripprefix.forceSlash=true'
+  #     - 'traefik.http.routers.parser.middlewares=strip_parser_prefix'
 
   # planet service
   planet:

--- a/docker/gitpod.yml
+++ b/docker/gitpod.yml
@@ -94,8 +94,9 @@ services:
     depends_on:
       - test-web-content
 
-  parser:
-    environment:
-      # For development and testing, the Parser service needs to contact the users
-      # service directly via Docker vs through the http://localhost domain.
-      - USERS_URL=http://users:7000
+  # TODO: https://github.com/Seneca-CDOT/telescope/issues/2111
+  # parser:
+  #   environment:
+  #     # For development and testing, the Parser service needs to contact the users
+  #     # service directly via Docker vs through the http://localhost domain.
+  #     - USERS_URL=http://users:7000

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -104,9 +104,10 @@ services:
       # This will take care of copying the serviceAccountKey.json file needed by firestore.js
       - ../../firebase/serviceAccountKey.json:/app/serviceAccountKey.json
 
-  # users service
-  parser:
-    restart: unless-stopped
+  # TODO: https://github.com/Seneca-CDOT/telescope/issues/2111
+  # parser service
+  # parser:
+  #   restart: unless-stopped
 
   # planet service
   planet:

--- a/src/api/parser/src/index.js
+++ b/src/api/parser/src/index.js
@@ -1,5 +1,6 @@
 const { Satellite, isAuthenticated, isAuthorized } = require('@senecacdot/satellite');
-const { router } = require('bull-board');
+// TODO: https://github.com/Seneca-CDOT/telescope/issues/2345
+// const { router } = require('bull-board');
 // const startParserQueue = require('./parser-queue');
 
 const service = new Satellite();
@@ -7,12 +8,13 @@ const service = new Satellite();
 // We're commenting startParserQueue() for now so it doesn't clash with our current backend, will uncomment when tests go in and we remove the backend.
 // startParserQueue();
 
+// Re-enable as part of // TODO: https://github.com/Seneca-CDOT/telescope/issues/2345
 // Only authenticated Telescope users, or other services, can hit this route
-service.router.get(
-  '/',
-  isAuthenticated(),
-  isAuthorized((req, user) => user.roles.includes('telescope') || user.roles.includes('service')),
-  router
-);
+// service.router.get(
+//   '/',
+//   isAuthenticated(),
+//   isAuthorized((req, user) => user.roles.includes('telescope') || user.roles.includes('service')),
+//   router
+// );
 
 module.exports = service;


### PR DESCRIPTION
The parser service is crashing on staging due to #2345.  It's actually not really ready for use yet (#2111), so we're going to disable it until it's ready.  Once we finish the code and tests, we can revert this.