### PR TITLE
Handle portainer routing in nginx

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -149,10 +149,29 @@ http {
   # Verify chain of trust of OCSP response using Root CA and Intermediate certs
   ssl_trusted_certificate /etc/letsencrypt/live/${TELESCOPE_HOST}/chain.pem;
 
-  # Requests to the (api|portainer).* domain should be proxied to Traefik
+  # Requests to the Portainer app
   server {
     listen 443 ssl http2;
-    server_name ${API_HOST} ${PORTAINER_HOST};
+    server_name ${PORTAINER_HOST};
+
+    location /api/websocket/  {
+      proxy_cache_bypass 1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_pass  http://portainer:9000/api/websocket;
+    }
+
+    location / {
+      proxy_cache_bypass 1;
+      proxy_set_header Connection "";
+      proxy_pass http://portainer:9000/;
+    }
+  }
+
+  # Requests to the api.* domain should be proxied to Traefik
+  server {
+    listen 443 ssl http2;
+    server_name ${API_HOST};
 
     location / {
       proxy_set_header  Host            $host;
@@ -160,11 +179,6 @@ http {
       proxy_set_header  X-Forwarded-for $remote_addr;
       # We run Traefik via Docker on port 8888
       proxy_pass        http://traefik:8888;
-    }
-
-    # Let's Encrypt route
-    location /.well-known/acme-challenge/ {
-      root /var/www/certbot;
     }
   }
 

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -183,6 +183,7 @@ services:
   rss-bridge:
     restart: unless-stopped
 
+  # Portainer's routing is managed in our nginx.conf
   portainer:
     image: portainer/portainer-ce:alpine
     container_name: 'portainer'
@@ -194,16 +195,3 @@ services:
       - ../../portainer/portainer:/data/portainer
     depends_on:
       - nginx
-      - traefik
-    labels:
-      # Enable Traefik
-      - 'traefik.enable=true'
-      # Traefik routing for the portainer app portainer.*
-      - 'traefik.http.routers.portainer.rule=HOST(`${PORTAINER_HOST}`)'
-      # Specify the portainer service port used internally
-      - 'traefik.http.services.portainer.loadbalancer.server.port=80'
-      # Specify the portainer service port used internally, which is 9000
-      # NOTE: portainer also uses port 8000 for remote SSH connections, but
-      # I don't think we need this.  See:
-      # https://github.com/portainer/portainer-docs/issues/91
-      - 'traefik.http.services.portainer.loadbalancer.server.port=9000'


### PR DESCRIPTION
Fixes #3018.  This moves the Portainer routing back under nginx.  I'm not going to fight with Traefik over web socket connections.

The web socket connections are there so that we can shell into containers via the browser.

I can't really test this without trying on staging.