### PR TITLE
Add padding to build log terminal

### DIFF
--- a/src/api/status/public/css/terminal.css
+++ b/src/api/status/public/css/terminal.css
@@ -1,0 +1,3 @@
+.xterm {
+  padding: 0.5rem;
+}

--- a/src/api/status/public/pages/build.html
+++ b/src/api/status/public/pages/build.html
@@ -25,6 +25,7 @@
     <link id="pagestyle" href="assets/css/material-dashboard.css?v=3.0.0" rel="stylesheet" />
     <!-- Telescope CSS Override -->
     <link rel="stylesheet" type="text/css" href="css/telescope-dashboard.css" />
+    <link rel="stylesheet" type="text/css" href="css/terminal.css" />
   </head>
 
   <body class="g-sidenav-show bg-gray-200">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #2534 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

Add `1rem` padding to build log terminal.
<!-- Please add a detailed description of what this PR does and why it is needed -->

<img width="227" alt="Screen Shot 2021-11-29 at 10 27 27 AM" src="https://user-images.githubusercontent.com/53121061/143895631-8371efc1-5942-4c5b-a02f-e7fb6699f29a.png">


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
