### PR TITLE
Don't specify tini version, which breaks on some setups

### DIFF
--- a/src/api/sso/Dockerfile
+++ b/src/api/sso/Dockerfile
@@ -35,7 +35,7 @@ RUN npm install --production
 # Use a smaller node image (-alpine) at runtime
 FROM node:lts-alpine as deploy
 # https://github.com/krallin/tini
-RUN apk --no-cache add tini=0.19.0-r0
+RUN apk --no-cache add tini
 WORKDIR /home/node/app
 # Copy what we've installed/built from production
 COPY --chown=node:node --from=production /home/node/app/node_modules /home/node/app/node_modules/


### PR DESCRIPTION
We're breaking the build on production with the version of `tini` not being found.  @HyperTHD had the same issue on Windows, but it doesn't happen on CI or my local machine.

I've removed the version number, so it should use whatever version is available.