### PR TITLE
Fix docker/production.yml so it validates

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -187,8 +187,8 @@ services:
         soft: -1
         hard: -1
 
-    rss-bridge:
-      restart: unless-stopped
+  rss-bridge:
+    restart: unless-stopped
 
   portainer:
     image: portainer/portainer-ce:alpine


### PR DESCRIPTION
I had this indented 1 tab stop too far, so it was being interpreted as part of the elasticsearch service definition.