### PR TITLE
Issue 2412  GET /feeds/invalid

### DIFF
--- a/src/api/posts/src/routes/feeds.js
+++ b/src/api/posts/src/routes/feeds.js
@@ -1,6 +1,6 @@
 const { Router, logger, isAuthenticated, isAuthorized } = require('@senecacdot/satellite');
 const Feed = require('../data/feed');
-const { getFeeds } = require('../storage');
+const { getFeeds, getInvalidFeeds } = require('../storage');
 const { validateNewFeed, validateFeedsIdParam } = require('../validation');
 
 const feeds = Router();
@@ -25,6 +25,23 @@ feeds.get('/', async (req, res, next) => {
         id,
         url: `${feedURL}/${id}`,
       }))
+  );
+});
+
+feeds.get('/invalid', async (req, res, next) => {
+  let invalidFeeds;
+  try {
+    invalidFeeds = await getInvalidFeeds();
+  } catch (error) {
+    logger.error({ error }, 'Unable to get invalid feeds from Redis');
+    return next(error);
+  }
+  res.set('X-Total-Count', invalidFeeds.length);
+  return res.json(
+    invalidFeeds.map((element) => ({
+      ...element,
+      url: `${feedURL}/${element.id}`,
+    }))
   );
 });
 

--- a/src/api/posts/test/feeds.test.js
+++ b/src/api/posts/test/feeds.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const { app } = require('../src');
+const Feed = require('../src/data/feed');
+
+describe('Test GET /feeds/invalid endpoint', () => {
+  const createdItems = 150;
+  // Array of feeds
+  const feeds = [...Array(createdItems).keys()].map((item) => {
+    return new Feed('foo', `http://telescope${item}.cdot.systems`);
+  });
+  beforeAll(() => Promise.all(feeds.map((feed) => feed.save())));
+
+  it('Should return 200 and empty body when there are no invalid feeds', async () => {
+    const res = await request(app).get('/feeds/invalid');
+
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.get('X-Total-Count')).toBe('0');
+    expect(res.body.length).toBe(0);
+    expect(res.body instanceof Array).toBe(true);
+  });
+
+  it('Should return 200 and invalid feeds object', async () => {
+    // arrange invalid feeds
+    const createdInvalidFeeds = 20;
+    for (let i = 0; i < createdInvalidFeeds; i += 1) {
+      feeds[i].setInvalid('test');
+    }
+    const res = await request(app).get('/feeds/invalid');
+
+    expect(res.status).toEqual(200);
+    expect(res.get('Content-type')).toContain('application/json');
+    expect(res.get('X-Total-Count')).toBe(createdInvalidFeeds.toString());
+    expect(res.body.length).toBe(createdInvalidFeeds);
+    expect(res.body instanceof Array).toBe(true);
+    expect(res.body[0].reason).toBe('test');
+    expect(res.body[0].id).toBe(feeds[0].id);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2412 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #2412
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This is PR for issue- #2412: adding GET /feeds/invalid.  I have added the route in posts/src/routes/feeds.js file and new methods to get invalids keys from Redis in posts/src/storage.js. I have not modified the Redis database code in https://github.com/Seneca-CDOT/telescope/blob/master/src/backend/utils/storage.js as prof David mentioned. 
I have not written the unit tests for this but I tested it in local and the GET /feeds/invalid returned the expected result. 
Thank you for reviewing and please let me know if I am on the right track.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
