### PR TITLE
Fix student quotes mismatch quote urls

### DIFF
--- a/src/web/src/components/Banner.tsx
+++ b/src/web/src/components/Banner.tsx
@@ -105,8 +105,6 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-const studentQuote = quotes[Math.floor(Math.random() * quotes.length)];
-
 type BannerProps = {
   onVisibilityChange: (visible: boolean) => void;
 };
@@ -118,6 +116,7 @@ export default function Banner({ onVisibilityChange }: BannerProps) {
     sha: '',
     version: '',
   });
+  const [studentQuote, setStudentQuote] = useState(quotes[0]);
 
   const timelineAnchor = useRef<HTMLDivElement>(null);
   const bannerAnchor = useRef<HTMLDivElement>(null);
@@ -135,6 +134,7 @@ export default function Banner({ onVisibilityChange }: BannerProps) {
       // Apply smooth scroll polyfill on mobile
       smoothscroll.polyfill();
     }
+    setStudentQuote(quotes[Math.floor(Math.random() * quotes.length)]);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
Fixes #2646.

The bug happens because we generate a random quote at https://github.com/Seneca-CDOT/telescope/blob/323abdffe1c3b288d4928bfe25113f99b56e604a/src/web/src/components/Banner.tsx#L108. 

Because NextJS tries to pre-render stuff, first, a random quote is generated once at build time, and once when the page loads. Now the new quote is updated to the visual elements of the page but not the `href` of the `<a>` tag which is still the pre-rendered one. I am not sure why the `href` is not updated.

In this fix, I put the random quote to a state, and generate it once the banner component is loaded. I could also generate it in the `useState` initializer but the initializer might be invoked twice because of  [React development strict mode](https://reactjs.org/docs/strict-mode.html).
 
## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
