### PR TITLE
Fix link to Environment Setup documentation

### DIFF
--- a/src/docs/docs/contributing/CONTRIBUTING.md
+++ b/src/docs/docs/contributing/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Before creating an issue:
 
 Telescope has many parts, and setup requires you to install a number of tools
 and dependencies. For instructions on how to setup your Telescope environment, please see
-the [Environment Setup documentation](https://github.com/Seneca-CDOT/telescope/blob/master/src/docs/docs/getting-started/environment-setup.md). For a discussion of Telescope's design, see our [Architecture](architecture.md) documentation.
+the [Environment Setup documentation](../getting-started/environment-setup.md). For a discussion of Telescope's design, see our [Architecture](architecture.md) documentation.
 
 ## Browser-based Setup using Gitpod
 

--- a/src/docs/docs/contributing/CONTRIBUTING.md
+++ b/src/docs/docs/contributing/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Before creating an issue:
 
 Telescope has many parts, and setup requires you to install a number of tools
 and dependencies. For instructions on how to setup your Telescope environment, please see
-the [Environment Setup documentation](https://github.com/Seneca-CDOT/telescope/blob/master/docs/environment-setup.md). For a discussion of Telescope's design, see our [Architecture](architecture.md) documentation.
+the [Environment Setup documentation](https://github.com/Seneca-CDOT/telescope/blob/master/src/docs/docs/getting-started/environment-setup.md). For a discussion of Telescope's design, see our [Architecture](architecture.md) documentation.
 
 ## Browser-based Setup using Gitpod
 


### PR DESCRIPTION
Noticed that `Environment Setup documentation` link was pointing to a markdown file that no longer exists.

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
