### PR TITLE
Changed from '^1.x' to 'latest' for Satellite dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,23 +173,23 @@ importers:
 
   src/api/dependency-discovery:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       env-cmd: 10.1.0
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
     devDependencies:
       env-cmd: 10.1.0
       nodemon: 2.0.15
 
   src/api/feed-discovery:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       cheerio: 1.0.0-rc.10
       got: 11.8.3
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       cheerio: 1.0.0-rc.10
       got: 11.8.3
     devDependencies:
@@ -197,14 +197,14 @@ importers:
 
   src/api/image:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       celebrate: 15.0.1
       del-cli: 4.0.1
       got: 11.8.3
       nodemon: 2.0.15
       sharp: 0.29.3
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       celebrate: 15.0.1
       got: 11.8.3
       sharp: 0.29.3
@@ -216,7 +216,7 @@ importers:
     specifiers:
       '@elastic/elasticsearch': 7.16.0
       '@elastic/elasticsearch-mock': 0.3.1
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       bull: 3.29.3
       bull-board: 2.1.3
       jsdom: 18.1.1
@@ -225,7 +225,7 @@ importers:
     dependencies:
       '@elastic/elasticsearch': 7.16.0
       '@elastic/elasticsearch-mock': 0.3.1
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       bull: 3.29.3
       bull-board: 2.1.3
       jsdom: 18.1.1
@@ -234,13 +234,13 @@ importers:
 
   src/api/planet:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       env-cmd: 10.1.0
       express: 4.17.2
       express-handlebars: 5.3.5
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       express: 4.17.2
       express-handlebars: 5.3.5
     devDependencies:
@@ -249,7 +249,7 @@ importers:
 
   src/api/posts:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       bull: 3.29.3
       express-validator: 6.14.0
       ioredis: 4.28.2
@@ -258,7 +258,7 @@ importers:
       normalize-url: 6.1.0
       supertest: 6.1.6
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       bull: 3.29.3
       express-validator: 6.14.0
       ioredis: 4.28.2
@@ -270,18 +270,18 @@ importers:
 
   src/api/search:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       express-validator: 6.14.0
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       express-validator: 6.14.0
     devDependencies:
       nodemon: 2.0.15
 
   src/api/sso:
     specifiers:
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       '@supabase/supabase-js': 1.29.4
       celebrate: 15.0.1
       connect-redis: 6.0.0
@@ -293,7 +293,7 @@ importers:
       passport: 0.5.2
       passport-saml: 3.2.0
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       '@supabase/supabase-js': 1.29.4
       celebrate: 15.0.1
       connect-redis: 6.0.0
@@ -312,7 +312,7 @@ importers:
       '@octokit/plugin-retry': 3.0.9
       '@octokit/plugin-throttling': 3.5.2
       '@popperjs/core': 2.10.2
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       bootstrap: 5.1.3
       env-cmd: 10.1.0
       express: 4.17.2
@@ -332,7 +332,7 @@ importers:
       '@octokit/plugin-retry': 3.0.9
       '@octokit/plugin-throttling': 3.5.2_@octokit+core@3.5.1
       '@popperjs/core': 2.10.2
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       bootstrap: 5.1.3_@popperjs+core@2.10.2
       express: 4.17.2
       express-handlebars: 6.0.2
@@ -352,7 +352,7 @@ importers:
   src/api/users:
     specifiers:
       '@firebase/rules-unit-testing': 2.0.2
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       celebrate: 15.0.1
       env-cmd: 10.1.0
       firebase-admin: 10.0.1
@@ -361,7 +361,7 @@ importers:
       nodemon: 2.0.15
       supertest: 6.1.6
     dependencies:
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       celebrate: 15.0.1
       firebase-admin: 10.0.1
       http-link-header: 1.0.3
@@ -471,7 +471,7 @@ importers:
   tools/autodeployment:
     specifiers:
       '@octokit/webhooks': 9.15.0
-      '@senecacdot/satellite': ^1.x
+      '@senecacdot/satellite': latest
       date-fns: 2.26.0
       dotenv: 10.0.0
       merge-stream: 2.0.0
@@ -480,7 +480,7 @@ importers:
       shelljs: 0.8.5
     dependencies:
       '@octokit/webhooks': 9.15.0
-      '@senecacdot/satellite': 1.17.0
+      '@senecacdot/satellite': 1.24.0
       date-fns: 2.26.0
       dotenv: 10.0.0
       merge-stream: 2.0.0
@@ -3827,20 +3827,6 @@ packages:
       - supports-color
     dev: false
 
-  /@elastic/ecs-helpers/1.1.0:
-    resolution: {integrity: sha512-MDLb2aFeGjg46O5mLpdCzT5yOUDnXToJSrco2ShqGIXxNJaM8uJjX+4nd+hRYV4Vex8YJyDtOFEVBldQct6ndg==}
-    engines: {node: '>=10'}
-    dependencies:
-      fast-json-stringify: 2.7.13
-    dev: false
-
-  /@elastic/ecs-pino-format/1.3.0:
-    resolution: {integrity: sha512-U8D57gPECYoRCcwREsrXKBtqeyFFF/KAwHi4rG1u/oQhAg91Kzw8ZtUQJXD/DMDieLOqtbItFr2FRBWI3t3wog==}
-    engines: {node: '>=10'}
-    dependencies:
-      '@elastic/ecs-helpers': 1.1.0
-    dev: false
-
   /@elastic/elasticsearch-mock/0.3.1:
     resolution: {integrity: sha512-ip+bsSxv0aE+P05be9bX4sWjQ37T61EcpMPsGJaGW07dSU+ERH4Q4Tq8kYSnFlUgpXZTf2nhtix+j/EOvZSXvQ==}
     dependencies:
@@ -5007,27 +4993,25 @@ packages:
       rollup: 2.64.0
     dev: false
 
-  /@senecacdot/satellite/1.17.0:
-    resolution: {integrity: sha512-rgiGej+/GEcONV0GpPue+yrPDdX9cFxcY4P/2Hytq/vHAt4Iy3DXCc1aTBqfZ9oKX8gPqLrUjAIR7cKXJ1nqWg==}
-    engines: {node: '>=12.0.0'}
+  /@senecacdot/satellite/1.24.0:
+    resolution: {integrity: sha512-LC5Dhe+oV3hICw6f8w7pJNc0QdD+uQo3wGuDf/GjOri+mIgOxsPBWTXBPv6pc4LEoP9mUTUrKHI9MDP4ExLbLA==}
+    engines: {node: '>=14.0.0', pnpm: '>=6'}
     dependencies:
-      '@elastic/ecs-pino-format': 1.3.0
       '@elastic/elasticsearch': 7.16.0
       '@elastic/elasticsearch-mock': 0.3.1
       '@godaddy/terminus': 4.10.2
       cors: 2.8.5
-      elastic-apm-node: 3.27.0
-      express: 4.17.1
+      express: 4.17.2
       express-jwt: 6.1.0
-      express-pino-logger: 6.0.0
       helmet: 4.6.0
       http-errors: 1.8.1
       ioredis: 4.28.3
-      ioredis-mock: 5.8.1_ioredis@4.28.3
+      ioredis-mock: 5.9.1_ioredis@4.28.3
       jsonwebtoken: 8.5.1
       node-fetch: 2.6.7
-      pino: 6.13.4
-      pino-colada: 2.2.2
+      pino: 7.6.5
+      pino-http: 6.6.0
+      pino-pretty: 7.5.1
     transitivePeerDependencies:
       - encoding
       - redis-commands
@@ -5559,6 +5543,7 @@ packages:
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
+    dev: true
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -6083,10 +6068,6 @@ packages:
     engines: {node: '>= 0.12.0'}
     dev: false
 
-  /after-all-results/2.0.0:
-    resolution: {integrity: sha1-asL8ICtQD4jaj09VMM+hAPTGotA=}
-    dev: false
-
   /agent-base/6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -6495,12 +6476,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /async-cache/1.1.0:
-    resolution: {integrity: sha1-SppaidBl7F2OUlS9nulrp2xTK1o=}
-    dependencies:
-      lru-cache: 4.1.5
-    dev: false
-
   /async-listener/0.6.10:
     resolution: {integrity: sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==}
     engines: {node: <=0.11.8 || >0.11.10}
@@ -6515,16 +6490,6 @@ packages:
       retry: 0.13.1
     dev: false
     optional: true
-
-  /async-value-promise/1.1.1:
-    resolution: {integrity: sha512-c2RFDKjJle1rHa0YxN9Ysu97/QBu3Wa+NOejJxsX+1qVDJrkD3JL/GN1B3gaILAEXJXbu/4Z1lcoCHFESe/APA==}
-    dependencies:
-      async-value: 1.2.2
-    dev: false
-
-  /async-value/1.2.2:
-    resolution: {integrity: sha1-hFF6Hny2saW14YH6Mb4QQ3t/sSU=}
-    dev: false
 
   /async/0.9.2:
     resolution: {integrity: sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=}
@@ -6593,7 +6558,7 @@ packages:
   /axios/0.21.4_debug@4.3.3:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.7
+      follow-redirects: 1.14.7_debug@4.3.3
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6847,6 +6812,7 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       safe-buffer: 5.1.2
+    dev: true
 
   /batch/0.6.1:
     resolution: {integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=}
@@ -6876,10 +6842,6 @@ packages:
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-
-  /binary-search/1.3.6:
-    resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
-    dev: false
 
   /binary/0.3.0:
     resolution: {integrity: sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=}
@@ -7013,12 +6975,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-
-  /breadth-filter/2.0.0:
-    resolution: {integrity: sha512-thQShDXnFWSk2oVBixRCyrWsFoV5tfOpWKHmxwafHQDNxCfDBk539utpvytNjmlFrTMqz41poLwJvA1MW3z0MQ==}
-    dependencies:
-      object.entries: 1.1.5
-    dev: false
 
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
@@ -7776,14 +7732,6 @@ packages:
 
   /console-control-strings/1.1.0:
     resolution: {integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=}
-
-  /console-log-level/1.4.1:
-    resolution: {integrity: sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ==}
-    dev: false
-
-  /container-info/1.1.0:
-    resolution: {integrity: sha512-eD2zLAmxGS2kmL4f1jY8BdOqnmpL6X70kvzTBW/9FIQnxoxiBJ4htMsTmtPLPWRs7NHYFvqKQ1VtppV08mdsQA==}
-    dev: false
 
   /content-disposition/0.5.2:
     resolution: {integrity: sha1-DPaLud318r55YcOoUXjLhdunjLQ=}
@@ -8761,61 +8709,6 @@ packages:
       jake: 10.8.2
     dev: false
 
-  /elastic-apm-http-client/10.3.0:
-    resolution: {integrity: sha512-BAqB7k5JA/x09L8BVj04WRoknRptmW2rLAoHQVrPvPhUm/IgNz63wPfiBuhWVE//Hl7xEpURO5pMV6az0UArkA==}
-    engines: {node: ^8.6.0 || 10 || >=12}
-    dependencies:
-      breadth-filter: 2.0.0
-      container-info: 1.1.0
-      end-of-stream: 1.4.4
-      fast-safe-stringify: 2.1.1
-      fast-stream-to-buffer: 1.0.0
-      object-filter-sequence: 1.0.0
-      readable-stream: 3.6.0
-      stream-chopper: 3.0.1
-    dev: false
-
-  /elastic-apm-node/3.27.0:
-    resolution: {integrity: sha512-x8rWjGBgwKYcYN9IQWUv3dzq88RxEVnVIC6KMXQpFkRBG6XtWG4FeMvLaDSeTdXVnDBKTDVGCF9np5HdGhYbBw==}
-    engines: {node: ^8.6.0 || 10 || 12 || 14 || 15 || 16 || 17}
-    dependencies:
-      '@elastic/ecs-pino-format': 1.3.0
-      after-all-results: 2.0.0
-      async-cache: 1.1.0
-      async-value-promise: 1.1.1
-      basic-auth: 2.0.1
-      cookie: 0.4.1
-      core-util-is: 1.0.3
-      elastic-apm-http-client: 10.3.0
-      end-of-stream: 1.4.4
-      error-callsites: 2.0.4
-      error-stack-parser: 2.0.6
-      escape-string-regexp: 4.0.0
-      fast-safe-stringify: 2.1.1
-      http-headers: 3.0.2
-      is-native: 1.0.1
-      load-source-map: 2.0.0
-      lru-cache: 6.0.0
-      measured-reporting: 1.51.1
-      monitor-event-loop-delay: 1.0.0
-      object-filter-sequence: 1.0.0
-      object-identity-map: 1.0.2
-      original-url: 1.2.3
-      pino: 6.13.4
-      read-pkg-up: 7.0.1
-      relative-microtime: 2.0.0
-      require-in-the-middle: 5.1.0
-      semver: 6.3.0
-      set-cookie-serde: 1.0.0
-      shallow-clone-shim: 2.0.0
-      sql-summary: 1.0.1
-      traceparent: 1.0.0
-      traverse: 0.6.6
-      unicode-byte-truncate: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /electron-to-chromium/1.4.53:
     resolution: {integrity: sha512-rFveSKQczlcav+H3zkKqykU6ANseFwXwkl855jOIap5/0gnEcuIhv2ecz6aoTrXavF6I/CEBeRnBnkB51k06ew==}
 
@@ -8916,11 +8809,6 @@ packages:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
     dev: true
     optional: true
-
-  /error-callsites/2.0.4:
-    resolution: {integrity: sha512-V877Ch4FC4FN178fDK1fsrHN4I1YQIBdtjKrHh3BUHMnh3SMvwUVrqkaOgDpUuevgSNna0RBq6Ox9SGlxYrigA==}
-    engines: {node: '>=6.x'}
-    dev: false
 
   /error-ex/1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -9755,12 +9643,6 @@ packages:
       lodash.set: 4.3.2
     dev: false
 
-  /express-pino-logger/6.0.0:
-    resolution: {integrity: sha512-YjBnalqgsNylRnWEpQGf8YzBP54stpoqX/o+SnpGr04OB7dRIQlsC1qvutFOyRjhLhXIWCe43pYJcjp9zM1Ccg==}
-    dependencies:
-      pino-http: 5.8.0
-    dev: false
-
   /express-session/1.17.2:
     resolution: {integrity: sha512-mPcYcLA0lvh7D4Oqr5aNJFMtBMKPLl++OKKxkHzZ0U0oDq1rpKBnkR5f5vCHR26VeArlTOEF9td4x5IjICksRQ==}
     engines: {node: '>= 0.8.0'}
@@ -9922,26 +9804,12 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.4
 
-  /fast-json-parse/1.0.3:
-    resolution: {integrity: sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==}
-    dev: false
-
   /fast-json-patch/3.1.0:
     resolution: {integrity: sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==}
     dev: false
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-
-  /fast-json-stringify/2.7.13:
-    resolution: {integrity: sha512-ar+hQ4+OIurUGjSJD1anvYSDcUflywhKjfxnsW4TBTD7+u0tJufv6DKRWoQk3vI6YBOWMoz0TQtfbe7dxbQmvA==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      ajv: 6.12.6
-      deepmerge: 4.2.2
-      rfdc: 1.3.0
-      string-similarity: 4.0.4
-    dev: false
 
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
@@ -9956,12 +9824,6 @@ packages:
 
   /fast-shallow-equal/1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-    dev: false
-
-  /fast-stream-to-buffer/1.0.0:
-    resolution: {integrity: sha512-bI/544WUQlD2iXBibQbOMSmG07Hay7YrpXlKaeGTPT7H7pC0eitt3usak5vUwEvCGK/O7rUAM3iyQValGU22TQ==}
-    dependencies:
-      end-of-stream: 1.4.4
     dev: false
 
   /fast-text-encoding/1.0.3:
@@ -10316,10 +10178,6 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /flatstr/1.0.12:
-    resolution: {integrity: sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==}
-    dev: false
-
   /flatted/3.2.4:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
@@ -10348,6 +10206,18 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  /follow-redirects/1.14.7_debug@4.3.3:
+    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.3
+    dev: false
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -10443,10 +10313,6 @@ packages:
       react-fast-compare: 2.0.4
       tiny-warning: 1.0.3
       tslib: 1.14.1
-    dev: false
-
-  /forwarded-parse/2.1.2:
-    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
     dev: false
 
   /forwarded/0.2.0:
@@ -11388,12 +11254,6 @@ packages:
       statuses: 1.5.0
       toidentifier: 1.0.1
 
-  /http-headers/3.0.2:
-    resolution: {integrity: sha512-87E1I+2Wg4dxxz4rcxElo3dxO/w1ZtgL1yA0Sb6vH3qU16vRKq1NjWQv9SCY3ly2OQROcoxHZOUpmelS+k6wOw==}
-    dependencies:
-      next-line: 1.1.0
-    dev: false
-
   /http-link-header/1.0.3:
     resolution: {integrity: sha512-nARK1wSKoBBrtcoESlHBx36c1Ln/gnbNQi1eB6MeTUefJIT3NvUOsV15bClga0k38f0q/kN5xxrGSDS3EFnm9w==}
     engines: {node: '>=4.0.0'}
@@ -11693,8 +11553,8 @@ packages:
       standard-as-callback: 2.1.0
     dev: false
 
-  /ioredis-mock/5.8.1_ioredis@4.28.3:
-    resolution: {integrity: sha512-YWUoE7ZZLzo2fJMWLjeh3F/TkgHqeazdOeExZskit+/2ZSA0bsFPkXiKMOUHZxjOk2JskOP9iuYvf/iO3mhMZg==}
+  /ioredis-mock/5.9.1_ioredis@4.28.3:
+    resolution: {integrity: sha512-ZirdGJFOqH5nP8FYXuHUJmexvtZ6r2Ybc5alaGMzt38QA0kse5/rYnBQcb4ofxkyqzhXHuaCsXiwLlfG6NyhhQ==}
     engines: {node: '>=10'}
     peerDependencies:
       ioredis: 4.x
@@ -11846,11 +11706,6 @@ packages:
     resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
     engines: {node: '>=0.10.0'}
 
-  /is-finite/1.1.0:
-    resolution: {integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /is-fullwidth-code-point/1.0.0:
     resolution: {integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs=}
     engines: {node: '>=0.10.0'}
@@ -11899,12 +11754,6 @@ packages:
       global-dirs: 3.0.0
       is-path-inside: 3.0.3
 
-  /is-integer/1.0.7:
-    resolution: {integrity: sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=}
-    dependencies:
-      is-finite: 1.1.0
-    dev: false
-
   /is-lambda/1.0.1:
     resolution: {integrity: sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=}
     dev: true
@@ -11922,20 +11771,9 @@ packages:
       define-properties: 1.1.3
     dev: false
 
-  /is-native/1.0.1:
-    resolution: {integrity: sha1-zRjMFi6EUNaDtbq+eayZwUVElnU=}
-    dependencies:
-      is-nil: 1.0.1
-      to-source-code: 1.0.2
-    dev: false
-
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
-
-  /is-nil/1.0.1:
-    resolution: {integrity: sha1-LauingtYUGOHXntTnQcfWxWTeWk=}
-    dev: false
 
   /is-npm/4.0.0:
     resolution: {integrity: sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==}
@@ -13243,13 +13081,6 @@ packages:
       pify: 3.0.0
       strip-bom: 3.0.0
 
-  /load-source-map/2.0.0:
-    resolution: {integrity: sha512-QNZzJ2wMrTmCdeobMuMNEXHN1QGk8HG6louEkzD/zwQ7EU2RarrzlhQ4GnUYEFzLhK+Jq7IGyF/qy+XYBSO7AQ==}
-    engines: {node: '>= 8'}
-    dependencies:
-      source-map: 0.7.3
-    dev: false
-
   /loader-runner/4.2.0:
     resolution: {integrity: sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==}
     engines: {node: '>=6.11.5'}
@@ -13524,13 +13355,6 @@ packages:
       yallist: 2.1.2
     dev: false
 
-  /lru-cache/4.1.5:
-    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
-    dependencies:
-      pseudomap: 1.0.2
-      yallist: 2.1.2
-    dev: false
-
   /lru-cache/5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
@@ -13616,10 +13440,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /mapcap/1.0.0:
-    resolution: {integrity: sha512-KcNlZSlFPx+r1jYZmxEbTVymG+dIctf10WmWkuhrhrblM+KMoF77HelwihL5cxYlORye79KoR4IlOOk99lUJ0g==}
-    dev: false
-
   /markdown-escapes/1.0.4:
     resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
 
@@ -13675,24 +13495,6 @@ packages:
 
   /mdurl/1.0.1:
     resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
-
-  /measured-core/1.51.1:
-    resolution: {integrity: sha512-DZQP9SEwdqqYRvT2slMK81D/7xwdxXosZZBtLVfPSo6y5P672FBTbzHVdN4IQyUkUpcVOR9pIvtUy5Ryl7NKyg==}
-    engines: {node: '>= 5.12'}
-    dependencies:
-      binary-search: 1.3.6
-      optional-js: 2.3.0
-    dev: false
-
-  /measured-reporting/1.51.1:
-    resolution: {integrity: sha512-JCt+2u6XT1I5lG3SuYqywE0e62DJuAzBcfMzWGUhIYtPQV2Vm4HiYt/durqmzsAbZV181CEs+o/jMKWJKkYIWw==}
-    engines: {node: '>= 5.12'}
-    dependencies:
-      console-log-level: 1.4.1
-      mapcap: 1.0.0
-      measured-core: 1.51.1
-      optional-js: 2.3.0
-    dev: false
 
   /media-typer/0.3.0:
     resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
@@ -13972,10 +13774,6 @@ packages:
     resolution: {integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==}
     dev: false
 
-  /monitor-event-loop-delay/1.0.0:
-    resolution: {integrity: sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q==}
-    dev: false
-
   /morgan/1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
     engines: {node: '>= 0.8.0'}
@@ -14119,10 +13917,6 @@ packages:
 
   /next-compose-plugins/2.2.1:
     resolution: {integrity: sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==}
-    dev: false
-
-  /next-line/1.1.0:
-    resolution: {integrity: sha1-/K5XhTBStqm66CCOQN19PC0wRgM=}
     dev: false
 
   /next-pwa/5.4.4_@babel+core@7.16.7+next@12.0.9:
@@ -14474,19 +14268,9 @@ packages:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
 
-  /object-filter-sequence/1.0.0:
-    resolution: {integrity: sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ==}
-    dev: false
-
   /object-hash/2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
-
-  /object-identity-map/1.0.2:
-    resolution: {integrity: sha512-a2XZDGyYTngvGS67kWnqVdpoaJWsY7C1GhPJvejWAFCsUioTAaiTu8oBad7c6cI4McZxr4CmvnZeycK05iav5A==}
-    dependencies:
-      object.entries: 1.1.5
-    dev: false
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -14519,6 +14303,7 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.3
       es-abstract: 1.19.1
+    dev: true
 
   /object.fromentries/2.0.5:
     resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==}
@@ -14629,10 +14414,6 @@ packages:
       xml: 1.0.1
     dev: false
 
-  /optional-js/2.3.0:
-    resolution: {integrity: sha512-B0LLi+Vg+eko++0z/b8zIv57kp7HKEzaPJo7LowJXMUKYdf+3XJGu/cw03h/JhIOsLnP+cG5QnTHAuicjA5fMw==}
-    dev: false
-
   /optionator/0.8.3:
     resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
     engines: {node: '>= 0.8.0'}
@@ -14667,12 +14448,6 @@ packages:
       strip-ansi: 5.2.0
       wcwidth: 1.0.1
     dev: true
-
-  /original-url/1.2.3:
-    resolution: {integrity: sha512-BYm+pKYLtS4mVe/mgT3YKGtWV5HzN/XKiaIu1aK4rsxyjuHeTW9N+xVBEpJcY1onB3nccfH0RbzUEoimMqFUHQ==}
-    dependencies:
-      forwarded-parse: 2.1.2
-    dev: false
 
   /os-homedir/1.0.2:
     resolution: {integrity: sha1-/7xJiDNuDoM94MFox+8VISGqf7M=}
@@ -14880,11 +14655,6 @@ packages:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  /parse-ms/2.1.0:
-    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /parse-numeric-range/1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
     dev: false
@@ -15067,17 +14837,6 @@ packages:
       split2: 4.1.0
     dev: false
 
-  /pino-colada/2.2.2:
-    resolution: {integrity: sha512-tzZl6j4D2v9WSQ4vEa7s8j15v16U6+z6M0fAWJOu5gBKxpy+XnOAgFBzeZGkxm6W3AQ04WvdSpqVLnDBdJlvOQ==}
-    hasBin: true
-    dependencies:
-      chalk: 3.0.0
-      fast-json-parse: 1.0.3
-      prettier-bytes: 1.0.4
-      pretty-ms: 5.1.0
-      split2: 3.2.2
-    dev: false
-
   /pino-elasticsearch/6.2.0:
     resolution: {integrity: sha512-kGjgRK84GBO9HU6d9Wnm2v/XY0rxWB/olPEQPHg54KiFiFpfN112jB7sqda8PeMCzgf5KaJKdZncP04sok+Tmg==}
     engines: {node: '>=10'}
@@ -15092,20 +14851,12 @@ packages:
       - supports-color
     dev: false
 
-  /pino-http/5.8.0:
-    resolution: {integrity: sha512-YwXiyRb9y0WCD1P9PcxuJuh3Dc5qmXde/paJE86UGYRdiFOi828hR9iUGmk5gaw6NBT9gLtKANOHFimvh19U5w==}
-    dependencies:
-      fast-url-parser: 1.1.3
-      pino: 6.13.4
-      pino-std-serializers: 4.0.0
-    dev: false
-
   /pino-http/6.6.0:
     resolution: {integrity: sha512-PlItaK2MLpoIMLEcClhfb1VQk/o6fKppINl5s6sPE/4rvufkdO3kCSs/92EwrBsB1yssRCQqDV+w1xpYuPVnjg==}
     dependencies:
       fast-url-parser: 1.1.3
       get-caller-file: 2.0.5
-      pino: 7.6.4
+      pino: 7.6.5
       pino-std-serializers: 5.1.0
     dev: false
 
@@ -15127,8 +14878,22 @@ packages:
       strip-json-comments: 3.1.1
     dev: false
 
-  /pino-std-serializers/3.2.0:
-    resolution: {integrity: sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==}
+  /pino-pretty/7.5.1:
+    resolution: {integrity: sha512-xEOUJiokdBGcZ9d0v7OY6SqEp+rrVH2drE3bHOUsK8elw44eh9V83InZqeL1dFwgD1IDnd6crUoec3hIXxfdBQ==}
+    hasBin: true
+    dependencies:
+      args: 5.0.1
+      colorette: 2.0.16
+      dateformat: 4.6.3
+      fast-safe-stringify: 2.1.1
+      joycon: 3.1.1
+      pino-abstract-transport: 0.5.0
+      pump: 3.0.0
+      readable-stream: 3.6.0
+      rfdc: 1.3.0
+      secure-json-parse: 2.4.0
+      sonic-boom: 2.6.0
+      strip-json-comments: 3.1.1
     dev: false
 
   /pino-std-serializers/4.0.0:
@@ -15139,21 +14904,24 @@ packages:
     resolution: {integrity: sha512-BlNiiaqALYzQVLDsyRRfb/s/PjxzO7BjfVJo0P9JQEtr995l0A6RFHVLmPZXaGg3v06AC26dpCixUibpwrbWrA==}
     dev: false
 
-  /pino/6.13.4:
-    resolution: {integrity: sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==}
+  /pino/7.6.4:
+    resolution: {integrity: sha512-ktibPg3ttWONxYQ2Efk1zYbIvofD5zdd/ReoujK84ggEp0REflb9TsXavSjt8u1CdT2mMJe9QQ3ZpyOQxUKipA==}
     hasBin: true
     dependencies:
       fast-redact: 3.1.0
-      fast-safe-stringify: 2.1.1
-      flatstr: 1.0.12
-      pino-std-serializers: 3.2.0
+      on-exit-leak-free: 0.2.0
+      pino-abstract-transport: 0.5.0
+      pino-std-serializers: 4.0.0
       process-warning: 1.0.0
       quick-format-unescaped: 4.0.4
-      sonic-boom: 1.4.1
+      real-require: 0.1.0
+      safe-stable-stringify: 2.3.1
+      sonic-boom: 2.6.0
+      thread-stream: 0.13.1
     dev: false
 
-  /pino/7.6.4:
-    resolution: {integrity: sha512-ktibPg3ttWONxYQ2Efk1zYbIvofD5zdd/ReoujK84ggEp0REflb9TsXavSjt8u1CdT2mMJe9QQ3ZpyOQxUKipA==}
+  /pino/7.6.5:
+    resolution: {integrity: sha512-38tAwlJ7HevMENHD5FZE+yxSlAH5Wg3FoOjbB3MX2j3/kgpOEkmDHhTVKkecR57qxD5doHo2yi9nac94gqqbiQ==}
     hasBin: true
     dependencies:
       fast-redact: 3.1.0
@@ -15805,10 +15573,6 @@ packages:
     resolution: {integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=}
     engines: {node: '>=4'}
 
-  /prettier-bytes/1.0.4:
-    resolution: {integrity: sha1-mUsCqkb2mcULYle1+qp/4lV+YtY=}
-    dev: false
-
   /prettier-linter-helpers/1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
@@ -15842,13 +15606,6 @@ packages:
       ansi-styles: 5.2.0
       react-is: 17.0.2
     dev: true
-
-  /pretty-ms/5.1.0:
-    resolution: {integrity: sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==}
-    engines: {node: '>=8'}
-    dependencies:
-      parse-ms: 2.1.0
-    dev: false
 
   /pretty-quick/3.1.3_prettier@2.4.1:
     resolution: {integrity: sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==}
@@ -16141,10 +15898,6 @@ packages:
   /random-bytes/1.0.0:
     resolution: {integrity: sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=}
     engines: {node: '>= 0.8'}
-    dev: false
-
-  /random-poly-fill/1.0.1:
-    resolution: {integrity: sha512-bMOL0hLfrNs52+EHtIPIXxn2PxYwXb0qjnKruTjXiM/sKfYqj506aB2plFwWW1HN+ri724bAVVGparh4AtlJKw==}
     dev: false
 
   /randombytes/2.1.0:
@@ -16478,15 +16231,6 @@ packages:
       object-assign: 4.1.1
     dev: false
 
-  /read-pkg-up/7.0.1:
-    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
-    engines: {node: '>=8'}
-    dependencies:
-      find-up: 4.1.0
-      read-pkg: 5.2.0
-      type-fest: 0.8.1
-    dev: false
-
   /read-pkg-up/8.0.0:
     resolution: {integrity: sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==}
     engines: {node: '>=12'}
@@ -16503,16 +16247,6 @@ packages:
       load-json-file: 4.0.0
       normalize-package-data: 2.5.0
       path-type: 3.0.0
-
-  /read-pkg/5.2.0:
-    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@types/normalize-package-data': 2.4.1
-      normalize-package-data: 2.5.0
-      parse-json: 5.2.0
-      type-fest: 0.6.0
-    dev: false
 
   /read-pkg/6.0.0:
     resolution: {integrity: sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==}
@@ -16717,10 +16451,6 @@ packages:
   /relateurl/0.2.7:
     resolution: {integrity: sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=}
     engines: {node: '>= 0.10'}
-    dev: false
-
-  /relative-microtime/2.0.0:
-    resolution: {integrity: sha512-l18ha6HEZc+No/uK4GyAnNxgKW7nvEe35IaeN54sShMojtqik2a6GbTyuiezkjpPaqP874Z3lW5ysBo5irz4NA==}
     dev: false
 
   /release-zalgo/1.0.0:
@@ -17361,10 +17091,6 @@ packages:
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
 
-  /set-cookie-serde/1.0.0:
-    resolution: {integrity: sha512-Vq8e5GsupfJ7okHIvEPcfs5neCo7MZ1ZuWrO3sllYi3DOWt6bSSCpADzqXjz3k0fXehnoFIrmmhty9IN6U6BXQ==}
-    dev: false
-
   /set-harmonic-interval/1.0.1:
     resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
     engines: {node: '>=6.9'}
@@ -17389,10 +17115,6 @@ packages:
 
   /setprototypeof/1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  /shallow-clone-shim/2.0.0:
-    resolution: {integrity: sha512-YRNymdiL3KGOoS67d73TEmk4tdPTO9GSMCoiphQsTcC9EtC+AOmMPjkyBkRoCJfW9ASsaZw1craaiw1dPN2D3Q==}
-    dev: false
 
   /shallow-clone/3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
@@ -17568,13 +17290,6 @@ packages:
       ip: 1.1.5
       smart-buffer: 4.2.0
 
-  /sonic-boom/1.4.1:
-    resolution: {integrity: sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==}
-    dependencies:
-      atomic-sleep: 1.0.0
-      flatstr: 1.0.12
-    dev: false
-
   /sonic-boom/2.6.0:
     resolution: {integrity: sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==}
     dependencies:
@@ -17730,10 +17445,6 @@ packages:
     resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
     dev: false
 
-  /sql-summary/1.0.1:
-    resolution: {integrity: sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww==}
-    dev: false
-
   /sshpk/1.17.0:
     resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
     engines: {node: '>=0.10.0'}
@@ -17818,12 +17529,6 @@ packages:
     engines: {node: '>=4', npm: '>=6'}
     dev: false
 
-  /stream-chopper/3.0.1:
-    resolution: {integrity: sha512-f7h+ly8baAE26iIjcp3VbnBkbIRGtrvV0X0xxFM/d7fwLTYnLzDPTXRKNxa2HZzohOrc96NTrR+FaV3mzOelNA==}
-    dependencies:
-      readable-stream: 3.6.0
-    dev: false
-
   /stream-events/1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
     dependencies:
@@ -17853,10 +17558,6 @@ packages:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
     dev: true
-
-  /string-similarity/4.0.4:
-    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
-    dev: false
 
   /string-width/1.0.2:
     resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=}
@@ -18511,12 +18212,6 @@ packages:
     dependencies:
       is-number: 7.0.0
 
-  /to-source-code/1.0.2:
-    resolution: {integrity: sha1-3RNr2x4dvYC76s8IiZJnjpBwv+o=}
-    dependencies:
-      is-nil: 1.0.1
-    dev: false
-
   /toggle-selection/1.0.6:
     resolution: {integrity: sha1-bkWxJj8gF/oKzH2J14sVuL932jI=}
     dev: false
@@ -18591,19 +18286,9 @@ packages:
       punycode: 2.1.1
     dev: false
 
-  /traceparent/1.0.0:
-    resolution: {integrity: sha512-b/hAbgx57pANQ6cg2eBguY3oxD6FGVLI1CC2qoi01RmHR7AYpQHPXTig9FkzbWohEsVuHENZHP09aXuw3/LM+w==}
-    dependencies:
-      random-poly-fill: 1.0.1
-    dev: false
-
   /traverse/0.3.9:
     resolution: {integrity: sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=}
     dev: true
-
-  /traverse/0.6.6:
-    resolution: {integrity: sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=}
-    dev: false
 
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -18889,14 +18574,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest/0.6.0:
-    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
-    engines: {node: '>=8'}
-    dev: false
-
   /type-fest/0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+    dev: true
 
   /type-fest/1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
@@ -18970,13 +18651,6 @@ packages:
       inherits: 2.0.4
       xtend: 4.0.2
 
-  /unicode-byte-truncate/1.0.0:
-    resolution: {integrity: sha1-qm8PNHUZP+IMMgrJIT425i6HZKc=}
-    dependencies:
-      is-integer: 1.0.7
-      unicode-substring: 0.1.0
-    dev: false
-
   /unicode-canonical-property-names-ecmascript/2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -18995,10 +18669,6 @@ packages:
   /unicode-property-aliases-ecmascript/2.0.0:
     resolution: {integrity: sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==}
     engines: {node: '>=4'}
-
-  /unicode-substring/0.1.0:
-    resolution: {integrity: sha1-YSDOPDkDhdvND2DDK5BlxBgdSzY=}
-    dev: false
 
   /unified/8.4.2:
     resolution: {integrity: sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==}

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "^1.x"
+    "@senecacdot/satellite": "latest"
   },
   "devDependencies": {
     "env-cmd": "10.1.0",

--- a/src/api/feed-discovery/package.json
+++ b/src/api/feed-discovery/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "cheerio": "1.0.0-rc.10",
     "got": "11.8.3"
   },

--- a/src/api/image/package.json
+++ b/src/api/image/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "celebrate": "15.0.1",
     "got": "11.8.3",
     "sharp": "0.29.3"

--- a/src/api/parser/package.json
+++ b/src/api/parser/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "7.16.0",
     "@elastic/elasticsearch-mock": "0.3.1",
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "bull": "3.29.3",
     "bull-board": "2.1.3",
     "jsdom": "18.1.1",

--- a/src/api/planet/package.json
+++ b/src/api/planet/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "express": "4.17.2",
     "express-handlebars": "5.3.5"
   },

--- a/src/api/posts/package.json
+++ b/src/api/posts/package.json
@@ -16,7 +16,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "bull": "3.29.3",
     "express-validator": "6.14.0",
     "ioredis": "4.28.2",

--- a/src/api/search/package.json
+++ b/src/api/search/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "express-validator": "6.14.0"
   },
   "engines": {

--- a/src/api/sso/package.json
+++ b/src/api/sso/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "@supabase/supabase-js": "1.29.4",
     "celebrate": "15.0.1",
     "connect-redis": "6.0.0",

--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -22,7 +22,7 @@
     "@octokit/plugin-retry": "3.0.9",
     "@octokit/plugin-throttling": "3.5.2",
     "@popperjs/core": "2.10.2",
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "bootstrap": "5.1.3",
     "express": "4.17.2",
     "express-handlebars": "6.0.2",

--- a/src/api/users/package.json
+++ b/src/api/users/package.json
@@ -7,7 +7,7 @@
     "dev": "env-cmd -f env.local nodemon src/server.js"
   },
   "dependencies": {
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "celebrate": "15.0.1",
     "firebase-admin": "10.0.1",
     "http-link-header": "1.0.3"

--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "@octokit/webhooks": "9.15.0",
-    "@senecacdot/satellite": "^1.x",
+    "@senecacdot/satellite": "latest",
     "date-fns": "2.26.0",
     "dotenv": "10.0.0",
     "merge-stream": "2.0.0",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2934 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
- Changed all the Satellite version `^1.x` in the `package.json` of our microservices to `"latest"`, then ran `pnpm install`
<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
- This will pickup the newest Satellite versions whenever `pnpm install` is ran. 
- Whoever releases Satellite will also have to also run `pnpm install` in Telescope to get the updates

## Steps to test the PR

- All tests passed locally
- Telescope was able to start locally

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
variables are added/changed or an explanation of why it does not(if applicable)
