### PR TITLE
Use buildx in docker-compose

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -6,6 +6,11 @@
 
 COMPOSE_PROJECT_NAME=telescope_api
 
+# Use buildx in docker-compose, see https://docs.docker.com/buildx/working-with-buildx
+# With buildx, you get a more efficient build, better caching, and more.
+COMPOSE_DOCKER_CLI_BUILD=1
+DOCKER_BUILDKIT=1
+
 # Compose files to use together during development. NOTE: we specify separator below
 # so it will work on Windows and Unix, see
 # https://docs.docker.com/compose/reference/envvars/#compose_file

--- a/config/env.production
+++ b/config/env.production
@@ -6,6 +6,11 @@
 
 COMPOSE_PROJECT_NAME=telescope_api
 
+# Use buildx in docker-compose, see https://docs.docker.com/buildx/working-with-buildx
+# With buildx, you get a more efficient build, better caching, and more.
+COMPOSE_DOCKER_CLI_BUILD=1
+DOCKER_BUILDKIT=1
+
 # Compose files to use together on production. NOTE: we specify separator below
 # so it will work on Windows and Unix, see
 # https://docs.docker.com/compose/reference/envvars/#compose_file

--- a/config/env.staging
+++ b/config/env.staging
@@ -6,6 +6,11 @@
 
 COMPOSE_PROJECT_NAME=telescope_api
 
+# Use buildx in docker-compose, see https://docs.docker.com/buildx/working-with-buildx
+# With buildx, you get a more efficient build, better caching, and more.
+COMPOSE_DOCKER_CLI_BUILD=1
+DOCKER_BUILDKIT=1
+
 # Compose files to use together on production. NOTE: we specify separator below
 # so it will work on Windows and Unix, see
 # https://docs.docker.com/compose/reference/envvars/#compose_file


### PR DESCRIPTION
This forces docker to prefer [`buildx`](https://docs.docker.com/buildx/working-with-buildx/) when building with `docker-compose`. I've only tested on macOS.

Not critical for 2.6.