### PR TITLE
Added jobs count to dashboard

### DIFF
--- a/src/api/posts/test/feeds.test.js
+++ b/src/api/posts/test/feeds.test.js
@@ -75,18 +75,12 @@ describe('Test GET /feeds/delayed endpoint', () => {
 describe('GET /feeds/info', () => {
   test('Should return 200 and valid response object', async () => {
     function checkKeys(resBody) {
-      let bool = true;
       const allKeys = ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused', 'jobCnt'];
-      const resKeys = Object.keys(resBody.queueInfo);
-      for (let i = 0; i < resKeys.length; i += 1) {
-        if (allKeys.indexOf(resKeys[i]) < 0 || typeof resBody.queueInfo[resKeys[i]] !== 'number') {
-          bool = false;
-          break;
-        }
-      }
-      return bool;
+      // return true if the response object has all correct properties/keys and correct value types
+      return Object.keys(resBody.queueInfo).every(
+        (key) => allKeys.includes(key) && typeof resBody.queueInfo[key] === 'number'
+      );
     }
-
     const res = await request(app).get('/feeds/info');
 
     expect(res.status).toEqual(200);

--- a/src/api/status/src/js/queue-stats.js
+++ b/src/api/status/src/js/queue-stats.js
@@ -1,0 +1,12 @@
+const { fetch, logger } = require('@senecacdot/satellite');
+
+module.exports = async function getJobCount() {
+  try {
+    const data = await fetch(`${process.env.POSTS_URL}/feeds/info`, { method: 'GET' });
+    const { queueInfo } = await data.json();
+    return queueInfo.jobCnt;
+  } catch (error) {
+    logger.warn({ error }, 'Failed to get feed queue info');
+  }
+  return 0;
+};

--- a/src/api/status/src/server.js
+++ b/src/api/status/src/server.js
@@ -6,6 +6,7 @@ const { check } = require('./services');
 const getGitHubData = require('./js/github-stats');
 const getFeedCount = require('./js/feed-stats');
 const getPostsCount = require('./js/posts-stats');
+const getJobCount = require('./js/queue-stats');
 
 const host = process.env.API_HOST || 'localhost';
 
@@ -75,13 +76,14 @@ service.router.get(process.env.PATH_PREFIX || '/', async (req, res) => {
   let satellite;
   let totalPost;
   let totalFeeds;
-
+  let jobCount;
   try {
-    [totalPost, totalFeeds, telescope, satellite] = await Promise.all([
-      getPostsCount(),
-      getFeedCount(),
+    [telescope, satellite, totalPost, totalFeeds, jobCount] = await Promise.all([
       getGitHubData('Seneca-CDOT', 'telescope'),
       getGitHubData('Seneca-CDOT', 'satellite'),
+      getPostsCount(),
+      getFeedCount(),
+      getJobCount(),
     ]);
   } catch (e) {
     console.error(e);
@@ -98,6 +100,7 @@ service.router.get(process.env.PATH_PREFIX || '/', async (req, res) => {
     satellite: { ...satellite, title: 'Satellite' },
     totalPost,
     totalFeeds,
+    jobCount,
     environment,
   });
 });

--- a/src/api/status/src/views/partials/jobCountCard.hbs
+++ b/src/api/status/src/views/partials/jobCountCard.hbs
@@ -1,0 +1,24 @@
+<div class="col-xl-3 col-sm-6 mb-xl-0 mb-4 mt-4">
+  <div class="card card--telescope">
+    <div class="card-header card-header--telescope p-3 pt-2">
+      <div class="
+                    icon icon-lg icon-shape
+                    bg-gradient-info
+                    shadow-info
+                    text-center
+                    border-radius-xl
+                    mt-n4
+                    position-absolute
+                  ">
+        <i class="material-icons opacity-10">person</i>
+      </div>
+      <div class="text-end pt-1">
+        <h6 class="mb-0 text-capitalize">Telescope</h6>
+        <p class="text-sm mb-0 text-capitalize">Jobs in queue</p>
+        <h4 class="mb-0" id="job-count">{{#if jobCount}}{{jobCount}}{{else}}N/A{{/if}}</h4>
+      </div>
+    </div>
+    <hr class="dark horizontal my-0" />
+    <div class="card-footer p-3"></div>
+  </div>
+</div>

--- a/src/api/status/src/views/status.hbs
+++ b/src/api/status/src/views/status.hbs
@@ -41,6 +41,7 @@
 
       {{> totalPostCard}}
       {{> totalFeedCard}}
+      {{> jobCountCard}}
     </div>
 
     <div class="row mt-4">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

This fixes issue #2414 which is also a follow up of PR #2541 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

- Added `jobCountCard.hbs` to display jobs in feeds queue in the backend 
- Added to `src/api/status/src/js` a new file `queue-stats.js` to fetch queue's information using posts API `posts/feeds/info`

### To test this feature: 

- Added `*` or `http://localhost/v1/posts/feeds/info` to `connectSrc` in [server.js](https://github.com/Seneca-CDOT/telescope/blob/master/src/api/status/src/server.js)
- Change the fetch url in `queue/index.js` to `http://localhost/v1/posts/feeds/info`
- Run `pnpm run services:start posts` in root folder and `npm run dev` in `api/status`, you'll get `feeds/info` initial response 
- (Optional) Run all services `pnpm run services:start` and `pnpm start` to start the backend feeds queue. Reload to see changes

https://user-images.githubusercontent.com/58532267/145457103-3a3643b1-d981-4949-8f42-388254193405.mp4

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
