### PR TITLE
[Fix] Use correct base url for planet link

### DIFF
--- a/src/web/src/components/Banner.tsx
+++ b/src/web/src/components/Banner.tsx
@@ -3,7 +3,7 @@ import { BsInfoCircle } from 'react-icons/bs';
 import { makeStyles, Theme, createStyles, Typography, Fab } from '@material-ui/core';
 import smoothscroll from 'smoothscroll-polyfill';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import { telescopeUrl, statusUrl } from '../config';
+import { telescopeUrl, webUrl, statusUrl } from '../config';
 import BannerDynamicItems from './BannerDynamicItems';
 import BannerButtons from './BannerButtons';
 import ScrollAction from './ScrollAction';
@@ -213,11 +213,7 @@ export default function Banner({ onVisibilityChange }: BannerProps) {
           </Fab>
         </ScrollAction>
         <div className={classes.planet}>
-          <a
-            href={`${telescopeUrl}/planet`}
-            title="telescope planet"
-            className={classes.planetAnchor}
-          >
+          <a href={`${webUrl}/planet`} title="telescope planet" className={classes.planetAnchor}>
             Planet
           </a>
         </div>


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Currently, the link to `planet` in our `Banner` component when telescope is deployed locally points to `localhost:3000/planet`, and it should be `localhost:8000/planet`.
This PR changes to base url used in the link. 

## Steps to test the PR

- Check out the branch used in this PR
- Install dependencies `pnpm i`

### Local deployment
- Copy `config/env.development` to `.env`
- Run `pnpm dev`
- Go to `localhost:8000`
- Make sure he `planet` link points to `localhost:8000/planet`

### Staging / Production
- Copy `config/env.staging` to `.env`
- Run `pnpm dev`
- Go to `localhost:8000`
- Make sure the `planet` link points to `dev.telescope.cdot.systems/planet`

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
