### PR TITLE
Added a Bull client, and a route /feeds/info to query queue's info

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,7 @@ importers:
   src/api/posts:
     specifiers:
       '@senecacdot/satellite': ^1.x
+      bull: ^3.20.1
       express-validator: ^6.13.0
       ioredis: ^4.28.0
       ioredis-mock: ^5.8.0
@@ -255,6 +256,7 @@ importers:
       supertest: ^6.1.6
     dependencies:
       '@senecacdot/satellite': 1.17.0
+      bull: 3.29.3
       express-validator: 6.13.0
       ioredis: 4.28.2
       ioredis-mock: 5.8.1_ioredis@4.28.2

--- a/src/api/posts/package.json
+++ b/src/api/posts/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@senecacdot/satellite": "^1.x",
+    "bull": "^3.20.1",
     "express-validator": "^6.13.0",
     "ioredis": "^4.28.0",
     "ioredis-mock": "^5.8.0",

--- a/src/api/posts/src/queue.js
+++ b/src/api/posts/src/queue.js
@@ -1,0 +1,20 @@
+const Bull = require('bull');
+const redis = require('./redis');
+
+const client = redis;
+const subscriber = redis;
+
+const queue = new Bull('feed-queue', {
+  createClient: (type) => {
+    switch (type) {
+      case 'client':
+        return client;
+      case 'subscriber':
+        return subscriber;
+      default:
+        return redis;
+    }
+  },
+});
+
+module.exports = queue;

--- a/src/api/posts/test/feeds.test.js
+++ b/src/api/posts/test/feeds.test.js
@@ -71,3 +71,27 @@ describe('Test GET /feeds/delayed endpoint', () => {
     expect(res.body[0].id).toBe(feeds[0].id);
   });
 });
+
+describe('GET /feeds/info', () => {
+  test('Should return 200 and valid response object', async () => {
+    function checkKeys(resBody) {
+      let bool = true;
+      const allKeys = ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused', 'jobCnt'];
+      const resKeys = Object.keys(resBody.queueInfo);
+      for (let i = 0; i < resKeys.length; i += 1) {
+        if (allKeys.indexOf(resKeys[i]) < 0 || typeof resBody.queueInfo[resKeys[i]] !== 'number') {
+          bool = false;
+          break;
+        }
+      }
+      return bool;
+    }
+
+    const res = await request(app).get('/feeds/info');
+
+    expect(res.status).toEqual(200);
+    expect(typeof res.body).toEqual('object');
+    expect(typeof res.body.queueInfo).toEqual('object');
+    expect(checkKeys(res.body)).toBe(true);
+  });
+});


### PR DESCRIPTION

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This fixes #2414 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This is draft PR for issue #2414. 

I added a new file `queue.js` that creates and exports a new Bull client with `redis` client connection required from [posts/src/redis.js](https://github.com/Seneca-CDOT/telescope/blob/master/src/api/posts/src/redis.js). I also added a new GET route `feeds/info` to return the queue's information, for now I'm trying to return the number of jobs in the queue. 

I tested the route by running `npm run services:start`, `npm start` first and running `http://localhost/v1/posts/feeds/info` in Postman. However, I haven't got the expected response, please let me know if I'm on the right track!

The response I got was a long loading screen until Bad Gateway

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
