### PR TITLE
Fix prettier-check issues on master

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,5 @@ out
 
 # We don't maintain these files
 src/api/status/public/assets
+src/web/public/sw*
+src/web/public/workbox*

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,6 @@
   "endOfLine": "lf",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
-  "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
   "proseWrap": "preserve",
   "quoteProps": "as-needed",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "start": "node src/backend",
     "server": "node src/backend/web/server",
     "test-ci": "run-s prettier-check test",
-    "pre-commit": "pretty-quick --staged && npm run lint",
+    "pre-commit": "pretty-quick --staged",
     "postversion": "git push upstream master --tags",
     "services:start": "node bin/services-start.js --",
     "services:stop": "node bin/services-stop.js",


### PR DESCRIPTION
We have a few prettier issues on `master`:

1. we shouldn't be running lint on pre commit, it's messing with prettier.  I think this is what is messing up people's prettier commits, since eslint and prettier are fighting each other
2. we are using deprecated prettier config
3. we aren't ignore generated workbox scripts
