### PR TITLE
Use port 9000 vs. 80 for portainer router

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -202,3 +202,8 @@ services:
       - 'traefik.http.routers.portainer.rule=HOST(`${PORTAINER_HOST}`)'
       # Specify the portainer service port used internally
       - 'traefik.http.services.portainer.loadbalancer.server.port=80'
+      # Specify the portainer service port used internally, which is 9000
+      # NOTE: portainer also uses port 8000 for remote SSH connections, but
+      # I don't think we need this.  See:
+      # https://github.com/portainer/portainer-docs/issues/91
+      - 'traefik.http.services.portainer.loadbalancer.server.port=9000'


### PR DESCRIPTION
https://dev.portainer.telescope.cdot.systems/ gives "Bad Gateway" from nginx, because Traefik is routing to the wrong port in the Portainer container.  I'm using 80, but it's really 9000.

There's no way to test this except to do it on staging.