### PR TITLE
added advanced search query for elasticsearch

### DIFF
--- a/src/api/search/src/bin/validation.js
+++ b/src/api/search/src/bin/validation.js
@@ -1,4 +1,4 @@
-const { check, validationResult } = require('express-validator');
+const { oneOf, check, validationResult } = require('express-validator');
 
 const queryValidationRules = [
   // text must be between 1 and 256 and not empty
@@ -31,8 +31,59 @@ const queryValidationRules = [
     .bail(),
 ];
 
-const validateQuery = (rules) => {
+/**
+ * Advanced search is more flexible, only needs at least ONE field, but can run without any too.
+ * Date formats must be YYYY-MM-DD
+ */
+const advancedQueryValidationRules = [
+  oneOf([
+    check('post')
+      .exists({ checkFalsy: true })
+      .withMessage('post should not be empty')
+      .bail()
+      .isLength({ max: 256, min: 1 })
+      .withMessage('post should be between 1 to 256 characters')
+      .bail(),
+    check('author')
+      .exists({ checkFalsy: true })
+      .withMessage('author should exist')
+      .bail()
+      .isLength({ max: 100, min: 2 })
+      .withMessage('invalid author value')
+      .bail(),
+    check('title')
+      .exists({ checkFalsy: true })
+      .withMessage('title should exist')
+      .bail()
+      .isLength({ max: 100, min: 2 })
+      .withMessage('invalid title value')
+      .bail(),
+  ]),
+  check('to').optional().isISO8601().withMessage('invalid date format').bail(),
+
+  check('from').optional().isISO8601().withMessage('invalid date format').bail(),
+  check('perPage')
+    .optional()
+    .isInt({ min: 1, max: 10 })
+    .withMessage('perPage should be empty or a number between 1 to 10')
+    .bail(),
+
+  check('page')
+    .optional()
+    .isInt({ min: 0, max: 999 })
+    .withMessage('page should be empty or a number between 0 to 999')
+    .bail(),
+];
+
+/**
+ * Validates query by passing rules. The rules are different based on the pathname
+ * of the request. If the pathname is '/' it is the basic route.
+ * Otherwise, if '/advanced/' it is the advanced search
+ */
+const validateQuery = () => {
   return async (req, res, next) => {
+    const rules = req.baseUrl === '/' ? queryValidationRules : advancedQueryValidationRules;
+
     await Promise.all(rules.map((rule) => rule.run(req)));
 
     const result = validationResult(req);
@@ -45,4 +96,4 @@ const validateQuery = (rules) => {
   };
 };
 
-module.exports.validateQuery = validateQuery(queryValidationRules);
+module.exports.validateQuery = validateQuery();

--- a/src/api/search/src/routes/query.js
+++ b/src/api/search/src/routes/query.js
@@ -1,6 +1,6 @@
 const { Router, createError } = require('@senecacdot/satellite');
 const { validateQuery } = require('../bin/validation');
-const search = require('../search');
+const { search, advancedSearch } = require('../search');
 
 const router = Router();
 
@@ -8,6 +8,15 @@ router.get('/', validateQuery, async (req, res, next) => {
   try {
     const { text, filter, page, perPage } = req.query;
     res.send(await search(text, filter, page, perPage));
+  } catch (error) {
+    next(createError(503, error));
+  }
+});
+
+// route for advanced
+router.get('/advanced', validateQuery, async (req, res, next) => {
+  try {
+    res.send(await advancedSearch(req.query));
   } catch (error) {
     next(createError(503, error));
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
## Issue This PR Addresses
This PR closes #2110 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
This PR Is aimed to help make search queries more flexible. What I have done here is I looked into Elasticsearch so that we can further query different fields we have indexed in Posts. I looked at the data presented back by Elasticsearch and realized we have more fields we can use to search: 
- post
- title
- author
- date published

This PR allows for us to query all of this on the backend, with search and Elasticsearch. 

Additionally, this query seems to be more promising than the original query for the post/author search. We should eventually use the query provided here, as the `zero_terms_query: 'all',` means that if that field is not provided, to search without it. This means we can use this query to search for one, two, three... or all fields, acting the same way as the previous implementation but doing more. The query will also work if we want to search for all posts published on X date, or from x to y dates.

<!-- Please add a detailed description of what this PR does and why it is needed -->
## Steps to test: 
1. delete redis-data file if it exists
2. `cp config/env.development .env`
3. `docker-compose --env-file ./config/env.development up --build search elasticsearch redis posts`
4. to rebuild search: `docker-compose --env-file ./config/env.development up --build -d search posts` (NOT Necessary - Skip! just FYI)
5. in another terminal run `pnpm start` to start the feed parser. Wait a bit for some posts to populate.
6. As the changes are only reflected in the API, you can test queries using such:
```http://localhost/v1/search/advanced/?post=elasticsearch&author=amasia```
feel free to add more filters such as author, title, from, to and post

After you are done ensure your containers are down by running `docker-compose --env-file ./config/env.development down `
## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

Example of how the search works:

The screenshot is taken from elasticsearch on localhost:9200 for reference of the post: 
![chrome_eujzknH9TX](https://user-images.githubusercontent.com/77639637/146290659-98015599-fbc0-4386-84f1-ed2e14a20caf.png)


