### PR TITLE
Bump expo deps in src/mobile

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -10,15 +10,15 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "44.0.0",
+    "expo": "44.0.5",
     "expo-status-bar": "1.2.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "react-native": "0.64.3",
-    "react-native-web": "0.17.1"
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-native": "0.67.1",
+    "react-native-web": "0.17.5"
   },
   "devDependencies": {
-    "@babel/core": "7.12.9",
+    "@babel/core": "7.16.12",
     "@rnx-kit/metro-config": "1.2.27",
     "@rnx-kit/metro-resolver-symlinks": "0.1.16"
   },


### PR DESCRIPTION
I tried @menghif's work on `src/mobile` locally, and it works!

<img width="793" alt="Screen Shot 2022-01-28 at 10 30 57 AM" src="https://user-images.githubusercontent.com/427398/151575286-f3b48642-a912-4df9-8960-138f8190f5dc.png">

While I was playing with it, I noticed that the deps need to be updated.  We also have a `node-fetch` issue like before with 2.6.6 that still needs to be fixed somehow.