### PR TITLE
Fixes #2975: GITHUB_TOKEN showing in logs

### DIFF
--- a/tools/autodeployment/deploy.sh
+++ b/tools/autodeployment/deploy.sh
@@ -2,7 +2,6 @@
 
 set -e
 set -u
-set -x
 
 # Delete and Clone Latest
 cd ..


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #2975
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR removes the `-x` option in our deploy script to avoid printing commands' details before they're executed.
More info [here](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin) (option `-x`).


## Steps to test the PR

Latest build was run after removing the `-x` option. Go through the build log to see if the build log only displays command's output.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
