### PR TITLE
2383- Added redirect for port 4000 in nginx

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -231,6 +231,13 @@ http {
       proxy_pass http://portainer:9000/;
     }
 
+    # Redirect traffic from /deploy/* to the autodeployment server
+    # extra slash for accepting all request_uri e.g. /deploy/status
+    location /deploy/ {
+      proxy_cache_bypass 1;
+      proxy_pass https://${TELESCOPE_HOST}:4000/;
+    }
+
     # Static next.js front-end
     location / {
       # Directory from which we serve Next's static content


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
fixes #2383 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This allows us to redirect from the /deploy route to the port 4000 servers, this way we don't have to recall which port the logs and status are running on. 

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)


<a href="https://gitpod.io/#https://github.com/Seneca-CDOT/telescope/pull/2485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

