### PR TITLE
[Fix]: Build header doesn't display build info in production

### DIFF
--- a/src/api/status/public/js/build-log/build-header.js
+++ b/src/api/status/public/js/build-log/build-header.js
@@ -50,11 +50,10 @@ function renderLoadingAnimation(code) {
 }
 
 function renderBuildInfo({ isCurrent, githubData, startedDate, stoppedDate, code, sha }) {
-  const {
-    sender,
-    compare,
-    head_commit: { message },
-  } = githubData;
+  const { sender, compare } = githubData;
+
+  /* Depending on the event type (merge vs release), we extract the message that will be displayed in the header from the appropriate prop */
+  const message = githubData.ref ? githubData.head_commit.message : githubData.release.name;
 
   if (buildHeaderInfo.hidden) {
     buildHeaderInfo.hidden = false;


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Currently, the build header is stuck loading in `production`
![image](https://user-images.githubusercontent.com/23108901/154771854-afb933c6-61a8-48ca-9ee7-4b209696bb2a.png)

The problem is that the build header tries to extract the commit message that will be displayed from a prop (`head_commit.message`) that doesn't exist in the payload received from the `autodeployment` for releases. (it exists for regular merges to master).
This is a temporary fix, we should change the `autodeployment` server to send only one type of payload, regardless of event type.
 
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR

This was already tested in production
<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
