### PR TITLE
Resize terminal depending on window height

### DIFF
--- a/src/api/status/public/js/build-log/terminal.js
+++ b/src/api/status/public/js/build-log/terminal.js
@@ -66,4 +66,8 @@ const copyToClipboard = async () => {
 };
 copyToClipboardButton.addEventListener('click', () => copyToClipboard());
 
+window.addEventListener('resize', () => {
+  fitAddon.fit();
+});
+
 export default terminal;

--- a/src/api/status/src/views/builds.hbs
+++ b/src/api/status/src/views/builds.hbs
@@ -1,6 +1,6 @@
 {{> sidebar}}
 
-<main class="main-content position-relative max-height-vh-100 h-100 border-radius-lg display:flex; flex-direction:column">
+<main class="main-content position-relative max-height-vh-100 h-100 border-radius-lg d-flex flex-column align-items-stretch">
   <!-- Navbar -->
   <nav class="navbar navbar-main navbar-expand-lg px-0 shadow-none border-radius-xl" id="navbarBlur"
     navbar-scroll="true">
@@ -31,7 +31,7 @@
       </nav>
     </div>
   </nav>
-  <div style="width: 100%; max-height: 100%; ">
+  <div class="d-flex flex-column flex-fill" style="width: 100%; min-height: 0;">
     <div id="build-header" class="card bg-white">
      <div class="card-body">
         <h6 id="build-header-title" class="mb-0 text-lg text-center">
@@ -73,9 +73,9 @@
         </div>
      </div>
     </div>
-    <div class="position-relative">
+    <div class="position-relative d-flex flex-fill" style="min-height: 0">
     <button id="copy-to-clipboard-button" class="btn btn-dark">Copy<i class="material-icons">content_copy</i></button>
-    <div id="terminal"></div>
+    <div id="terminal" class="flex-fill h-100"></div>
     </div>
   </div>
 </main>

--- a/src/api/status/src/views/layouts/main.hbs
+++ b/src/api/status/src/views/layouts/main.hbs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   {{> header }}
-<body class="g-sidenav-show bg-gray-200">
+<body class="g-sidenav-show bg-gray-200 vh-100">
     {{> _toast}}
     {{{body}}}
 </body>


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #2842

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

We resize the height of the terminal for the build log in the dashboard by resizing it with the API offered by `xterm.js`.

## Steps to test the PR

1. Get the changes from the branch
2. Install dependencies (`pnpm install`)
3. Run the dashboard (`cd src/api/status && pnpm dev`)

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally.
- [ ] **Tests**: This PR does not include tests because it does not add a new feature.
- [X] **Screenshots**: This PR includes screenshots ![image](https://user-images.githubusercontent.com/53304516/152673735-817cd3dd-c55e-4701-9ee3-3f2dddcc2774.png)
- [ ] **Documentation**: This PR does not include documentation because no user-exposed functionality was added/changed.
