### PR TITLE
2698: Remove advanced search validation breaking production search

### DIFF
--- a/src/api/search/src/bin/validation.js
+++ b/src/api/search/src/bin/validation.js
@@ -82,8 +82,7 @@ const advancedQueryValidationRules = [
  */
 const validateQuery = () => {
   return async (req, res, next) => {
-    const rules = req.baseUrl === '/' ? queryValidationRules : advancedQueryValidationRules;
-
+    const rules = req.route.path === '/' ? queryValidationRules : advancedQueryValidationRules;
     await Promise.all(rules.map((rule) => rule.run(req)));
 
     const result = validationResult(req);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR fixes #2698

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
I removed the inline conditional statement to determine which validation rules to use and replaced it with a function which will return the rules.

Once we complete the refactor in #2618, we can remove the change or keep it depending if we want the route search types. 

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
I removed the inline conditional statement to determine which validation rules to use. 
The rules are not required for advanced search because we have not implemented any of the work yet and will be reintroduced in the refactor #2618 
<!-- Please add a detailed description of what this PR does and why it is needed -->


## How to test
Because previously this slipped up - I will go through this thoroughly to provide why this should work:

1. delete redis-data file if it exists
2. `cp config/env.development .env`
3. `docker-compose --env-file ./config/env.development up --build search elasticsearch redis posts`
4. in another terminal run `pnpm start` to start the feed parser. Wait a bit for some posts to populate.
5. in another terminal run `pnpm run dev` to start the front end app. 

OK there's two things to test here:
_1. the backend api still works for both searches_
you can test queries using the following link on your local machine:
**Advanced queries:**
```http://localhost/v1/search/advanced/?post=elasticsearch&author=amasia```
feel free to add more filters such as author, title, from, to and post
**Regular Queries:**
`http://localhost/v1/search/?text=amasia&filter=author` OR
`http://localhost/v1/search/?text=elasticsearch&filter=post`

_2. the front end search works and ONLY uses the regular query (not advanced search)_
you can test this by going to localhost:8000 and trying any search. This is the bug this PR aims to fix. I have attached screenshots to show myself searching locally and the network tab to indicate the query was to the correct path. 

**search author in telescope UI:**
![chrome_ndpIBu3bPr](https://user-images.githubusercontent.com/77639637/150450124-6f030a29-a664-4bee-bb4c-178b189b5c40.png)

**search post in telescope UI:**
![chrome_kCMmwHQIHw](https://user-images.githubusercontent.com/77639637/150450166-d68f66c3-0e92-49bb-8e6d-ba456a533b5c.png)

Both of these are now working, which is the most important. Kindly check the UI search after building the containers as described above.
## Checklist
We need to check the search works in the hosting for this PR, then it should be fine. 
<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
