### PR TITLE
Fixes #2644: Update release docs to use pnpm

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -21,19 +21,16 @@ When we release Telescope, we need to do a number of things:
 - generate a changelog
 - create a Release on GitHub
 
-We use the [npm-version](https://docs.npmjs.com/cli/v6/commands/npm-version) command line tool to help us automate the release process.
+We use the [npm-version](https://docs.npmjs.com/cli/v6/commands/npm-version) command line tool (with `pnpm version`) to help us automate the release process.
 
 ### Using npm-version
 
 To create a new release, follow these steps:
 
 1. Make sure your `master` branch is up-to-date, and you have the most recent git tags in your repo: `git pull upstream master --tags`.
-1. Run `npm outdated` to see a report of [outdated npm packages](https://docs.npmjs.com/cli-commands/outdated.html). Examine this list and decide whether we need to update
-   anything now, or before the next release. _Please file a new Issue to update
-   anything that is outdated_.
 1. Make sure your working tree is clean.
 1. Determine what the new version _string_ should be based on [semantic versioning](https://github.com/npm/node-semver#functions). New version should be a valid semver string. In our project, that would usually be `minor` (e.g. `1.5.0`, `1.6.0`, `1.7.0`) or `major` (e.g. `1.0.0`, `2.0.0`). See [npm-version docs](https://docs.npmjs.com/cli/v6/commands/npm-version) to learn more about what options are available for the new version string.
-1. Use `npm version <new-version-string> -m "Release message"` to trigger the automated release workflow. For example, `npm version minor -m "Release 1.6.0"` will increase the minor version of the project (`1.5.x` -> `1.6.0`). To make a major release, we can use `npm version major -m "Release 2.0.0"` (`1.x.x` to `2.0.0`).
+1. Use `pnpm version <new-version-string> -m "Release message"` to trigger the automated release workflow. For example, `pnpm version minor -m "Release 1.6.0"` will increase the minor version of the project (`1.5.x` -> `1.6.0`). To make a major release, we can use `pnpm version major -m "Release 2.0.0"` (`1.x.x` to `2.0.0`).
 
 `npm-version` will proceed to run tests locally. If successful, it will also bump the `version` in [package.json](https://github.com/Seneca-CDOT/telescope/blob/master/package.json), create a new [`git tag`](https://git-scm.com/book/en/v2/Git-Basics-Tagging) and push both the code and the tags to `upstream master` (which you should have configured to point to https://github.com/Seneca-CDOT/telescope at this point).
 That will trigger our [release workflow](https://github.com/Seneca-CDOT/telescope/blob/master/.github/workflows/release.yml), which will run all tests in the cloud. If tests finish successfully, [the release workflow](https://github.com/Seneca-CDOT/telescope/blob/master/.github/workflows/release.yml) will proceed to [generate a changelog](https://github.com/lob/generate-changelog#usage) and create a new [GitHub Release](https://github.com/Seneca-CDOT/telescope/releases).


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2644 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR updates the release docs to use `pnpm` instead of `npm`. It also removes the section about running `npm outdated` before each release.
I haven't found any issues when using `pnpm version` so this should be the correct way of creating a new release.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
