### PR TITLE
Added Cache-Control to build status header

### DIFF
--- a/tools/autodeployment/builds.js
+++ b/tools/autodeployment/builds.js
@@ -103,6 +103,7 @@ module.exports.addBuild = function (type, githubData, sha) {
 };
 
 module.exports.buildStatusHandler = function handleStatus(req, res) {
+  res.setHeader('Cache-Control', 'no-cache');
   res.json(builds);
 };
 
@@ -123,7 +124,7 @@ function handleBuildByName(buildName) {
     // If we have a build process, pipe that, otherwise we're done
     const pipeLog = () => (out ? out.pipe(res) : res.end());
 
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-cache' });
 
     // Send the cached build log, which is either everything, or everything so far.
     // After we're done, pipe the rest of the log as it happens.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2515 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
* Added `Cache-Control: no-cache` to build status response header. 

## Testing
I'm not sure if the `Cache-Control` header is added to the response. In `http://localhost/v1/status/build`, checking the network tab, I don't see the `Cache-Control` header in the `Response Headers`
![image](https://user-images.githubusercontent.com/58532267/151722060-8c6c5f85-2d9c-4e1a-843d-0d38a81a8039.png)

To run build log locally, change autodeploymentUrl in src\api\status\public\js\build-log\check-build-status.js
```js
const autodeploymentUrl = (path) => `//dev.telescope.cdot.systems/deploy${path}`;  
```
Allow all connectSrc in src\api\status\src\server.js
```js
connectSrc: ["'self'", "*"]
```


## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
