### PR TITLE
Use HTTP 1.1 for Portainer /api/websocket route

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -154,16 +154,19 @@ http {
     listen 443 ssl http2;
     server_name ${PORTAINER_HOST};
 
-    location /api/websocket/  {
-      proxy_cache_bypass 1;
+    # Allow WebSocket connections
+    location /api/websocket/ {
+      proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
-      proxy_pass  http://portainer:9000/api/websocket;
+      proxy_set_header Host $host;
+      proxy_pass http://portainer:9000/api/websocket/;
     }
 
+    # All other traffic can get proxied directly.
     location / {
-      proxy_cache_bypass 1;
       proxy_set_header Connection "";
+      proxy_set_header Host $host;
       proxy_pass http://portainer:9000/;
     }
   }


### PR DESCRIPTION
I thought I'd fixed the Portainer web socket access, but it looks like it's still broken:

```
containerConsoleController.js:173 WebSocket connection to 'wss://dev.portainer.telescope.cdot.systems/api/websocket/exec?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJhZG1pbiIsInJvbGUiOjEsInNjb3BlIjoiZGVmYXVsdCIsImV4cCI6MTY0NTc0NzA5Mn0.1RA-RvuwVMxH-k6zI1ZaDf27o-W7vuxFHXD1UL3Onp0&endpointId=1&id=f8160161d5e950783cac991551448f34fb8a92686265daa5c22476a49fe6ea55' failed
```

I think the issue is that you need to use HTTP 1.1 vs. HTTP 2 for the web socket connection upgrade to work.