### PR TITLE
edit terminal.js to full height of view port

### DIFF
--- a/src/api/status/public/css/terminal.css
+++ b/src/api/status/public/css/terminal.css
@@ -1,3 +1,4 @@
 .xterm {
   padding: 0.5rem;
+  height: 89vh;
 }


### PR DESCRIPTION
issue #2519:
The terminal port can't auto fit the height because the Browser can't get the size of the container.  So I edit the terminal.js file and get the window's width and height, then calculate the row height and column width based on these data.
If the user has more than one screen, just refresh the screen, the terminal window will fit the new screen.
**Before:**
![e01f38d53a69df584f6bb85c87a20d2](https://user-images.githubusercontent.com/55161917/144275355-57bbe604-9e94-4122-9863-6ee287671952.png)
**After:**
![6e3615f1006fa113d90c12ff899bea3](https://user-images.githubusercontent.com/55161917/144275418-81822c3b-74c0-46e5-9bcf-056ca9dec0f7.png)

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
