### PR TITLE
Fixing wrong build status url

### DIFF
--- a/src/api/status/public/js/build-log/check-build-status.js
+++ b/src/api/status/public/js/build-log/check-build-status.js
@@ -2,7 +2,7 @@
 // being loaded. On staging and production, remove the `api.` subdomain.
 // On localhost:1111, use localhost (drop the port).
 const autodeploymentUrl = (path) =>
-  `//${window.location.hostname.replace('.api', '')}/deploy${path}`;
+  `//${window.location.hostname.replace(/(api\.|\.api)/, '')}/deploy${path}`;
 
 const getBuildLog = async (buildName) => {
   if (!(buildName === 'current' || buildName === 'previous')) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Fixed #2747 

You can review the `regex` [here](https://regex101.com/r/nIin6v/1)

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
