### PR TITLE
Fixes #2442: Fixes linking of users icon, and adds title to users and telescope avatar icons

### DIFF
--- a/src/web/src/components/Posts/PostAvatar.tsx
+++ b/src/web/src/components/Posts/PostAvatar.tsx
@@ -60,7 +60,7 @@ const PostAvatar = ({ name, img, url }: AvatarProps) => {
     return (
       <div>
         {url?.length ? (
-          <a href={url} className={classes.link}>
+          <a href={url} className={classes.link} title={name}>
             <Avatar className={classes.avatar}>
               <p className={classes.text}>{initials}</p>
             </Avatar>

--- a/src/web/src/components/Posts/Users.tsx
+++ b/src/web/src/components/Posts/Users.tsx
@@ -57,13 +57,12 @@ const Users = ({ usernames, avatarSize = 25 }: Props) => {
         {usernames?.map((user) => (
           <li key={user} className={classes.user}>
             <div>
-              <a href={`https://github.com/${user}`}>
-                <TelescopeAvatar
-                  img={getUserImage(user, avatarSize)}
-                  size={`${avatarSize}px`}
-                  name={user}
-                />
-              </a>
+              <TelescopeAvatar
+                img={getUserImage(user, avatarSize)}
+                size={`${avatarSize}px`}
+                name={user}
+                url={`https://github.com/${user}`}
+              />
             </div>
           </li>
         ))}

--- a/src/web/src/components/Posts/Users.tsx
+++ b/src/web/src/components/Posts/Users.tsx
@@ -57,14 +57,13 @@ const Users = ({ usernames, avatarSize = 25 }: Props) => {
         {usernames?.map((user) => (
           <li key={user} className={classes.user}>
             <div>
-              <TelescopeAvatar
-                img={getUserImage(user, avatarSize)}
-                size={`${avatarSize}px`}
-                name={user}
-                action={() => {
-                  window.open(`https://github.com/${user}`, '_blank');
-                }}
-              />
+              <a href={`https://github.com/${user}`}>
+                <TelescopeAvatar
+                  img={getUserImage(user, avatarSize)}
+                  size={`${avatarSize}px`}
+                  name={user}
+                />
+              </a>
             </div>
           </li>
         ))}

--- a/src/web/src/components/TelescopeAvatar.tsx
+++ b/src/web/src/components/TelescopeAvatar.tsx
@@ -56,6 +56,7 @@ const TelescopeAvatar = ({
           backgroundColor: `${backColor}`,
           color: `${color}`,
         }}
+        title={name}
       >
         {initials}
       </Avatar>

--- a/src/web/src/components/TelescopeAvatar.tsx
+++ b/src/web/src/components/TelescopeAvatar.tsx
@@ -5,7 +5,7 @@ type TelescopeAvatarProps = {
   name: string;
   size: string;
   img?: string;
-  blog?: string;
+  url?: string;
   backgroundColor?: string;
   fontColor?: string;
   action?: MouseEventHandler;
@@ -29,7 +29,7 @@ const TelescopeAvatar = ({
   name,
   img,
   size,
-  blog,
+  url,
   backgroundColor,
   fontColor,
   action,
@@ -39,7 +39,7 @@ const TelescopeAvatar = ({
   const color = fontColor || '#000';
   return (
     <a
-      href={blog}
+      href={url}
       style={{
         textDecoration: 'none',
       }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
I wanna say this PR should close #2442 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR addresses how the user component was linking to user's github pages. It originally used `window.open()`, instead of an href which is typically how this is done. This PR fixes that. This PR also adds a tooltip title to the user icons, as well as the Telescope Avatar icon as well to keep consistency.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


<a href="https://gitpod.io/#https://github.com/Seneca-CDOT/telescope/pull/2447"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

