### PR TITLE
Add YouTube channel test case for feed discovery service

### DIFF
--- a/src/api/feed-discovery/test/router.test.js
+++ b/src/api/feed-discovery/test/router.test.js
@@ -161,6 +161,36 @@ describe('POST /', () => {
       expect(res.body).toEqual(result);
     });
 
+    it('should return 200 and 1 rss+xml feed url if the link is from a YouTube channel', async () => {
+      const youTubeDomain = 'https://www.youtube.com';
+      const channelUri = '/channel/UCqaMbMDf01BLttof1lHAo2A';
+      const youTubeChannelUrl = `${youTubeDomain}${channelUri}`;
+      const mockYouTubeChannelUrlResponseBody = `
+        <html lang="en">
+          <head>
+            <link rel="alternate" type="application/rss+xml" title="RSS" href="https://www.youtube.com/feeds/videos.xml?channel_id=UCqaMbMDf01BLttof1lHAo2A"/>
+          </head>
+          <body></body>
+        </html>
+      `;
+
+      const result = {
+        feedUrls: ['https://www.youtube.com/feeds/videos.xml?channel_id=UCqaMbMDf01BLttof1lHAo2A'],
+      };
+
+      // Mocking the response body html when call GET request to blog url
+      nock(youTubeDomain).get(channelUri).reply(200, mockYouTubeChannelUrlResponseBody, {
+        'Content-Type': 'text/html',
+      });
+
+      const res = await request(app)
+        .post('/')
+        .set('Authorization', `bearer ${createServiceToken()}`)
+        .send({ blogUrl: youTubeChannelUrl });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(result);
+    });
+
     it('should return 401 if no authorization token is included in headers', async () => {
       const res = await request(app).post('/').send({ blogUrl: 'https://test321.blogspot.com/' });
       expect(res.status).toBe(401);


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #2675.

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [X] **Test**: Change that adds test cases

## Description

This PR adds a test case to ensure that the feed discovery microservice works with YouTube URLs.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not.
- [X] **Screenshots**: This PR does not include screenshots as it does not modify UI.
- [X] **Documentation**: This PR does not include expanded documentation, because it does not add user-facing features.