### PR TITLE
Enabling cache for actions/setup-node

### DIFF
--- a/.github/workflows/node-js-ci.yml
+++ b/.github/workflows/node-js-ci.yml
@@ -15,7 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup a lock file
+        run: npm install --package-lock-only
       - uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14'
+          cache: 'npm'
       - name: Install dependencies and run prettier-check
         run: |
           npm install
@@ -27,7 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup a lock file
+        run: npm install --package-lock-only
       - uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14'
+          cache: 'npm'
       - name: Install dependencies and run eslint
         run: |
           npm install
@@ -43,20 +53,12 @@ jobs:
         node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2.1.6
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      - name: Setup a lock file
+        run: npm install --package-lock-only --ignore-scripts
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v1
       - name: Install dependencies and run tests with default env
@@ -72,16 +74,13 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/cache@v2.1.6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - uses: actions/checkout@v2
+      - name: Setup a lock file
+        run: npm install --package-lock-only
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - uses: microsoft/playwright-github-action@v1
       - name: Start microservices and run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup a lock file
+        run: npm install --package-lock-only
       - uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14'
+          cache: 'npm'
+
       - name: Install dependencies and run prettier-check
         run: |
           npm install
@@ -27,7 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup a lock file
+        run: npm install --package-lock-only
       - uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14'
+          cache: 'npm'
       - name: Install dependencies and run eslint
         run: |
           npm install
@@ -43,20 +54,12 @@ jobs:
         node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2.1.6
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+      - name: Setup a lock file
+        run: npm install --package-lock-only --ignore-scripts
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v1
       - name: Install dependencies and run tests with default env
@@ -72,16 +75,13 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/cache@v2.1.6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - uses: actions/checkout@v2
+      - name: Setup a lock file
+        run: npm install --package-lock-only
       - uses: actions/setup-node@v2.4.1
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - uses: microsoft/playwright-github-action@v1
       - name: Start microservices and run tests
         run: |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #2537 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Currently, the workflows use `actions/cache`, but `actions/node-setup` now has optional functionality to [cache and restore dependencies](https://github.com/actions/setup-node#caching-packages-dependencies). Following changes were made to `node-js-ci` and `release` workflow:

- Removed `actions/cache`
- Enabled cache for `actions/setup-node`

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: N/A
- [X] **Documentation**: N/A