### PR TITLE
increase max_pull_requests to 250

### DIFF
--- a/release-changelog-builder-config.json
+++ b/release-changelog-builder-config.json
@@ -97,7 +97,7 @@
     }
   ],
   "max_tags_to_fetch": 200,
-  "max_pull_requests": 200,
+  "max_pull_requests": 250,
   "max_back_track_time_days": 90,
   "tag_resolver": {
     "method": "semver"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2645 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
![image](https://user-images.githubusercontent.com/32626950/150195357-3fb8e2d1-9db6-4592-9bfd-029d4900ee0b.png)

According to the build logs for [Release 2.4.0](https://github.com/Seneca-CDOT/telescope/runs/4721341052?check_suite_focus=true), 220 merged PRs were accounted for.
The easiest fix is to increase the `max_pull_requests` option in the [`release-changelog-builder-config.json`](https://github.com/Seneca-CDOT/telescope/blob/master/release-changelog-builder-config.json)

However, I have been trying, but have failed, to understand how it got to 220 merged PRs.
Trying to [query merged PRs during the time frame](https://github.com/Seneca-CDOT/telescope/pulls?q=is%3Apr+merged%3A2021-11-09T03%3A53%3A05.000Z..2022-01-05T23%3A08%3A48.000Z+) provided by the log only comes up with 80 PRs
<img src="https://user-images.githubusercontent.com/32626950/150196605-ee675232-0ddd-400b-bc7c-2ed1e8ac1d47.png" width="500">

[Querying for all closed PRs](https://github.com/Seneca-CDOT/telescope/pulls?q=is%3Apr+closed%3A2021-11-09T03%3A53%3A05.000Z..2022-01-05T23%3A08%3A48.000Z+), not just merged, during this time frame comes up with 113 PRs.
<img src="https://user-images.githubusercontent.com/32626950/150197621-b2b27fc8-58f9-4370-b957-06877350d820.png" width="500">

Similar discrepancies are also in the [Release 2.3.0 log](https://github.com/Seneca-CDOT/telescope/runs/4111887957?check_suite_focus=true) where 152 merged PRs were accounted for. But querying on GitHub, there is only 48 [merged PRs](https://github.com/Seneca-CDOT/telescope/pulls?q=is%3Apr+merged%3A2021-10-08T18%3A57%3A47.000Z..2021-11-04T23%3A47%3A26.000Z), and 60 [closed](https://github.com/Seneca-CDOT/telescope/pulls?q=is%3Apr+closed%3A2021-10-08T18%3A57%3A47.000Z..2021-11-04T23%3A47%3A26.000Z+).

I couldn't load logs for earlier releases to check.

I suspect, but am unsure if PRs from the merged forked repositories are being accounted for.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
