### PR TITLE
Fix escape character

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express-validator": "6.10.0",
     "feed": "4.2.2",
     "helmet": "4.4.1",
-    "highlight.js": "10.6.0",
+    "highlight.js": "11.3.1",
     "http-proxy-middleware": "1.0.6",
     "ioredis": "4.26.0",
     "ioredis-mock": "5.5.5",

--- a/src/backend/utils/html/syntax-highlight.js
+++ b/src/backend/utils/html/syntax-highlight.js
@@ -1,7 +1,7 @@
 const hljs = require('highlight.js/lib/core');
 
 // Tweak the language list here, see https://highlightjs.org/usage/
-hljs.registerLanguage('cLike', require('highlight.js/lib/languages/c-like'));
+hljs.registerLanguage('c', require('highlight.js/lib/languages/c'));
 hljs.registerLanguage('sql', require('highlight.js/lib/languages/sql'));
 hljs.registerLanguage('powershell', require('highlight.js/lib/languages/powershell'));
 hljs.registerLanguage('csharp', require('highlight.js/lib/languages/csharp'));
@@ -40,22 +40,8 @@ module.exports = function (dom) {
     return;
   }
 
+  // highlight every elements
   dom.window.document.querySelectorAll('pre code').forEach((code) => {
-    const { value, language } = hljs.highlightAuto(code.innerHTML);
-
-    // If the language wasn't detected, return the HTML untouched
-    if (!language) {
-      return;
-    }
-
-    // Otherwise, decorate the <pre> with class names for highlighting this language
-    const pre = code.parentNode;
-    if (pre) {
-      pre.classList.add('hljs', language);
-    }
-    // Value from hljs.highlightAuto turn escape character to e.g &lt; to &amp;lt;
-    // Adding regex to convert &amp; of that escape character back to &
-    // Replace the contents with newly marked up syntax highlighting
-    code.innerHTML = value.replace(/\&amp;([^;|^&]+);/gm, '&$1');
+    hljs.highlightElement(code);
   });
 };

--- a/test/process-html.test.js
+++ b/test/process-html.test.js
@@ -12,7 +12,7 @@ describe('Process HTML', () => {
     const data = process(
       `<pre><code>const html = data.replace (/^## (.*$)/gim, '&lt;h2&gt;$1&lt;/h2&gt;')</code></pre>`
     );
-    const expectedData = `<pre class="hljs typescript"><code><span class="hljs-keyword">const</span> html = data.replace (<span class="hljs-regexp">/^## (.*$)/gim</span>, <span class="hljs-string">'&lt;h2&gt;$1&lt;/h2&gt;'</span>)</code></pre>`;
+    const expectedData = `<pre><code class="hljs language-typescript"><span class="hljs-keyword">const</span> html = data.<span class="hljs-property">replace</span> (<span class="hljs-regexp">/^## (.*$)/gim</span>, <span class="hljs-string">'&lt;h2&gt;$1&lt;/h2&gt;'</span>)</code></pre>`;
     expect(data).toBe(expectedData);
   });
 
@@ -20,7 +20,8 @@ describe('Process HTML', () => {
     const data = process(
       `<div><pre><code>&lt;img src={slackLogo} alt="logo"/&gt;</code></pre></div>`
     );
-    const expectedData = `<div><pre class="hljs xml"><code><span class="hljs-symbol">&lt;</span>img src={slackLogo} alt="logo"/<span class="hljs-symbol">&gt;</span></code></pre></div>`;
+    const expectedData =
+      '<div><pre><code class="hljs language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">img</span> <span class="hljs-attr">src</span>=<span class="hljs-string">{slackLogo}</span> <span class="hljs-attr">alt</span>=<span class="hljs-string">"logo"</span>/&gt;</span></code></pre></div>';
     expect(data).toBe(expectedData);
   });
 

--- a/test/syntax-highlight.test.js
+++ b/test/syntax-highlight.test.js
@@ -38,7 +38,7 @@ describe('syntax-highlight tests', () => {
     const original = 'const int i = 5; <pre><code>const int i = 5;</code></pre>';
     const result = syntaxHighlighter(original);
     const expected =
-      'const int i = 5; <pre class="hljs csharp"><code><span class="hljs-keyword">const</span> <span class="hljs-built_in">int</span> i = <span class="hljs-number">5</span>;</code></pre>';
+      'const int i = 5; <pre><code class="hljs language-csharp"><span class="hljs-keyword">const</span> <span class="hljs-built_in">int</span> i = <span class="hljs-number">5</span>;</code></pre>';
     expect(result).toEqual(expected);
   });
 
@@ -46,7 +46,7 @@ describe('syntax-highlight tests', () => {
     const original = '<pre><code>cd foo</code></pre>';
     const result = syntaxHighlighter(original);
     const expected =
-      '<pre class="hljs powershell"><code><span class="hljs-built_in">cd</span> foo</code></pre>';
+      '<pre><code class="hljs language-powershell"><span class="hljs-built_in">cd</span> foo</code></pre>';
     expect(result).toEqual(expected);
   });
 
@@ -55,7 +55,15 @@ describe('syntax-highlight tests', () => {
       '<pre><code>import React, { Component } from "react"; function main() { console.log("hi"); }</code></pre>';
     const result = syntaxHighlighter(original);
     const expected =
-      '<pre class="hljs typescript"><code><span class="hljs-keyword">import</span> React, { Component } <span class="hljs-keyword">from</span> <span class="hljs-string">"react"</span>; <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">main</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-built_in">console</span>.log(<span class="hljs-string">"hi"</span>); }</code></pre>';
+      '<pre><code class="hljs language-javascript"><span class="hljs-keyword">import</span> <span class="hljs-title class_">React</span>, { <span class="hljs-title class_">Component</span> } <span class="hljs-keyword">from</span> <span class="hljs-string">"react"</span>; <span class="hljs-keyword">function</span> <span class="hljs-title function_">main</span>(<span class="hljs-params"></span>) { <span class="hljs-variable language_">console</span>.<span class="hljs-title function_">log</span>(<span class="hljs-string">"hi"</span>); }</code></pre>';
     expect(result).toEqual(expected);
+  });
+
+  test('2 followed escape characters (e.g. &amp;&amp;) with preset syntax-highlight should be converted correctly', () => {
+    const data = syntaxHighlighter(
+      `<pre><code>npx husky-init <span class="o">&amp;&amp;</span> <span class="o">&amp;&lt;</span> npm <span class="nb">install</span> <span class="nt">--save-dev</span> prettier pretty-quick</code></pre>`
+    );
+    const expectedData = `<pre><code class="hljs language-sql">npx husky<span class="hljs-operator">-</span>init <span class="hljs-operator">&amp;&amp;</span> <span class="hljs-operator">&amp;</span><span class="hljs-operator">&lt;</span> npm install <span class="hljs-comment">--save-dev prettier pretty-quick</span></code></pre>`;
+    expect(data).toBe(expectedData);
   });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2457 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
- Modified our highlight syntax function
- Adjust test case

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
The current way of doing it causing some weird bug. 
`highlightAuto()` seems to run an encode to change value to escape character.  And when we have our data with preset syntax-highlight `span`. It is converting weirding.

For example:
```html
<pre class="hljs language-bash"><code><span class="o">&amp;&amp;</span></code></pre>
```
Will convert to
```html
<pre class="hljs language-bash xml"><code class="hljs language-bash"><span class="hljs-symbol">&amp;</span>amp;<span class="hljs-symbol">&amp;</span>amp;</code></pre>
```
I upgraded to the latest version, it kind of fixed itself but some didn't.
Finally solution was to change to use this https://highlightjs.readthedocs.io/en/latest/api.html#highlightelement
That will highlight the syntax+ add class (for language) in code tag instead of pre tag.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


<a href="https://gitpod.io/#https://github.com/Seneca-CDOT/telescope/pull/2468"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

