### PR TITLE
Always send a build's code as part of /status info

### DIFF
--- a/tools/autodeployment/builds.js
+++ b/tools/autodeployment/builds.js
@@ -34,14 +34,11 @@ class Build {
       type: this.type,
       githubData: this.githubData,
       startedDate: this.startedDate,
+      code: this.code,
     };
 
     if (this.stoppedDate) {
       build.stoppedDate = this.stoppedDate;
-    }
-
-    if (this.code) {
-      build.code = this.code;
     }
 
     return build;


### PR DESCRIPTION
Fixes #2719.

Follow-up on https://github.com/Seneca-CDOT/telescope/pull/2695#issuecomment-1020760044.  This sends the `code` for a build, no matter what it is.