### PR TITLE
Dockerize dependency-discovery

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -167,6 +167,15 @@ PARSER_URL=http://localhost/v1/parser
 # Planet Service Port (default is 9876)
 PLANET_PORT=9876
 
+################################################################################
+# Dependency Discovery Service
+################################################################################
+
+# Dependency Discovery Service Port (default is 10500)
+DEPENDENCY_DISCOVERY_PORT=10500
+
+# Dependency Discovery Service URL
+DEPENDENCY_DISCOVERY_URL=http://localhost/v1/dependency-discovery
 
 ################################################################################
 # Telescope 1.0 Legacy Environment

--- a/config/env.production
+++ b/config/env.production
@@ -169,6 +169,15 @@ PARSER_URL=https://api.telescope.cdot.systems/v1/parser
 # Planet Service Port (default is 9876)
 PLANET_PORT=9876
 
+################################################################################
+# Dependency Discovery Service
+################################################################################
+
+# Dependency Discovery Service Port (default is 10500)
+DEPENDENCY_DISCOVERY_PORT=10500
+
+# Dependency Discovery Service URL
+DEPENDENCY_DISCOVERY_URL=https://api.telescope.cdot.systems/v1/dependency-discovery
 
 ################################################################################
 # Telescope 1.0 Legacy Environment

--- a/config/env.staging
+++ b/config/env.staging
@@ -171,6 +171,15 @@ PARSER_URL=https://dev.api.telescope.cdot.systems/v1/parser
 # Planet Service Port (default is 9876)
 PLANET_PORT=9876
 
+################################################################################
+# Dependency Discovery Service
+################################################################################
+
+# Dependency Discovery Service Port (default is 10500)
+DEPENDENCY_DISCOVERY_PORT=10500
+
+# Dependency Discovery Service URL
+DEPENDENCY_DISCOVERY_URL=https://dev.api.telescope.cdot.systems/v1/dependency-discovery
 
 ################################################################################
 # Telescope 1.0 Legacy Environment

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -268,6 +268,28 @@ services:
       - PLANET_PORT
       - POSTS_URL
 
+  dependency-discovery:
+    container_name: 'dependency-discovery'
+    build:
+      context: ../src/api/dependency-discovery
+      dockerfile: Dockerfile
+    environment:
+      - NODE_ENV
+      - DEPENDENCY_DISCOVERY_PORT
+    depends_on:
+      - traefik
+    labels:
+      # Enable Traefik
+      - 'traefik.enable=true'
+      # Traefik routing for the dependency-discovery service at /v1/dependency-discovery
+      - 'traefik.http.routers.dependency-discovery.rule=PathPrefix(`/${API_VERSION}/dependency-discovery`)'
+      # Specify the dependency-discovery service port
+      - 'traefik.http.services.dependency-discovery.loadbalancer.server.port=${DEPENDENCY_DISCOVERY_PORT}'
+      # Add middleware to this route to strip the /v1/dependency-discovery prefix
+      - 'traefik.http.middlewares.strip_dependency_prefix.stripprefix.prefixes=/${API_VERSION}/dependency-discovery'
+      - 'traefik.http.middlewares.strip_dependency_prefix.stripprefix.forceSlash=true'
+      - 'traefik.http.routers.dependency-discovery.middlewares=strip_dependency_prefix'
+
   ##############################################################################
   # Third-Party Dependencies and Support Services
   ##############################################################################

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -122,6 +122,9 @@ services:
       - ELASTIC_URL=http://elasticsearch
       - ELASTIC_PORT=9200
 
+  dependency-discovery:
+    restart: unless-stopped
+
   ##############################################################################
   # Third-Party Dependencies and Support Services
   ##############################################################################

--- a/src/api/dependency-discovery/.dockerignore
+++ b/src/api/dependency-discovery/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore

--- a/src/api/dependency-discovery/Dockerfile
+++ b/src/api/dependency-discovery/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine as base
+
+RUN apk add dumb-init
+
+WORKDIR /app
+
+COPY --chown=node:node . .
+
+RUN npm install --only=production --no-package-lock
+
+USER node
+
+CMD ["dumb-init", "node", "src/server.js"]

--- a/src/api/dependency-discovery/README.md
+++ b/src/api/dependency-discovery/README.md
@@ -28,7 +28,17 @@ By default, the server is listening on port 10500 (http://localhost:10500).
 
 ### Docker
 
-TODO
+To run the service with only the container, you may use the following command:
+
+```bash
+docker run -p 10500:10500 telescope_dependency_discovery_svc:latest
+```
+
+You would have to build the container prior:
+
+```bash
+docker build . -t telescope_dependency_discovery_svc:latest
+```
 
 ### `docker-compose`
 

--- a/src/api/dependency-discovery/env.local
+++ b/src/api/dependency-discovery/env.local
@@ -3,4 +3,4 @@
 # ways we run this using Docker, the env is defined by one of the
 # config/env.* files in the root.  This requires that the other
 # services are running, particularly the login and users services.
-DEP_DISCOVERY_PORT=10500
+DEPENDENCY_DISCOVERY_PORT=10500

--- a/src/api/dependency-discovery/src/server.js
+++ b/src/api/dependency-discovery/src/server.js
@@ -1,5 +1,5 @@
 const service = require('.');
 
-const port = parseInt(process.env.DEP_DISCOVERY_PORT || 10500, 10);
+const port = parseInt(process.env.DEPENDENCY_DISCOVERY_PORT || 10500, 10);
 
 service.start(port);


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #2830 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR addresses the dockerization of the most recent added service, `dependency-discovery`. It also adds the necessary code to start it via `docker-compose`.

## Steps to test the PR

1. Pull my changes
2. You may start `dependency-discovery` by doing the following steps:
2.1. If you only want the service itself:
2.1.1. `cd src/api/dependency-discovery`
2.1.2. `docker build . -t telescope_dependency_discovery_svc:latest`
2.1.3. `docker run -p 10500:10500 telescope_dependency_discovery_svc:latest`
2.2. If you want to start it via `docker-compose`:
2.2.1. `pnpm run services:start` or `pnpm run services:start dependency-discovery`

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR does not include screenshots.
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
