### PR TITLE
Add unit tests for /advanced query routers

### DIFF
--- a/src/api/search/test/query.test.js
+++ b/src/api/search/test/query.test.js
@@ -1,9 +1,405 @@
 const request = require('supertest');
+const { Elastic, createError } = require('@senecacdot/satellite');
 const { app } = require('../src');
+
+const { POSTS_URL } = process.env;
 
 describe('/query routers', () => {
   it('return error 400 if no params given', async () => {
     const res = await request(app).get('/');
     expect(res.status).toBe(400);
+  });
+});
+
+describe('/advanced query routers', () => {
+  describe('Test queries that do not pass validation', () => {
+    it('Return error 400 if missing all 3 of "post", "author", and "title" param', async () => {
+      let res = await request(app).get('/advanced');
+      expect(res.status).toBe(400);
+
+      res = await request(app).get('/advanced').query({ to: '2020-04-05' });
+      expect(res.status).toBe(400);
+
+      res = await request(app).get('/advanced').query({ from: '2020-04-05' });
+      expect(res.status).toBe(400);
+
+      res = await request(app).get('/advanced').query({ perPage: 1 });
+      expect(res.status).toBe(400);
+
+      res = await request(app).get('/advanced').query({ page: 0 });
+      expect(res.status).toBe(400);
+
+      res = await request(app).get('/advanced').query({ someParam: 'someParam' });
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            { msg: 'author should exist', param: 'author', location: 'body' },
+            { msg: 'title should exist', param: 'title', location: 'body' },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "post" param is empty', async () => {
+      const res = await request(app).get('/advanced').query({ post: '' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { value: '', msg: 'post should not be empty', param: 'post', location: 'query' },
+            { msg: 'author should exist', param: 'author', location: 'body' },
+            { msg: 'title should exist', param: 'title', location: 'body' },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "post" param has a length greater than 256', async () => {
+      const longString = 'a'.repeat(257);
+      const res = await request(app).get('/advanced').query({ post: longString });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            {
+              value: `${longString}`,
+              msg: 'post should be between 1 to 256 characters',
+              param: 'post',
+              location: 'query',
+            },
+            { msg: 'author should exist', param: 'author', location: 'body' },
+            { msg: 'title should exist', param: 'title', location: 'body' },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "author" param is empty', async () => {
+      const res = await request(app).get('/advanced').query({ author: '' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            { value: '', msg: 'author should exist', param: 'author', location: 'query' },
+            { msg: 'title should exist', param: 'title', location: 'body' },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "author" param does not have a length between 2 and 256', async () => {
+      const longString = 'a'.repeat(257);
+      let res = await request(app).get('/advanced').query({ author: 'a' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            { value: 'a', msg: 'invalid author value', param: 'author', location: 'query' },
+            { msg: 'title should exist', param: 'title', location: 'body' },
+          ],
+        },
+      ]);
+
+      res = await request(app).get('/advanced').query({ author: longString });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            {
+              value: `${longString}`,
+              msg: 'invalid author value',
+              param: 'author',
+              location: 'query',
+            },
+            { msg: 'title should exist', param: 'title', location: 'body' },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "title" param is empty', async () => {
+      const res = await request(app).get('/advanced').query({ title: '' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            { msg: 'author should exist', param: 'author', location: 'body' },
+            { value: '', msg: 'title should exist', param: 'title', location: 'query' },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "title" param does not have a length between 2 and 256', async () => {
+      const longString = 'a'.repeat(257);
+      let res = await request(app).get('/advanced').query({ title: 'a' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            { msg: 'author should exist', param: 'author', location: 'body' },
+            { value: 'a', msg: 'invalid title value', param: 'title', location: 'query' },
+          ],
+        },
+      ]);
+
+      res = await request(app).get('/advanced').query({ title: longString });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          msg: 'Invalid value(s)',
+          param: '_error',
+          nestedErrors: [
+            { msg: 'post should not be empty', param: 'post', location: 'body' },
+            { msg: 'author should exist', param: 'author', location: 'body' },
+            {
+              value: `${longString}`,
+              msg: 'invalid title value',
+              param: 'title',
+              location: 'query',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('Return error 400 if "to" param has an invalid date format', async () => {
+      let res = await request(app)
+        .get('/advanced')
+        .query({ post: 'ElasticSearch', to: 'invalid date format' });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toStrictEqual('invalid date format');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', to: '06/04/2020' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          value: '06/04/2020',
+          msg: 'invalid date format',
+          param: 'to',
+          location: 'query',
+        },
+      ]);
+    });
+
+    it('Return error 400 if "from" param has an invalid date format', async () => {
+      let res = await request(app)
+        .get('/advanced')
+        .query({ post: 'ElasticSearch', from: 'foo-bar 2020' });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toStrictEqual('foo-bar 2020');
+
+      res = await request(app)
+        .get('/advanced')
+        .query({ post: 'ElasticSearch', from: '2020-25-23' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          value: '2020-25-23',
+          msg: 'invalid date format',
+          param: 'from',
+          location: 'query',
+        },
+      ]);
+    });
+
+    it('Return error 400 if "perPage" param is not an integer between 1 to 10', async () => {
+      let res = await request(app).get('/advanced').query({ post: 'ElasticSearch', perPage: 11 });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toBe('11');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', perPage: 0 });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toBe('0');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', perPage: 1.5 });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toBe('1.5');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', perPage: 'one' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          value: 'one',
+          msg: 'perPage should be empty or a number between 1 to 10',
+          param: 'perPage',
+          location: 'query',
+        },
+      ]);
+    });
+
+    it('Return error 400 if "page" param is not an integer between 0 to 999', async () => {
+      let res = await request(app).get('/advanced').query({ post: 'ElasticSearch', page: 1000 });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toBe('1000');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', page: -1 });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toBe('-1');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', page: 55.5 });
+      expect(res.status).toBe(400);
+      expect(res.body[0].value).toBe('55.5');
+
+      res = await request(app).get('/advanced').query({ post: 'ElasticSearch', page: 'five' });
+      expect(res.status).toBe(400);
+      expect(res.body).toStrictEqual([
+        {
+          value: 'five',
+          msg: 'page should be empty or a number between 0 to 999',
+          param: 'page',
+          location: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('Test queries that pass validation', () => {
+    // All Satellite Elastic clients will share this mock
+    // For more information please read the documentation at https://github.com/Seneca-CDOT/satellite#elastic
+    const { mock } = Elastic();
+
+    afterEach(() => {
+      mock.clearAll();
+    });
+
+    describe('Return status 200 if params pass validation checks', () => {
+      const mockResults = {
+        hits: {
+          total: { value: 0 },
+          hits: [],
+        },
+      };
+
+      beforeEach(() => {
+        mock.add(
+          {
+            method: ['POST', 'GET'],
+            path: '/posts/post/_search',
+          },
+          () => {
+            return mockResults;
+          }
+        );
+      });
+
+      it(`Invalid "post" with valid "author" or "title" param should pass validation`, async () => {
+        let res = await request(app).get('/advanced').query({ post: '', author: 'Roxanne' });
+        expect(res.status).toBe(200);
+
+        res = await request(app).get('/advanced').query({ post: '', title: 'OSD' });
+        expect(res.status).toBe(200);
+
+        res = await request(app)
+          .get('/advanced')
+          .query({ post: '', author: 'Roxanne', title: 'OSD' });
+        expect(res.status).toBe(200);
+        expect(res.body).toStrictEqual({ results: 0, values: [] });
+      });
+
+      it(`Invalid "author" with valid "post" or "title" param should pass validation`, async () => {
+        let res = await request(app).get('/advanced').query({ author: '', post: 'ElasticSearch' });
+        expect(res.status).toBe(200);
+
+        res = await request(app).get('/advanced').query({ author: '', title: 'OSD' });
+        expect(res.status).toBe(200);
+
+        res = await request(app)
+          .get('/advanced')
+          .query({ author: '', post: 'ElasticSearch', title: 'OSD' });
+        expect(res.status).toBe(200);
+        expect(res.body).toStrictEqual({ results: 0, values: [] });
+      });
+
+      it(`Invalid "title" with valid "author" or "post" param should pass validation`, async () => {
+        let res = await request(app).get('/advanced').query({ title: '', post: 'ElasticSearch' });
+        expect(res.status).toBe(200);
+
+        res = await request(app).get('/advanced').query({ title: '', author: 'Roxanne' });
+        expect(res.status).toBe(200);
+
+        res = await request(app)
+          .get('/advanced')
+          .query({ title: '', post: 'ElasticSearch', author: 'Roxanne' });
+        expect(res.status).toBe(200);
+        expect(res.body).toStrictEqual({ results: 0, values: [] });
+      });
+    });
+
+    it('Search results of more than 0 return "id" and "url" of posts', async () => {
+      const mockResults = {
+        hits: {
+          total: { value: 2 },
+          hits: [{ _id: '1111' }, { _id: '2222' }],
+        },
+      };
+
+      mock.add(
+        {
+          method: ['POST', 'GET'],
+          path: '/posts/post/_search',
+        },
+        () => {
+          return mockResults;
+        }
+      );
+
+      const res = await request(app).get('/advanced').query({
+        post: 'ElasticSearch',
+        author: 'Roxanne',
+        title: 'OSD',
+        from: '2020-04-06',
+        to: '2019-06-02',
+        perPage: '2',
+        page: '1',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.results).toBe(2);
+      expect(res.body.values).toStrictEqual([
+        { id: '1111', url: `${POSTS_URL}/1111` },
+        { id: '2222', url: `${POSTS_URL}/2222` },
+      ]);
+    });
+
+    it('Return error 503 if "hits" returned from ElasticSearch is undefined', async () => {
+      const mockResults = createError(404, 'Page Not Found');
+
+      mock.add(
+        {
+          method: ['POST', 'GET'],
+          path: '/posts/post/_search',
+        },
+        () => {
+          return mockResults;
+        }
+      );
+
+      const res = await request(app).get('/advanced').query({ post: 'ElasticSearch' });
+
+      expect(res.status).toBe(503);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Part of #2621 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **New Tests**:  Unit tests for the advanced search query


## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Needed so we could progress in advanced search

## Steps to test the PR
- `pnpm test search`
- Currently the `LOG_LEVEL` is set to default `debug` in  [config/env.development](https://github.com/Seneca-CDOT/telescope/blob/a48182b5f2541290e6b264c401fb1231ad2cd38c/config/env.development#L207). Can also consider adding `LOG_LEVEL` to `error` or `silent` to the `jest.setup.js` file in the Search microservice locally for a test experience with less logs.

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: Coverage
![image](https://user-images.githubusercontent.com/32626950/153681129-2cdd871b-fa33-4e3f-89b7-208983ef2357.png)

- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

## Discussions
- running `pnpm install` did not get me the new Satellite version needed for mocking ElasticSearch. I ran `pnpm update @senecacdot/satellite` in the Search directory. It changed some of the lines in `package.json` in Search and `pnpm-lock.yaml` in root. I'm not sure for the lines that changed from `'@senecacdot/satellite': ^1.x` to `'@senecacdot/satellite': ^1.24.0`, if I'm allowed to manually change them back to `^1.x` or if there's a command to do so. 

- For the last unit test of trying to hit the 503 error. I've only been able to hit it when these [lines in search.js](https://github.com/Seneca-CDOT/telescope/blob/bd2f4b0825cab81eb807cef268c7e6bfe10dcd39/src/api/search/src/search.js#L167-L168) try to read an object that doesn't exist.
```js
return {
    results: hits.total.value,
    values: hits.hits.map(({ _id }) => ({ id: _id, url: `${POSTS_URL}/${_id}` })),
  };
```
I tried to follow the [documentation](https://github.com/elastic/elasticsearch-js-mock#errors) of using errors from ElasticSearch. However, the unit test process will only get stuck. It seems perhaps we're missing methods of dealing with errors from ElasticSearch in `search.js`. Based on these [tests](https://github.com/elastic/elasticsearch-js-mock/blob/2c6c35dd135a2f124b52513f9b0e1b047de34bd4/test.js#L311-L335), We might need a Try-catch statement for `client.search()` to handle errors in `search.js`. I'm unsure if changing code in `search.js` is a part of this PR.
