### PR TITLE
Set up rss-bridge service

### DIFF
--- a/config/rss-bridge/config.ini.php
+++ b/config/rss-bridge/config.ini.php
@@ -1,0 +1,90 @@
+; <?php exit; ?> DO NOT REMOVE THIS LINE
+
+; This file contains the default settings for RSS-Bridge. Do not change this
+; file, it will be replaced on the next update of RSS-Bridge! You can specify
+; your own configuration in 'config.ini.php' (copy this file).
+
+[system]
+
+; Defines the timezone used by RSS-Bridge
+; Find a list of supported timezones at
+; https://www.php.net/manual/en/timezones.php
+; timezone = "UTC" (default)
+timezone = "EST"
+
+[cache]
+
+; Defines the cache type used by RSS-Bridge
+; "file" = FileCache (default)
+type = "file"
+
+; Allow users to specify custom timeout for specific requests.
+; true  = enabled
+; false = disabled (default)
+custom_timeout = false
+
+[admin]
+; Advertise an email address where people can reach the administrator.
+; This address is displayed on the main page, visible to everyone!
+; ""    = Disabled (default)
+email = ""
+
+; Show Donation information for bridges if available.
+; This will display a 'Donate' link on the bridge view
+; and a "Donate" button in the HTML view of the bridges feed.
+; true  = enabled (default)
+; false = disabled
+donations = false
+
+[proxy]
+
+; Sets the proxy url (i.e. "tcp://192.168.0.0:32")
+; ""    = Proxy disabled (default)
+url = ""
+
+; Sets the proxy name that is shown on the bridge instead of the proxy url.
+; ""    = Show proxy url
+name = "Hidden proxy name"
+
+; Allow users to disable proxy usage for specific requests.
+; true  = enabled
+; false = disabled (default)
+by_bridge = false
+
+[authentication]
+
+; Enables authentication for all requests to this RSS-Bridge instance.
+;
+; Warning: You'll have to upgrade existing feeds after enabling this option!
+;
+; true  = enabled
+; false = disabled (default)
+enable = false
+
+; The username for authentication. Insert this name when prompted for login.
+username = ""
+
+; The password for authentication. Insert this password when prompted for login.
+; Use a strong password to prevent others from guessing your login!
+password = ""
+
+[error]
+
+; Defines how error messages are returned by RSS-Bridge
+;
+; "feed" = As part of the feed (default)
+; "http" = As HTTP error message
+; "none" = No errors are reported
+output = "feed"
+
+; Defines how often an error must occur before it is reported to the user
+report_limit = 1
+
+; --- Cache specific configuration ---------------------------------------------
+
+[SQLiteCache]
+file = "cache.sqlite"
+
+[MemcachedCache]
+host = "localhost"
+port = 11211

--- a/config/rss-bridge/whitelist.txt
+++ b/config/rss-bridge/whitelist.txt
@@ -1,0 +1,1 @@
+TwitchBridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -322,3 +322,29 @@ services:
     # See the following:
     # - https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-docker.html,
     # - https://github.com/deviantony/docker-elk/issues/243
+
+  rss-bridge:
+    image: rssbridge/rss-bridge:2022-01-20
+    container_name: 'rss-bridge'
+    # See RSS-Bridge docs for config files:
+    # Whitelist - https://github.com/RSS-Bridge/rss-bridge/wiki/Whitelisting
+    # Configuration - https://github.com/RSS-Bridge/rss-bridge/wiki/Custom-Configuration#timezone
+    volumes:
+      - ../config/rss-bridge:/config
+    depends_on:
+      - traefik
+    labels:
+      # Enable Traefik
+      - 'traefik.enable=true'
+      # Traefik routing for the rss-bridge service at /v1/rss-bridge
+      - 'traefik.http.routers.rss_bridge.rule=PathPrefix(`/${API_VERSION}/rss-bridge`)'
+      # Specify the RSS-Bridge service port used internally
+      - 'traefik.http.services.rss_bridge.loadbalancer.server.port=80'
+      # Define redirect middleware for any requests to /v1/rss-bridge -> /v1/rss-bridge/ (trailing slash)
+      - 'traefik.http.middlewares.rss_bridge_redirect.redirectregex.regex=(^.*\/rss-bridge$$)'
+      - 'traefik.http.middlewares.rss_bridge_redirect.redirectregex.replacement=$$1/'
+      - 'traefik.http.middlewares.rss_bridge_redirect.redirectregex.permanent=true'
+      # Define prefix stripping middleware for any requests to /v1/rss-bridge/*
+      - 'traefik.http.middlewares.rss_bridge_prefix.stripprefix.prefixes=/${API_VERSION}/rss-bridge'
+      # Add our middleware to the router
+      - 'traefik.http.routers.rss_bridge.middlewares=rss_bridge_redirect,rss_bridge_prefix'

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -187,6 +187,9 @@ services:
         soft: -1
         hard: -1
 
+    rss-bridge:
+      restart: unless-stopped
+
   portainer:
     image: portainer/portainer-ce:alpine
     container_name: 'portainer'


### PR DESCRIPTION
## Issue This PR Addresses

#2728 This PR sets up the microservice that will provide the Twitch RSS feed

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds a 3rd party microservice, which generates RSS feeds of Twitch channels. This will be used further to close #2728.

## Steps to test the PR

* `pnpm run services:start` -> builds the service
* Go to `localhost:3123` -> a webpage of `rss-bridge` should appear
* Write a Twitch user name 
* Press the `Atom` button
* You should be able to download/preview the feed generated from the Twitch channel

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
