### PR TITLE
Set up back end to recollect information from pnpm

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,17 @@ importers:
       ts-jest: 27.1.2_ac3f9d4a26c88540c3f2823ef15b8533
       turbo: 1.0.28
 
+  src/api/dependency-discovery:
+    specifiers:
+      '@senecacdot/satellite': ^1.x
+      env-cmd: 10.1.0
+      nodemon: 2.0.15
+    dependencies:
+      '@senecacdot/satellite': 1.17.0
+    devDependencies:
+      env-cmd: 10.1.0
+      nodemon: 2.0.15
+
   src/api/feed-discovery:
     specifiers:
       '@senecacdot/satellite': ^1.x
@@ -13466,7 +13477,7 @@ packages:
     dependencies:
       debug: 4.3.3
       module-details-from-path: 1.0.3
-      resolve: 1.21.0
+      resolve: 1.22.0
     transitivePeerDependencies:
       - supports-color
     dev: false

--- a/src/api/dependency-discovery/env.local
+++ b/src/api/dependency-discovery/env.local
@@ -1,0 +1,6 @@
+# Environment variables needed if you want to run `npm run dev`
+# and run the server locally, outside of Docker. For all the various
+# ways we run this using Docker, the env is defined by one of the
+# config/env.* files in the root.  This requires that the other
+# services are running, particularly the login and users services.
+DEP_DISCOVERY_PORT=10500

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dependency-discovery",
+  "private": true,
+  "version": "0.1.0",
+  "description": "A dependency graph compilation service for Telescope",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/server.js",
+    "dev": "env-cmd -f env.local nodemon src/server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Seneca-CDOT/telescope.git"
+  },
+  "author": "",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/Seneca-CDOT/telescope/issues"
+  },
+  "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
+  "dependencies": {
+    "@senecacdot/satellite": "^1.x"
+  },
+  "devDependencies": {
+    "env-cmd": "10.1.0",
+    "nodemon": "2.0.15"
+  }
+}

--- a/src/api/dependency-discovery/src/dependency-list.js
+++ b/src/api/dependency-discovery/src/dependency-list.js
@@ -1,0 +1,14 @@
+const { readFile } = require('fs/promises');
+const { join } = require('path');
+const { cwd } = require('process');
+
+async function getDependencies() {
+  const dependencies = await readFile(join(cwd(), 'deps.txt'), 'utf8');
+
+  // The order of the alternatives is important!
+  // The regex engine will favor the first pattern on an alternation
+  // even if the other alternatives are subpatterns
+  return dependencies.split(/\r\n|\n|\r/).filter((line) => line !== '');
+}
+
+module.exports = getDependencies();

--- a/src/api/dependency-discovery/src/index.js
+++ b/src/api/dependency-discovery/src/index.js
@@ -1,0 +1,9 @@
+const { Satellite } = require('@senecacdot/satellite');
+
+const dependenciesRoute = require('./router');
+
+const service = new Satellite();
+
+service.router.use('/', dependenciesRoute);
+
+module.exports = service;

--- a/src/api/dependency-discovery/src/router.js
+++ b/src/api/dependency-discovery/src/router.js
@@ -1,0 +1,15 @@
+const { Router } = require('@senecacdot/satellite');
+const dependencyList = require('./dependency-list');
+
+const router = Router();
+
+router.get('/projects', async (req, res, next) => {
+  try {
+    res.set('Cache-Control', 'max-age=3600');
+    res.status(200).json(await dependencyList);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/src/api/dependency-discovery/src/server.js
+++ b/src/api/dependency-discovery/src/server.js
@@ -1,0 +1,5 @@
+const service = require('.');
+
+const port = parseInt(process.env.DEP_DISCOVERY_PORT || 10500, 10);
+
+service.start(port);

--- a/tools/pnpm-deps-gen.sh
+++ b/tools/pnpm-deps-gen.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# First regex can be read as the following:
+# .*\.pnpm\/(@?[^@]+).*
+# We use the literal .pnpm to find the start of the package name
+# After that, we use the pattern "@?[^@]+" to search for the name
+# that appears first, instead of ".+".
+#
+# Sometimes we could have foo@1.0.0_bar@1.0.0, in which case we want
+# to capture foo. With ".+", we could capture foo@1.0.0_bar.
+# Instead, we search for the string of characters that do not include
+# "@", which translates to "[^@]+". However, some package names include
+# @ at the start, so we cover that case, as well.
+
+set -e
+
+option=$1
+filename=$2
+
+if [[ $# -eq 2 && $option = "-o" && $filename ]]; then
+  echo "Start collecting dependencies"
+  pnpm list -w -r --parseable --depth=0 | sed -n -r -e "s|.*\.pnpm/(@?[^@]+).*|\1|p" -e "s/+/\//" | sort -u > $filename
+  echo "Dependencies collected"
+else
+  echo "command usage: $BASH_SOURCE -o filename"
+fi


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #2738 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The service offers a single route: `/projects`, where it returns a list of all project names that Telescope depends on. The service uses a text file to load this information. The file is named `deps.txt`. The one I have copied there is for testing purposes, so that you don't have to run the tool if you can't.

The tool that generates this file is a one-line `bash` script, which calls `pnpm list` and does some stream processing to reduce the information needed.  The tool can be found in the `tools` folder. Since this is a `bash` script, Windows users cannot test it. A PowerShell script may be necessary.

## Steps to test the PR

As of right now, this service is not integrated completely with Docker. To start it up, you have to do the following:

1. `pnpm install` to get all dependencies
2. Navigate to the `src/api/dependency-graph` folder
3. `pnpm start` to start up the application

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
