### PR TITLE
#2554 Search page re-renders on entering input 

### DIFF
--- a/src/web/src/components/SearchInput/AuthorSearchInput.tsx
+++ b/src/web/src/components/SearchInput/AuthorSearchInput.tsx
@@ -35,13 +35,10 @@ const AuthorSearchInput = () => {
       <input
         autoFocus
         className={classes.input}
-        list="search-suggestions"
         placeholder="How to contribute to Open Source"
         value={text}
         onChange={(event) => onTextChange(event.target.value)}
       />
-
-      <datalist aria-label="search telescope" id="search-suggestions" />
     </>
   );
 };

--- a/src/web/src/components/SearchInput/SearchInput.tsx
+++ b/src/web/src/components/SearchInput/SearchInput.tsx
@@ -5,7 +5,7 @@ import useSearchValue from '../../hooks/use-search-value';
 const SearchInput = () => {
   const { filter } = useSearchValue();
 
-  return filter === 'author' ? <AuthorSearchInput /> : <PostSearchInput />;
+  return <>{filter === 'author' ? <AuthorSearchInput /> : <PostSearchInput />}</>;
 };
 
 export default SearchInput;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue>
2. If your PR addresses an issue but does not close it
    USAGE: #<2554> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

This PR closes #2554 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
When entering any text into search, it should keep focus so that you can continue entering your search text. The <code>autofocus</code> attribute is not recommended by ESLint, unless the page is mainly used for searching, as it is in this case. See [The accessibility of HTML 5 autofocus](https://brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/).

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
