### PR TITLE
Move Portainer behind Traefik instead of nginx

### DIFF
--- a/config/env.production
+++ b/config/env.production
@@ -25,6 +25,9 @@ TELESCOPE_HOST=telescope.cdot.systems
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=api.telescope.cdot.systems
 
+# The host where portainer runs (e.g., https://portainer.telescope.cdot.systems)
+PORTAINER_HOST=portainer.telescope.cdot.systems
+
 # Front-end web URL (entry point to the next.js app). Make sure that the
 # ALLOWED_APP_ORIGINS variable below includes this URL, so that the Auth
 # service will allow redirects back to this origin.

--- a/config/env.staging
+++ b/config/env.staging
@@ -25,6 +25,9 @@ TELESCOPE_HOST=dev.telescope.cdot.systems
 # NOTE: if you change this, change all other occurrences below too.
 API_HOST=dev.api.telescope.cdot.systems
 
+# The host where portainer runs (e.g., https://dev.portainer.telescope.cdot.systems)
+PORTAINER_HOST=dev.portainer.telescope.cdot.systems
+
 # Front-end web URL (entry point to the next.js app). Make sure that the
 # ALLOWED_APP_ORIGINS variable below includes this URL, so that the SSO Auth
 # service will allow redirects back to this origin.

--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -4,7 +4,7 @@
 # back-end services.
 #
 # NOTE: this is a template vs. final conf file, and meant to be used with Docker
-# in order to replace the TELESCOPE_HOST and API_HOST variables
+# in order to replace the TELESCOPE_HOST, API_HOST, and PORTAINER_HOST variables
 # with values from the env.  See the section "Using environment variables in
 # nginx configuration (new in 1.19)" in:
 #
@@ -149,10 +149,10 @@ http {
   # Verify chain of trust of OCSP response using Root CA and Intermediate certs
   ssl_trusted_certificate /etc/letsencrypt/live/${TELESCOPE_HOST}/chain.pem;
 
-  # Requests to the api.* domain should be proxied to Traefik
+  # Requests to the (api|portainer).* domain should be proxied to Traefik
   server {
     listen 443 ssl http2;
-    server_name ${API_HOST};
+    server_name ${API_HOST} ${PORTAINER_HOST};
 
     location / {
       proxy_set_header  Host            $host;
@@ -215,20 +215,6 @@ http {
       add_header X-Proxy-Cache $upstream_cache_status;
 
       proxy_pass http://planet:9876;
-    }
-
-    # Non-cached /portainer route
-    location /portainer/api/websocket/  {
-      proxy_cache_bypass 1;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
-      proxy_pass  http://portainer:9000/api/websocket;
-    }
-
-    location /portainer/ {
-      proxy_cache_bypass 1;
-      proxy_set_header Connection "";
-      proxy_pass http://portainer:9000/;
     }
 
     # Redirect traffic from /deploy/* to the autodeployment server

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the status service at /v1/status
-      - 'traefik.http.routers.status.rule=PathPrefix(`/${API_VERSION}/status`)'
+      - 'traefik.http.routers.status.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/status`)'
       # Specify the status service port
       - 'traefik.http.services.status.loadbalancer.server.port=${STATUS_PORT}'
       # Define redirect middleware for any requests to /v1/status -> /v1/status/ (trailing slash)
@@ -62,7 +62,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the image service at /v1/image
-      - 'traefik.http.routers.image.rule=PathPrefix(`/${API_VERSION}/image`)'
+      - 'traefik.http.routers.image.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/image`)'
       # Specify the image service port
       - 'traefik.http.services.image.loadbalancer.server.port=${IMAGE_PORT}'
       # Add middleware to this route to strip the /v1/image prefix
@@ -102,7 +102,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the auth service at /v1/auth
-      - 'traefik.http.routers.auth.rule=PathPrefix(`/${API_VERSION}/auth`)'
+      - 'traefik.http.routers.auth.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/auth`)'
       # Specify the auth service port
       - 'traefik.http.services.auth.loadbalancer.server.port=${SSO_PORT}'
       # Add middleware to this route to strip the /v1/auth prefix
@@ -134,7 +134,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the search service at /v1/search
-      - 'traefik.http.routers.search.rule=PathPrefix(`/${API_VERSION}/search`)'
+      - 'traefik.http.routers.search.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/search`)'
       # Specify the search service port
       - 'traefik.http.services.search.loadbalancer.server.port=${SEARCH_PORT}'
       # Add middleware to this route to strip the /v1/search prefix
@@ -163,7 +163,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the image service at /v1/image
-      - 'traefik.http.routers.posts.rule=PathPrefix(`/${API_VERSION}/posts`)'
+      - 'traefik.http.routers.posts.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/posts`)'
       # Specify the posts service port
       - 'traefik.http.services.posts.loadbalancer.server.port=${POSTS_PORT}'
       # Add middleware to this route to strip the /v1/posts prefix
@@ -190,7 +190,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the feed discovery service at /v1/image
-      - 'traefik.http.routers.feed-discovery.rule=PathPrefix(`/${API_VERSION}/feed-discovery`)'
+      - 'traefik.http.routers.feed-discovery.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/feed-discovery`)'
       # Specify the feed discovery service port
       - 'traefik.http.services.feed-discovery.loadbalancer.server.port=${FEED_DISCOVERY_PORT}'
       # Add middleware to this route to strip the /v1/feed-discovery prefix
@@ -218,7 +218,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the users service at /v1/users
-      - 'traefik.http.routers.users.rule=PathPrefix(`/${API_VERSION}/users`)'
+      - 'traefik.http.routers.users.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/users`)'
       # Specify the users service port
       - 'traefik.http.services.users.loadbalancer.server.port=${USERS_PORT}'
       # Add middleware to this route to strip the /v1/users prefix
@@ -249,7 +249,7 @@ services:
   #     # Enable Traefik
   #     - 'traefik.enable=true'
   #     # Traefik routing for the parser service at /v1/parser
-  #     - 'traefik.http.routers.parser.rule=PathPrefix(`/${API_VERSION}/parser`)'
+  #     - 'traefik.http.routers.parser.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/parser`)'
   #     # Specify the parser service port
   #     - 'traefik.http.services.parser.loadbalancer.server.port=${PARSER_PORT}'
   #     # Add middleware to this route to strip the /v1/parser prefix
@@ -294,6 +294,7 @@ services:
     environment:
       - TELESCOPE_HOST
       - API_HOST
+      - PORTAINER_HOST
     restart: unless-stopped
     depends_on:
       - traefik
@@ -341,7 +342,7 @@ services:
       # Enable Traefik
       - 'traefik.enable=true'
       # Traefik routing for the rss-bridge service at /v1/rss-bridge
-      - 'traefik.http.routers.rss_bridge.rule=PathPrefix(`/${API_VERSION}/rss-bridge`)'
+      - 'traefik.http.routers.rss_bridge.rule=HOST(`${API_HOST}`) && PathPrefix(`/${API_VERSION}/rss-bridge`)'
       # Specify the RSS-Bridge service port used internally
       - 'traefik.http.services.rss_bridge.loadbalancer.server.port=80'
       # Define redirect middleware for any requests to /v1/rss-bridge -> /v1/rss-bridge/ (trailing slash)

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -139,11 +139,11 @@ services:
     restart: unless-stopped
     depends_on:
       - telescope
-    # This makes nginx swap only the 2 specified environment variables in our template (see:
+    # This makes nginx swap only the specified environment variables in our template (see:
     # https://github.com/docker-library/docs/issues/496) and then reload this configuration
     # (and the associated certificates) every six hours in the background and launches nginx
     # in the foreground.
-    command: /bin/sh -c "envsubst '$$TELESCOPE_HOST $$API_HOST' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g 'daemon off;'"
+    command: /bin/sh -c "envsubst '$$TELESCOPE_HOST $$API_HOST $$PORTAINER_HOST' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g 'daemon off;'"
 
   # API Gateway running on 8888. We use nginx in front of this for secure/compressed/cached responses
   traefik:
@@ -201,6 +201,14 @@ services:
       - ../../portainer/portainer:/data/portainer
     depends_on:
       - nginx
+      - traefik
+    labels:
+      # Enable Traefik
+      - 'traefik.enable=true'
+      # Traefik routing for the portainer app portainer.*
+      - 'traefik.http.routers.portainer.rule=HOST(`${PORTAINER_HOST}`)'
+      # Specify the portainer service port used internally
+      - 'traefik.http.services.portainer.loadbalancer.server.port=80'
 
 volumes:
   rotate:


### PR DESCRIPTION
We are trying to figure out how to organize our various URLs and domains.  We have:

- Web app at `telescope.cdot.systems`
- API servers at `api.telescope.cdot.systems`

And we have a growing set of "admin" apps: web apps that our developers need to access, separate from our web/api.

Trying to mix the "admin" apps into the current nginx/traefik web+api structure is proving difficult.  We use a path-based routing system vs. an sub-domain routing system, and it's causing problems with web apps that assume they live at the `/` of the web server.

I want to move our admin apps to their own sub-domains: `<admin-app-name>.telescope.cdot.systems`.  I wanted to try this with Portainer first, since we already run it in staging/production, and should be able to test.

This change updates our [Traefik routers](https://doc.traefik.io/traefik/routing/routers/) to use the host as well as path prefix when making decisions about which container should handle a request.

I've also added a new environment variable for the `PORTAINER_HOST` name, which we will use in our nginx config to define another server name.

This can't be tested locally, beyond making sure that it doesn't break local development (it seems fine for me).  We probably need to run it on staging to see how it behaves. 