### PR TITLE
2nd draft for Registering an Image

### DIFF
--- a/.github/workflows/deploy-feed-discovery-image.yaml
+++ b/.github/workflows/deploy-feed-discovery-image.yaml
@@ -1,0 +1,29 @@
+name: Build and push feed-discovery service to ghcr
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/api/feed-discovery/**'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: src/api/feed-discovery
+          push: true
+          tags: feed-discovery:latest


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #1743 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This is my second draft of this after attempting to use a different workflow in a [previous iteration](https://github.com/Seneca-CDOT/telescope/pull/2775). I have tried multiple different ways to try and get the buider to go into a sub directory instead of using the Dockerfile in the root with varying results 
![image](https://user-images.githubusercontent.com/59970326/151817651-a3559110-b15e-45d3-abe8-b8e455657acd.png)

I think the version in this PR is the proper way to go about it, but it's not supported yet 
![image](https://user-images.githubusercontent.com/59970326/151818142-e86cf5a9-f474-40f1-8650-a51c43ad4ad6.png)
![image](https://user-images.githubusercontent.com/59970326/151827638-7ae3534d-4541-4bdd-9a56-6da522bb8320.png)


I could be wrong but I'm not sure what else to try.
