### PR TITLE
Fix eslint and eslint vscode for src/web

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,7 @@
     "source.fixAll": true
   },
   "files.eol": "\n",
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "eslint.packageManager": "pnpm",
+  "eslint.workingDirectories": [{ "mode": "auto" }]
 }

--- a/src/web/.eslintrc.js
+++ b/src/web/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: 'eslint-config-telescope',
+  extends: '@senecacdot/eslint-config-telescope',
 
   overrides: [
     // TypeScript for Next.js


### PR DESCRIPTION
This is a partial fix for #2970.  We need to use the correct name for our plugin (fully qualified), and we also need to tell the VSCode eslint plugin about pnpm and our packages.

I think we probably need an `.eslintrc.js` file in every sub-project, even if it only uses `extends` so vscode can find the config file.