### PR TITLE
Fixes #2970 add eslint configurations to Docusaurus and play together with turborepo's linting

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,7 @@ importers:
       '@docusaurus/preset-classic': 2.0.0-beta.15
       '@docusaurus/types': 2.0.0-beta.15
       '@mdx-js/react': 1.6.22
+      '@senecacdot/eslint-config-telescope': 1.0.0
       clsx: 1.1.1
       prism-react-renderer: 1.2.1
       react: 17.0.2
@@ -358,6 +359,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@docusaurus/types': 2.0.0-beta.15
+      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
 
   src/web:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,7 @@ importers:
       eslint-plugin-jest: 25.3.4
       eslint-plugin-jest-playwright: 0.2.1
       eslint-plugin-jsx-a11y: 6.5.1
+      eslint-plugin-node: 11.1.0
       eslint-plugin-prettier: 3.4.1
       eslint-plugin-promise: 5.2.0
       eslint-plugin-react: 7.28.0
@@ -472,6 +473,7 @@ importers:
       eslint-plugin-jest: 25.3.4_cf0e947377590fbec5e3edece1a05d8c
       eslint-plugin-jest-playwright: 0.2.1
       eslint-plugin-jsx-a11y: 6.5.1_eslint@7.32.0
+      eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_6e975bd57c7acf028c1a9ddbbf60c898
       eslint-plugin-promise: 5.2.0_eslint@7.32.0
       eslint-plugin-react: 7.28.0_eslint@7.32.0
@@ -8510,6 +8512,17 @@ packages:
       anti-trojan-source: 1.4.0
     dev: true
 
+  /eslint-plugin-es/3.0.1_eslint@7.32.0:
+    resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
+    engines: {node: '>=8.10.0'}
+    peerDependencies:
+      eslint: '>=4.19.1'
+    dependencies:
+      eslint: 7.32.0
+      eslint-utils: 2.1.0
+      regexpp: 3.2.0
+    dev: true
+
   /eslint-plugin-import/2.25.4_eslint@7.32.0:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
@@ -8577,6 +8590,21 @@ packages:
       jsx-ast-utils: 3.2.1
       language-tags: 1.0.5
       minimatch: 3.1.2
+    dev: true
+
+  /eslint-plugin-node/11.1.0_eslint@7.32.0:
+    resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
+    engines: {node: '>=8.10.0'}
+    peerDependencies:
+      eslint: '>=5.16.0'
+    dependencies:
+      eslint: 7.32.0
+      eslint-plugin-es: 3.0.1_eslint@7.32.0
+      eslint-utils: 2.1.0
+      ignore: 5.2.0
+      minimatch: 3.0.4
+      resolve: 1.22.0
+      semver: 6.3.0
     dev: true
 
   /eslint-plugin-prettier/3.4.1_6e975bd57c7acf028c1a9ddbbf60c898:

--- a/src/docs/.eslintrc.js
+++ b/src/docs/.eslintrc.js
@@ -1,0 +1,42 @@
+module.exports = {
+  extends: 'eslint-config-telescope',
+
+  overrides: [
+    {
+      files: ['./**/*.js'],
+      extends: [
+        'plugin:import/typescript',
+        'plugin:node/recommended',
+        'plugin:react/recommended',
+        'plugin:react-hooks/recommended',
+      ],
+      plugins: ['react', 'react-hooks'],
+      rules: {
+        // https://github.com/facebook/docusaurus/blob/main/.eslintrc.js#L122
+        // Ignore certain webpack aliases because they can't be resolved
+        'import/no-unresolved': [
+          'off',
+          {
+            ignore: ['^@theme', '^@docusaurus', '^@generated', '^@site'],
+          },
+        ],
+        'global-require': 'off',
+        'no-use-before-define': 'off',
+        'node/no-missing-import': 'off',
+        'node/no-unsupported-features/es-syntax': 'off',
+        'react/jsx-filename-extension': ['error', { extensions: ['.js', '.jsx'] }],
+        // https://github.com/facebook/docusaurus/blob/main/.eslintrc.js#L154
+        // We build a static site, and nearly all components don't change.
+        'react/no-array-index-key': 'off',
+        'react/prop-types': 'off',
+      },
+      settings: {
+        'import/resolver': {
+          node: {
+            extensions: ['.js', '.jsx', '.ts', 'tsx'],
+          },
+        },
+      },
+    },
+  ],
+};

--- a/src/docs/.eslintrc.js
+++ b/src/docs/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   extends: '@senecacdot/eslint-config-telescope',
-
   overrides: [
     {
       files: ['./**/*.js'],
@@ -12,6 +11,7 @@ module.exports = {
       ],
       plugins: ['react', 'react-hooks'],
       rules: {
+        '@typescript-eslint/no-shadow': 'off',
         // https://github.com/facebook/docusaurus/blob/main/.eslintrc.js#L122
         // Ignore certain webpack aliases because they can't be resolved
         'import/no-unresolved': [
@@ -33,7 +33,7 @@ module.exports = {
       settings: {
         'import/resolver': {
           node: {
-            extensions: ['.js', '.jsx', '.ts', 'tsx'],
+            extensions: ['.js', '.jsx'],
           },
         },
       },

--- a/src/docs/.eslintrc.js
+++ b/src/docs/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: 'eslint-config-telescope',
+  extends: '@senecacdot/eslint-config-telescope',
 
   overrides: [
     {

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --port 4631 --host 0.0.0.0",
+    "lint": "pnpm eslint",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },
@@ -39,6 +40,7 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@docusaurus/types": "2.0.0-beta.15"
+    "@docusaurus/types": "2.0.0-beta.15",
+    "@senecacdot/eslint-config-telescope": "1.0.0"
   }
 }

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "telescope-docs",
+  "name": "@senecacdot/telescope-docs",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -14,6 +14,7 @@
     "eslint-plugin-jest": "25.3.4",
     "eslint-plugin-jest-playwright": "0.2.1",
     "eslint-plugin-jsx-a11y": "6.5.1",
+    "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.4.1",
     "eslint-plugin-promise": "5.2.0",
     "eslint-plugin-react": "7.28.0",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #2970 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Before when we ran `pnpm lint`, we get only lint our tree and the Next.js frontend
```
PS C:\Users\lecin\Documents\repo\telescope> pnpm lint   

> @senecacdot/telescope@2.7.1 lint C:\Users\lecin\Documents\repo\telescope
> pnpm turbo run lint

• Packages in scope: @senecacdot/autodeployment, @senecacdot/eslint-config-telescope, @senecacdot/feed-discovery-service, @senecacdot/image-service, @senecacdot/planet-service, @senecacdot/posts-service, @senecacdot/search-service, @senecacdot/sso-service, @senecacdot/status-service, @senecacdot/telescope-frontend, dependency-discovery, migrate, parser, telescope-docs
• Running lint in 14 packages
@senecacdot/telescope-frontend:lint: cache hit, replaying output ea6f907d061ff4ab
@senecacdot/telescope-frontend:lint: 
@senecacdot/telescope-frontend:lint: > @senecacdot/telescope-frontend@3.0.0 lint C:\Users\lecin\Documents\repo\telescope\src\web
@senecacdot/telescope-frontend:lint: > pnpm eslint
@senecacdot/telescope-frontend:lint: 

 Tasks:    1 successful, 1 total
Cached:    1 cached, 1 total
  Time:    1.254s >>> FULL TURBO
```

With this PR, we will also lint the Docusaurus sub-project
```
PS C:\Users\lecin\Documents\repo\telescope> pnpm lint

> @senecacdot/telescope@2.7.1 lint C:\Users\lecin\Documents\repo\telescope
> pnpm turbo run lint

• Packages in scope: @senecacdot/autodeployment, @senecacdot/eslint-config-telescope, @senecacdot/feed-discovery-service, @senecacdot/image-service, @senecacdot/planet-service, @senecacdot/posts-service, @senecacdot/search-service, @senecacdot/sso-service, @senecacdot/status-service, @senecacdot/telescope-docs, @senecacdot/telescope-frontend, dependency-discovery, migrate, parser
• Running lint in 14 packages
@senecacdot/telescope-frontend:lint: cache hit, replaying output 7aa4bbab10a81473
@senecacdot/telescope-frontend:lint: 
@senecacdot/telescope-docs:lint: cache hit, replaying output 068f9f9922d75b3e
@senecacdot/telescope-docs:lint: 
@senecacdot/telescope-docs:lint: > @senecacdot/telescope-docs@0.0.1 lint C:\Users\lecin\Documents\repo\telescope\src\docs
@senecacdot/telescope-docs:lint: > pnpm eslint
@senecacdot/telescope-docs:lint: 
@senecacdot/telescope-frontend:lint: > @senecacdot/telescope-frontend@3.0.0 lint C:\Users\lecin\Documents\repo\telescope\src\web
@senecacdot/telescope-frontend:lint: > pnpm eslint
@senecacdot/telescope-frontend:lint: 

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    1.284s >>> FULL TURBO
```

## Steps to test the PR
To test this PR locally:
1. Add my repository as a remote: `git remote add cindyledev https://github.com/cindyledev/telescope.git`
2. Fetch my branches: `git fetch cindyledev`
3. Checkout my branch: `git checkout issue-2970`
4. Install dependencies using pnpm in root (this will also install dependencies in src/docs: `pnpm install`
5. Lint: `pnpm lint`

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
