### PR TITLE
Fix #2486: build log for autodeployment is not working

### DIFF
--- a/src/api/status/public/js/build-log/api.js
+++ b/src/api/status/public/js/build-log/api.js
@@ -8,14 +8,14 @@ export const checkBuildStatus = async () => {
       throw new Error('unable to get build info');
     }
     const data = await res.json();
-    if (!data.started) {
+    if (!data.current) {
       return { building: false };
     }
 
     return {
       building: true,
-      title: data.status,
-      startedAt: new Date(data.started),
+      title: data.type,
+      startedAt: new Date(data.current.startedDate),
     };
   } catch (err) {
     console.error(err);

--- a/src/api/status/public/js/build-log/index.js
+++ b/src/api/status/public/js/build-log/index.js
@@ -1,4 +1,0 @@
-import { checkForBuild } from './check-for-build.js';
-
-checkForBuild();
-setInterval(checkForBuild, 5000);

--- a/src/api/status/public/js/pages/build.js
+++ b/src/api/status/public/js/pages/build.js
@@ -1,0 +1,6 @@
+import { checkForBuild } from '../build-log/check-for-build.js';
+
+window.addEventListener('load', () => {
+  checkForBuild();
+  setInterval(checkForBuild, 5000);
+});

--- a/src/api/status/public/pages/build.html
+++ b/src/api/status/public/pages/build.html
@@ -163,6 +163,6 @@
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.5.0/lib/xterm-addon-fit.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.4.0/lib/xterm-addon-web-links.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-webgl@0.11.3/lib/xterm-addon-webgl.min.js"></script>
-    <script type="module" src="js/build-log/index.js" defer></script>
+    <script type="module" src="js/pages/build.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #2486

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
- Fix build log doesn't parse the data correctly, so it always returns false (i.e. no on-going build).
- Change files structure to align with other scripts.

![image](https://user-images.githubusercontent.com/52666982/142979599-69b7e014-abb2-4b46-b288-86ccf7b04673.png)
![image](https://user-images.githubusercontent.com/52666982/142979606-05430ad8-675c-43e3-a3a0-eccea43224f2.png)

## Test plan

- Change autodeploymentUrl in public/js/buildl-log/api.js
```diff
- const autodeploymentUrl = (path) => `//${location.hostname}:4000/${path}`;
+ const autodeploymentUrl = (path) => `//dev.api.telescope.cdot.systems:4000/${path}`;  
```
- Allow all src in src/server.js
```diff
-         connectSrc: [
-          "'self'",
-          '*.fontawesome.com',
-          `${host.replace(/(^\w+:|^)\/\//, '')}:4000`,
-          '*.github.com',
-        ],
+ connectSrc: ["'self'", "*"]
```
- Go to /src/api/status.
- Run `npm run dev`
- Go to pages/build.html
- Build log only shows up if there is an on-going build

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
