### PR TITLE
Fixes #2419: show feeds count on status dashboard

### DIFF
--- a/src/api/posts/src/index.js
+++ b/src/api/posts/src/index.js
@@ -5,6 +5,7 @@ const posts = require('./routes/posts');
 const feeds = require('./routes/feeds');
 
 const service = new Satellite({
+  cors: { exposedHeaders: ['X-Total-Count', 'Link'] },
   healthCheck: () => redis.ping(),
 });
 

--- a/src/api/status/public/index.html
+++ b/src/api/status/public/index.html
@@ -16,6 +16,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <base href="/v1/status/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="apple-touch-icon" sizes="76x76" href="assets/img/apple-icon.png" />
     <link rel="icon" type="image/png" href="assets/img/favicon.png" />
@@ -1277,7 +1278,6 @@
         </div>
       </div>
     </div>
-    <script src="./script.js"></script>
     <!--   Core JS Files   -->
     <script src="assets/js/core/popper.min.js"></script>
     <script src="assets/js/core/bootstrap.min.js"></script>
@@ -1288,7 +1288,12 @@
     <script src="assets/js/demo-sidenav.js"></script>
     <!-- Control Center for Material Dashboard: parallax effects, scripts for the example pages etc -->
     <script src="assets/js/material-dashboard.min.js?v=3.0.0"></script>
+    <<<<<<< HEAD
     <!-- Telescope JS Files -->
     <script src="js/github-stats.js"></script>
+    =======
+
+    <script src="./script.js"></script>
+    >>>>>>> 478f347 (made changes to multiple lines)
   </body>
 </html>

--- a/src/api/status/public/index.html
+++ b/src/api/status/public/index.html
@@ -16,7 +16,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <base href="/v1/status/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="apple-touch-icon" sizes="76x76" href="assets/img/apple-icon.png" />
     <link rel="icon" type="image/png" href="assets/img/favicon.png" />
@@ -473,6 +472,22 @@
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+        <div class="col-xl-3 col-sm-6 mb-xl-0 mb-4 mt-4">
+          <div class="card">
+            <div class="card-header p-3 pt-2">
+              <div
+                class="icon icon-lg icon-shape bg-gradient-success shadow-success text-center border-radius-xl mt-n4 position-absolute"
+              >
+                <i class="material-icons opacity-10">person</i>
+              </div>
+              <div class="text-end pt-1">
+                <p class="text-sm mb-0 text-capitalize">Total feeds</p>
+                <h4 class="mb-0" id="feeds-count"></h4>
+              </div>
+            </div>
+            <div class="card-footer"></div>
           </div>
         </div>
         <div class="row mt-4">
@@ -1288,13 +1303,8 @@
     <script src="assets/js/demo-sidenav.js"></script>
     <!-- Control Center for Material Dashboard: parallax effects, scripts for the example pages etc -->
     <script src="assets/js/material-dashboard.min.js?v=3.0.0"></script>
-    <<<<<<< HEAD <<<<<<< HEAD
     <!-- Telescope JS Files -->
     <script src="js/github-stats.js"></script>
-    ======= =======
-    <!-- Telescope Dashboard -->
-    >>>>>>> 60664c3 (add feed folder and api file)
-    <script src="./script.js"></script>
-    >>>>>>> 478f347 (made changes to multiple lines)
+    <script src="js/feed/index.js"></script>
   </body>
 </html>

--- a/src/api/status/public/index.html
+++ b/src/api/status/public/index.html
@@ -16,7 +16,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <base href="/v1/status/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="apple-touch-icon" sizes="76x76" href="assets/img/apple-icon.png" />
     <link rel="icon" type="image/png" href="assets/img/favicon.png" />
@@ -1278,6 +1277,7 @@
         </div>
       </div>
     </div>
+    <script src="./script.js"></script>
     <!--   Core JS Files   -->
     <script src="assets/js/core/popper.min.js"></script>
     <script src="assets/js/core/bootstrap.min.js"></script>

--- a/src/api/status/public/index.html
+++ b/src/api/status/public/index.html
@@ -16,6 +16,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <base href="/v1/status/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="apple-touch-icon" sizes="76x76" href="assets/img/apple-icon.png" />
     <link rel="icon" type="image/png" href="assets/img/favicon.png" />

--- a/src/api/status/public/index.html
+++ b/src/api/status/public/index.html
@@ -1288,11 +1288,12 @@
     <script src="assets/js/demo-sidenav.js"></script>
     <!-- Control Center for Material Dashboard: parallax effects, scripts for the example pages etc -->
     <script src="assets/js/material-dashboard.min.js?v=3.0.0"></script>
-    <<<<<<< HEAD
+    <<<<<<< HEAD <<<<<<< HEAD
     <!-- Telescope JS Files -->
     <script src="js/github-stats.js"></script>
-    =======
-
+    ======= =======
+    <!-- Telescope Dashboard -->
+    >>>>>>> 60664c3 (add feed folder and api file)
     <script src="./script.js"></script>
     >>>>>>> 478f347 (made changes to multiple lines)
   </body>

--- a/src/api/status/public/js/api.js
+++ b/src/api/status/public/js/api.js
@@ -1,0 +1,1 @@
+export const fetchFeeds = () => fetch(`https://${process.env.API_HOST}/v1/posts/feeds`);

--- a/src/api/status/public/js/api.js
+++ b/src/api/status/public/js/api.js
@@ -1,1 +1,0 @@
-export const fetchFeeds = () => fetch(`https://dev.api.telescope.cdot.systems/v1/posts/feeds`);

--- a/src/api/status/public/js/api.js
+++ b/src/api/status/public/js/api.js
@@ -1,1 +1,1 @@
-export const fetchFeeds = () => fetch(`https://${process.env.API_HOST}/v1/posts/feeds`);
+export const fetchFeeds = () => fetch(`https://dev.api.telescope.cdot.systems/v1/posts/feeds`);

--- a/src/api/status/public/js/feed/index.js
+++ b/src/api/status/public/js/feed/index.js
@@ -1,12 +1,18 @@
-const { fetchFeeds } = require('../api');
+const apiHost = new URL(location).origin;
 
-export async function getFeedCount() {
+async function getFeedCount() {
   try {
-    const data = await fetchFeeds();
-    const feedCount = data.headers.get('X-Total-Count');
+    const data = await fetch(`${apiHost}/v1/posts/feeds`, {
+      method: 'HEAD',
+    });
+    const feedCount = data.headers.get('x-total-count');
     const feedCountElement = document.getElementById('feeds-count');
-    feedCountElement.innerText = feedCount;
+    feedCountElement.innerText = feedCount ?? 'N/A';
   } catch (err) {
     console.error(err);
   }
 }
+
+window.onload = () => {
+  getFeedCount();
+};

--- a/src/api/status/public/js/feed/index.js
+++ b/src/api/status/public/js/feed/index.js
@@ -1,0 +1,12 @@
+const { fetchFeeds } = require('../api');
+
+export async function getFeedCount() {
+  try {
+    const data = await fetchFeeds();
+    const feedCount = data.headers.get('X-Total-Count');
+    const feedCountElement = document.getElementById('feeds-count');
+    feedCountElement.innerText = feedCount;
+  } catch (err) {
+    console.error(err);
+  }
+}


### PR DESCRIPTION
Fix #2419
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Add feeds count for status dashboard. I ran docker and used `localhost/v1/posts/feeds` to test it out. And I also have to add cors to expose headers in posts service
## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


<a href="https://gitpod.io/#https://github.com/Seneca-CDOT/telescope/pull/2471"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

