### PR TITLE
Fix routing in Traefik for status server, remove hacks in express

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - SECRET
     depends_on:
       - traefik
+      - redis
     labels:
       # Enable Traefik
       - 'traefik.enable=true'
@@ -33,10 +34,14 @@ services:
       - 'traefik.http.routers.status.rule=PathPrefix(`/${API_VERSION}/status`)'
       # Specify the status service port
       - 'traefik.http.services.status.loadbalancer.server.port=${STATUS_PORT}'
+      # Define redirect middleware for any requests to /v1/status -> /v1/status/ (trailing slash)
+      - 'traefik.http.middlewares.status_redirect.redirectregex.regex=(^.*\/status$$)'
+      - 'traefik.http.middlewares.status_redirect.redirectregex.replacement=$$1/'
+      - 'traefik.http.middlewares.status_redirect.redirectregex.permanent=true'
       # Add middleware to this route to strip the /v1/status prefix
       - 'traefik.http.middlewares.strip_status_prefix.stripprefix.prefixes=/${API_VERSION}/status'
       - 'traefik.http.middlewares.strip_status_prefix.stripprefix.forceSlash=true'
-      - 'traefik.http.routers.status.middlewares=strip_status_prefix'
+      - 'traefik.http.routers.status.middlewares=status_redirect,strip_status_prefix'
 
   # image service
   image:

--- a/src/api/status/env.local
+++ b/src/api/status/env.local
@@ -1,5 +1,4 @@
 PLANET_PORT=1111
-PATH_PREFIX=/v1/status
 WEB_URL=http://localhost
 POSTS_URL=http://localhost/v1/posts
 MOCK_REDIS=1

--- a/src/api/status/src/views/partials/header.hbs
+++ b/src/api/status/src/views/partials/header.hbs
@@ -1,6 +1,5 @@
 <head>
   <meta charset="utf-8" />
-  <base href="/v1/status/" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <link rel="apple-touch-icon" sizes="76x76" href="assets/img/apple-icon.png" />
   <link rel="icon" type="image/svg+xml" href="./logo.svg" />


### PR DESCRIPTION
Fixes #2804 

We've added a bunch of terrible hacks to deal with the static asset routing on the status service, where you needed to prefix things with `/v1/status` in the frontend and backend.

A better solution is to add a redirect to the Traefik router, to serve the page from `/v1/status/` (trailing slash) which allows all the relative links to resolve properly.

With this, I can remove all the hacks.

We can land this in 2.7 if it's not doable in 2.6, it's not critical.