### PR TITLE
Handling invalid feed

### DIFF
--- a/src/api/posts/src/storage.js
+++ b/src/api/posts/src/storage.js
@@ -84,7 +84,7 @@ module.exports = {
         const id = key.replace(feedNamespace, '').replace(invalidSuffix, '');
         return {
           id,
-          reason,
+          reason: reason.replace(/\n/g, ' '),
         };
       })
     );
@@ -108,7 +108,8 @@ module.exports = {
 
   setInvalidFeed: (id, reason) => {
     const key = createInvalidFeedKey(id);
-    return redis.set(key, reason);
+    const sevenDaysInSeconds = 60 * 60 * 24 * 7; // Expire after 7 days
+    return redis.set(key, reason, 'EX', sevenDaysInSeconds);
   },
 
   /**

--- a/src/backend/utils/storage.js
+++ b/src/backend/utils/storage.js
@@ -64,7 +64,8 @@ module.exports = {
 
   setInvalidFeed: (id, reason) => {
     const key = createInvalidFeedKey(id);
-    return redis.set(key, reason);
+    const sevenDaysInSeconds = 60 * 60 * 24 * 7; // Expire after 7 days
+    return redis.set(key, reason, 'EX', sevenDaysInSeconds);
   },
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixed #2569 

I got the 2/3 of the issue that we are having, handling invalid feed. In this PR I have replaced all the `\n` with whitespace `' '`. Adding a `ttl` so as the `invalid` blog post will be expire in 7 days. I have test through `redis-cli` after I `flushall` the old invalid key and using `ttl (invalid key)` it return the associate expired time which is 7 days.  

![image](https://user-images.githubusercontent.com/43376325/145757482-6d0c2d11-abf5-4d59-ac94-2aaa86bb10a3.png)

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
