### PR TITLE
Renovate: disallow node-fetch >= 3.0 and increase renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
   "reviewers": ["Seneca-CDOT/telescope-maintainers"],
   "includeForks": false,
   "rebaseWhen": "never",
-  "schedule": ["before 3am on Monday"],
+  "schedule": ["every weekend"],
   "prConcurrentLimit": 1,
   "prHourlyLimit": 1
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,8 @@
 {
   "extends": ["config:base"],
   "packageRules": [
-    {
-      "matchPackagePatterns": ["@senecacdot/satellite"],
-      "rangeStrategy": "replace"
-    }
+    { "matchPackagePatterns": ["@senecacdot/satellite"], "rangeStrategy": "replace" },
+    { "matchPackagePatterns": ["node-fetch"], "allowedVersions": "<3.0" }
   ],
   "dependencyDashboard": true,
   "major": {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->
Only allow node-fetch <3.0
- Refer to #2705, we don't want to go to node-fetch 3.0 because it's ESM module only. 

Expand Renovate's schedule to every weekend.

- We don't know when Renovate triggers dependencies check on our Repo. Only when Renovate happens to work during the current time window setting, `before 3 am every Monday`, PRs are allowed to be created. This is too small, and last week, Renovate failed to work in the schedule and didn't make any PRs.

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
