### PR TITLE
Fixes 2479: Remove paragraphs with only a br inside

### DIFF
--- a/src/backend/utils/html/index.js
+++ b/src/backend/utils/html/index.js
@@ -4,6 +4,7 @@ const fixIFrameWidth = require('./fix-iframe-width');
 const lazyLoad = require('./lazy-load');
 const syntaxHighlight = require('./syntax-highlight');
 const fixEmptyPre = require('./modify-pre');
+const removeEmpty = require('./remove-empty-paragraphs');
 const toDOM = require('./dom');
 
 const { JSDOM } = jsdom;
@@ -39,6 +40,8 @@ module.exports = function process(html) {
   fixIFrameWidth(dom);
   // Update <img> and <iframe> elements to use native lazy loading.
   lazyLoad(dom);
+  // Remove <p> elements that contain whitespace, and <br>
+  removeEmpty(dom);
 
   // Return the resulting HTML
   return dom.window.document.body.innerHTML;

--- a/src/backend/utils/html/remove-empty-paragraphs.js
+++ b/src/backend/utils/html/remove-empty-paragraphs.js
@@ -4,10 +4,14 @@ module.exports = function (dom) {
   if (!(dom && dom.window && dom.window.document)) {
     return;
   }
+
   dom.window.document.querySelectorAll('p').forEach((p) => {
     p.innerHTML = cleanWhiteSpace(p.innerHTML);
     const paragraphInnerHTML = p.innerHTML;
-    if (!paragraphInnerHTML.replace(/&nbsp;/gm, '').trim()) {
+    if (
+      !paragraphInnerHTML.replace(/&nbsp;/gm, '').trim() ||
+      paragraphInnerHTML.trim() === '<br>'
+    ) {
       p.remove();
     }
   });

--- a/test/remove-empty-paragraphs.test.js
+++ b/test/remove-empty-paragraphs.test.js
@@ -32,4 +32,11 @@ describe('Remove no content anchor tags', () => {
     const expectedHtml = '<div></div>';
     expect(htmlData.window.document.body.innerHTML).toEqual(expectedHtml);
   });
+
+  test('should remove <p><br></p> (line break)', () => {
+    const htmlData = toDom('<div><p><br></p></div>');
+    removeEmptyParagraphs(htmlData);
+    const expectedHtml = '<div></div>';
+    expect(htmlData.window.document.body.innerHTML).toEqual(expectedHtml);
+  });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2479 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
### problems
- The current version does not call the function from `remove-empty-paragraphs.js` in `src/backend/utils/index.js`
- There is a edge case that blog post that contains `<p><br><p>`
### Fix
- Change the function to catch if `<p>` contains empty `<br>` 
- Invoke the function from `remove-empty-paragraphs.js` in `src/backend/utils/index.js`
- Add unit test on `remove-empty-paragraphs.test.js`

![fix-after](https://user-images.githubusercontent.com/55969486/142231178-cdb64148-58df-424a-a065-5dd75f472296.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


<a href="https://gitpod.io/#https://github.com/Seneca-CDOT/telescope/pull/2481"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

