### PR TITLE
Fix fetch status url for staging/prod

### DIFF
--- a/src/api/status/src/server.js
+++ b/src/api/status/src/server.js
@@ -44,7 +44,7 @@ if (process.env.PATH_PREFIX) {
   service.router.use('/', serveStatic(path.join(__dirname, '../public')));
 }
 
-service.router.get('/v1/status/status', (req, res) => {
+service.router.get(`${process.env.PATH_PREFIX || ''}/status`, (req, res) => {
   check()
     .then((status) => {
       // This status response shouldn't be cached (we need current status info)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
## Issue This PR Addresses
Related #2418 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Because staging/prod adds `/v1/status`, the URL for fetching turns into `/v1/status/v1/status/status`
Used `PATH_PREFIX` to fix that issue.
- In development (local), route will be `PATH_PREFIX/status`
- In staging/prod, route `/status`
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
