### PR TITLE
Add a default state to useMedia hook

### DIFF
--- a/src/web/src/hooks/use-preferred-theme.ts
+++ b/src/web/src/hooks/use-preferred-theme.ts
@@ -5,7 +5,7 @@ import { useLocalStorage, useMedia } from 'react-use';
  * loads of the app, and initial logic to get the browser's preferred colour.
  */
 export default function usePreferredTheme() {
-  const isDarkThemePreferred = useMedia('(prefers-color-scheme: dark)');
+  const isDarkThemePreferred = useMedia('(prefers-color-scheme: dark)', false);
   const [preferredTheme, setPreferredTheme] = useLocalStorage(
     'preference:theme',
     isDarkThemePreferred ? 'dark' : 'light'


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2672, this adds the default state to 'useMedia' hook call because otherwise the browser will fall back to false when server-side rendering which might not match the client's state.

https://github.com/streamich/react-use/blob/master/docs/useMedia.md#reference
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
