### PR TITLE
Using workspace-base to create a custom gitpod env image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,25 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-base
 
-# Install pnpm
-RUN npm install -g pnpm
+# Installing Node LTS
+# https://github.com/nvm-sh/nvm#installing-and-updating
+USER gitpod
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash \
+    && bash -c ". .nvm/nvm.sh \
+        && nvm install --lts \
+        && nvm alias default lts/* \
+        && npm install -g pnpm"
+
+# Installing docker
+# https://docs.docker.com/engine/install/ubuntu/
+USER root
+RUN curl -o /var/lib/apt/dazzle-marks/docker.gpg -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    && apt-key add /var/lib/apt/dazzle-marks/docker.gpg \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && install-packages docker-ce docker-ce-cli containerd.io
+
+RUN curl -o /usr/bin/slirp4netns -fsSL https://github.com/rootless-containers/slirp4netns/releases/download/v1.1.12/slirp4netns-$(uname -m) \
+    && chmod +x /usr/bin/slirp4netns
+
+RUN curl -o /usr/local/bin/docker-compose -fsSL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 \
+    && chmod +x /usr/local/bin/docker-compose
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Closes #2564 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
As highlighted in #2564, a smaller, more optimized image for gitpod can be created rather than using the default `workspace-full` which contains a lot of tools that we are not using. So, I've added a custom `.gitpod.Dockerfile` using the [`gitpod/workspace-base`](https://github.com/gitpod-io/workspace-images/blob/master/base/Dockerfile) image. 

#### Changes
Installed the following on top of the `base` image:
- Node
- [typescript](https://www.npmjs.com/package/typescript), [yarn](https://www.npmjs.com/package/yarn) and [pnpm](https://www.npmjs.com/package/pnpm)  packages
- Docker

Verified the installation by building and running the image locally:
![image](https://user-images.githubusercontent.com/52294825/144969001-5cc88a09-8908-4123-a9fb-1c87d19c768b.png)


## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: N/A
- [X] **Documentation**: N/A
