### PR TITLE
Set packages to private:true so they don't get published by pnpm

### DIFF
--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@senecacdot/autodeployment",
+  "private": true,
   "version": "0.0.1",
   "description": "A tool for automatic deployment",
   "main": "server.js",

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -1,5 +1,6 @@
 {
   "author": "",
+  "private": true,
   "dependencies": {
     "jsdom": "^18.0.1",
     "node-fetch": "2.6.7"


### PR DESCRIPTION
Fixes #2974 

This should stop `pnpm publish` from publishing these packages to npm.