### PR TITLE
Add rss-bridge and dependency-discovery statuses

### DIFF
--- a/src/api/status/src/services.js
+++ b/src/api/status/src/services.js
@@ -49,6 +49,16 @@ const services = [
     staging: 'https://dev.telescope.cdot.systems/deploy/healthcheck',
     production: 'https://telescope.cdot.systems/deploy/healthcheck',
   },
+  {
+    name: 'dependency-discovery',
+    staging: stagingUrl('/dependency-discovery/healthcheck'),
+    production: prodUrl('/dependency-discovery/healthcheck'),
+  },
+  {
+    name: 'rss-bridge',
+    staging: stagingUrl('/rss-bridge'),
+    production: prodUrl('/rss-bridge'),
+  },
 ];
 
 async function checkService(service) {


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #2935 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

As per #2829, we will add status endpoints for two of the three new services we have added to Telescope. 

This somewhat depends on #2830 to be finished, but I suppose we can agree the endpoint to be `/dependency-discovery`. If we need to change it, we shall do so.

## Steps to test the PR

This one is difficult to test correctly, since it mostly depends on the either staging or production. The status dashboard does not access the status of the microservices started locally.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
