### PR TITLE
Update .npmrc to not add ^ to package versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,6 @@ unsafe-perm=true
 # Set empty tag version prefix
 tag-version-prefix=""
 
+# Don't use ^ when adding packages, prefix with nothing, see:
+# https://pnpm.io/npmrc#save-prefix
+save-prefix=""


### PR DESCRIPTION
During reviews, I often need to ask people to pin their dependencies.  Instead of using `^1.2.3` we want `1.2.3`.  This [updates our `.npmrc` to set a `save-prefix` of nothing](https://pnpm.io/npmrc#save-prefix).