### PR TITLE
Fix CSP error and build log crashes in dashboard

### DIFF
--- a/src/api/status/env.local
+++ b/src/api/status/env.local
@@ -1,5 +1,6 @@
 PLANET_PORT=1111
 PATH_PREFIX=/v1/status
 API_HOST=localhost
+WEB_URL=localhost
 POSTS_URL=http://localhost/v1/posts
 MOCK_REDIS=1

--- a/src/api/status/public/js/build-log/build-header.js
+++ b/src/api/status/public/js/build-log/build-header.js
@@ -50,12 +50,12 @@ function renderBuildInfo({ isCurrent, githubData, startedDate, stoppedDate, code
 }
 
 export default function buildHeader(build) {
-  if (build && !build.stoppedDate) {
+  if (!build) {
     const icon = document.createElement('i');
     icon.className = 'fas fa-server px-2';
     buildHeaderTitle.innerHTML = '';
     buildHeaderTitle.append(icon);
-    buildHeaderTitle.innerHTML += 'There is no current or previous build at the moment.';
+    buildHeaderTitle.innerHTML += 'Unable to get build info at the moment. Please try again later.';
     buildHeaderInfo.innerHTML = '';
     return;
   }

--- a/src/api/status/src/server.js
+++ b/src/api/status/src/server.js
@@ -8,7 +8,8 @@ const getFeedCount = require('./js/feed-stats');
 const getPostsCount = require('./js/posts-stats');
 const getJobCount = require('./js/queue-stats');
 
-const host = process.env.API_HOST || 'localhost';
+// We need to be able to talk to the autodeployment server
+const autodeploymentHost = process.env.WEB_URL || 'localhost';
 
 const satelliteOptions = {
   helmet: {
@@ -23,12 +24,7 @@ const satelliteOptions = {
           'fonts.googleapis.com',
           'cdn.jsdelivr.net',
         ],
-        connectSrc: [
-          "'self'",
-          '*.fontawesome.com',
-          `${host.replace(/(^\w+:|^)\/\//, '')}/deploy`,
-          '*.github.com',
-        ],
+        connectSrc: ["'self'", '*.fontawesome.com', autodeploymentHost, '*.github.com'],
         fontSrc: ["'self'", 'data:', 'https:', '*.fontawesome.com'],
         imgSrc: ["'self'", 'data:', 'https:'],
       },

--- a/tools/autodeployment/builds.js
+++ b/tools/autodeployment/builds.js
@@ -123,16 +123,17 @@ module.exports.buildLogHandler = function (buildName) {
       return;
     }
 
+    const { out, cache } = build;
+
     res.writeHead(200, { 'Content-Type': 'text/plain' });
 
     // Send the cached build log, which is either everything, or everything so far
-    const buildLog = build.cache.getContents();
-    if (buildLog) {
-      res.write(buildLog);
+    const cached = cache.getContents();
+    if (cached) {
+      res.write(cached);
     }
 
     // If we don't have a build happening, we're done
-    const { out } = build;
     if (!out) {
       res.end();
       return;


### PR DESCRIPTION
This is a follow-up to the build log cache PR I just merged.  I have a few bugs still in it:

- we need to connect back to the `/deploy` route of the web host vs. api host, so that CSP won't block it.
- we need to deal with the build being null, and show the error

I also cleaned up a path in the build server logic.