### PR TITLE
Fix WEB_URL env config for status service

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       dockerfile: Dockerfile
     environment:
       - NODE_ENV
-      - API_HOST
+      - WEB_URL
       - STATUS_PORT
       - STATUS_URL
       # Satellite authentication/authorization support

--- a/src/api/status/env.local
+++ b/src/api/status/env.local
@@ -1,6 +1,5 @@
 PLANET_PORT=1111
 PATH_PREFIX=/v1/status
-API_HOST=localhost
-WEB_URL=localhost
+WEB_URL=http://localhost
 POSTS_URL=http://localhost/v1/posts
 MOCK_REDIS=1


### PR DESCRIPTION
I'm back with a config fix.  The status service needs to access the `WEB_URL` env var, which means I need to expose it to the container.  I've also removed the `API_HOST`, which we don't use any more, and updated the dev env variables.