### PR TITLE
fix docker production env for status services

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -84,6 +84,8 @@ services:
   # status service
   status:
     restart: unless-stopped
+    environment:
+      - POSTS_URL
 
   # image service
   image:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Related #2553
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Since staging using `production.yml`, env `POSTS_URL` wasn't exposed which lead to not being able to fetch total post and feed in the dashboard.
![image](https://user-images.githubusercontent.com/58233223/145759751-5796350d-b227-4147-99b6-756196d79b08.png)

Fix by adding `POSTS_URL` env for status services in `production.yml`
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
