### PR TITLE
Fix post info to not overflow

### DIFF
--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -29,6 +29,7 @@ type Props = {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
+      display: 'flow-root',
       padding: '0',
       paddingBottom: '2em',
       marginBottom: '3em',
@@ -36,7 +37,6 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: '1.5rem',
       width: '100%',
       backgroundColor: theme.palette.background.default,
-      minHeight: '300px',
     },
     spinner: {
       padding: '20px',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->
 Fixes #2568 
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
The post info overflow the post container if the post text wasn't long enough.
I set the root to `display: flow-root` so it will makes sure everything will stay in that post container.

![image](https://user-images.githubusercontent.com/58233223/149379315-e3ff7d66-a62f-4a33-a9b7-0bc23c866335.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
