### PR TITLE
fix: build-log should read till end of stream

### DIFF
--- a/src/api/status/public/js/build-log/check-for-build.js
+++ b/src/api/status/public/js/build-log/check-for-build.js
@@ -19,8 +19,11 @@ function processLog({ done, value }) {
   }
 
   if (terminal) {
-    return terminal.write(value);
+    terminal.write(value);
   }
+
+  // Recursively invoke processLog until `done === true`
+  return reader.read().then(processLog).catch(finish);
 }
 
 export default async function checkForBuild() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2539 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
As David has mentioned in the issue, `read()` is only called once so the log stuck.

<!-- Please add a detailed description of what this PR does and why it is needed -->

https://user-images.githubusercontent.com/52666982/144975015-aa462511-10fa-4dd3-b0e0-205957d3e11e.mp4

## Test plan
- Go to /dashboard/build.html
- Ask @humphd or @manekenpix to trigger a build
- The terminal should print a bunch of text, then stop, then print again (sometimes it can take a while).

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
