### PR TITLE
Improve local development set up of status dash

### DIFF
--- a/src/api/status/env.local
+++ b/src/api/status/env.local
@@ -1,1 +1,2 @@
 PLANET_PORT=1111
+PATH_PREFIX=/v1/status

--- a/src/api/status/src/server.js
+++ b/src/api/status/src/server.js
@@ -30,6 +30,10 @@ const satelliteOptions = {
 
 const service = new Satellite(satelliteOptions);
 
+// For local dev, allow specifying a different path prefix (i.e., to mimic Traefik routing with our <base> tag)
+const staticPathPrefix = process.env.PATH_PREFIX || '/';
+service.router.use(staticPathPrefix, static(path.join(__dirname, '../public')));
+
 // Static web assets can be cached for a long time
 service.router.use('/', static(path.join(__dirname, '../public')));
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## #2473
Allow specifying a <code>/v1/status</code> path prefix for development 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
