### PR TITLE
Increase buffer size for the dependency script

### DIFF
--- a/tools/collect-dependencies.js
+++ b/tools/collect-dependencies.js
@@ -13,7 +13,13 @@ if (option !== '-o' || !filename) {
 console.log('Starting to collect dependencies');
 
 console.log('Invoking pnpm list...');
-const output = execSync('pnpm list -w -r --parseable --depth=2').toString('utf8');
+
+// Warning: the maxBuffer has been increased to 10 MB as a quick solution.
+// In the case we hit the limit of the buffer again, we shall rewrite the
+// script for a better way to handle it.
+const output = execSync('pnpm list -w -r --parseable --depth=2', {
+  maxBuffer: 1024 * 1024 * 10, // approx. 10 Megabyte = 1024 bytes per Kilobyte * 1024 Kilobytes per Megabyte * 10 Megabytes
+}).toString('utf8');
 
 const regex = /.*\.pnpm\/(@?[^@]+).*/g;
 


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3006 

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This may fix the issue, however, I am not sure that it will completely fix it. The issue that @manekenpix showed is related to the output being too big so it cannot hold it in the buffer. This PR just increases the maximum size of the buffer.

The reason I am unsure that these two errors are linked is because the error happens before writing to the file, however, the file itself looks like it was truncated and did not receive any output.

## Steps to test the PR

1. Get my changes
2. You can run the script with `node tools/collect-dependencies.js -- -o src/api/dependency-discovery/deps.txt`.

We might need to test the `preversion` script. I would need some assistance for this.

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
