### PR TITLE
update Satellite rangeStrategy to 'bump' for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "packageRules": [
-    { "matchPackagePatterns": ["@senecacdot/satellite"], "rangeStrategy": "replace" },
+    { "matchPackagePatterns": ["@senecacdot/satellite"], "rangeStrategy": "bump" },
     { "matchPackagePatterns": ["node-fetch"], "allowedVersions": "<3.0" }
   ],
   "dependencyDashboard": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
 
   src/api/dependency-discovery:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       env-cmd: 10.1.0
       nodemon: 2.0.15
     dependencies:
@@ -156,7 +156,7 @@ importers:
 
   src/api/feed-discovery:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       cheerio: 1.0.0-rc.10
       got: 11.8.3
       nodemon: 2.0.15
@@ -169,7 +169,7 @@ importers:
 
   src/api/image:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       celebrate: 15.0.1
       del-cli: 4.0.1
       got: 11.8.3
@@ -188,7 +188,7 @@ importers:
     specifiers:
       '@bull-board/api': 3.7.0
       '@bull-board/express': 3.7.0
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       babel-jest: 27.3.1
       bull: 3.22.0
       clean-whitespace: 0.1.2
@@ -215,13 +215,13 @@ importers:
       rss-parser: 3.12.0
       sanitize-html: 2.5.3
     devDependencies:
-      babel-jest: 27.3.1
+      babel-jest: 27.3.1_@babel+core@7.17.5
       env-cmd: 10.1.0
       nodemon: 2.0.7
 
   src/api/planet:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       env-cmd: 10.1.0
       express: 4.17.3
       express-handlebars: 5.3.5
@@ -236,7 +236,7 @@ importers:
 
   src/api/posts:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       bull: 3.29.3
       express-validator: 6.14.0
       ioredis: 4.28.5
@@ -257,7 +257,7 @@ importers:
 
   src/api/search:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       express-validator: 6.14.0
       nodemon: 2.0.15
     dependencies:
@@ -268,7 +268,7 @@ importers:
 
   src/api/sso:
     specifiers:
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       '@supabase/supabase-js': 1.29.4
       celebrate: 15.0.1
       connect-redis: 6.0.0
@@ -299,7 +299,7 @@ importers:
       '@octokit/plugin-retry': 3.0.9
       '@octokit/plugin-throttling': 3.5.2
       '@popperjs/core': 2.10.2
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       bootstrap: 5.1.3
       env-cmd: 10.1.0
       express: 4.17.3
@@ -431,7 +431,7 @@ importers:
   tools/autodeployment:
     specifiers:
       '@octokit/webhooks': 9.15.0
-      '@senecacdot/satellite': 1.26.0
+      '@senecacdot/satellite': ^1.26.0
       date-fns: 2.26.0
       dotenv: 10.0.0
       merge-stream: 2.0.0
@@ -1439,14 +1439,6 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-async-generators/7.8.4:
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.17.4:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
@@ -1464,14 +1456,6 @@ packages:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
 
-  /@babel/plugin-syntax-bigint/7.8.3:
-    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.17.5:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
@@ -1479,14 +1463,6 @@ packages:
     dependencies:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-
-  /@babel/plugin-syntax-class-properties/7.12.13:
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.4:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -1571,14 +1547,6 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-import-meta/7.10.4:
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.17.5:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
@@ -1586,14 +1554,6 @@ packages:
     dependencies:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-
-  /@babel/plugin-syntax-json-strings/7.8.3:
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.17.4:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -1641,14 +1601,6 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4:
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.17.4:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -1665,14 +1617,6 @@ packages:
     dependencies:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3:
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.4:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -1691,14 +1635,6 @@ packages:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
 
-  /@babel/plugin-syntax-numeric-separator/7.10.4:
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.17.4:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
@@ -1715,14 +1651,6 @@ packages:
     dependencies:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-
-  /@babel/plugin-syntax-object-rest-spread/7.8.3:
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.9:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1750,14 +1678,6 @@ packages:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3:
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.17.4:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
@@ -1774,14 +1694,6 @@ packages:
     dependencies:
       '@babel/core': 7.17.5
       '@babel/helper-plugin-utils': 7.16.7
-
-  /@babel/plugin-syntax-optional-chaining/7.8.3:
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.4:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -1817,15 +1729,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.5
-      '@babel/helper-plugin-utils': 7.16.7
-    dev: true
-
-  /@babel/plugin-syntax-top-level-await/7.14.5:
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
       '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
@@ -6232,7 +6135,7 @@ packages:
   /axios/0.21.4_debug@4.3.3:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.7_debug@4.3.3
+      follow-redirects: 1.14.7
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6249,17 +6152,18 @@ packages:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
     dev: true
 
-  /babel-jest/27.3.1:
+  /babel-jest/27.3.1_@babel+core@7.17.5:
     resolution: {integrity: sha512-SjIF8hh/ir0peae2D6S6ZKRhUy7q/DnpH7k/V6fT4Bgs/LXXUztOpX4G2tCgq8mLo5HA9mN6NmlFMeYtKmIsTQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
+      '@babel/core': 7.17.5
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.1.18
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1
+      babel-preset-jest: 27.5.1_@babel+core@7.17.5
       chalk: 4.1.2
       graceful-fs: 4.2.9
       slash: 3.0.0
@@ -6457,25 +6361,6 @@ packages:
     resolution: {integrity: sha512-kDXhW2iPTL81x4Ye2aUMdEXQ56JP0sBJmRQRXJPH5FsNB7fOc/YCsHTqHv8IovPyw9Rk07gdd7MVUz8tUmRBCA==}
     dev: true
 
-  /babel-preset-current-node-syntax/1.0.1:
-    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/plugin-syntax-async-generators': 7.8.4
-      '@babel/plugin-syntax-bigint': 7.8.3
-      '@babel/plugin-syntax-class-properties': 7.12.13
-      '@babel/plugin-syntax-import-meta': 7.10.4
-      '@babel/plugin-syntax-json-strings': 7.8.3
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
-      '@babel/plugin-syntax-numeric-separator': 7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
-      '@babel/plugin-syntax-top-level-await': 7.14.5
-    dev: true
-
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.17.5:
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
@@ -6494,16 +6379,6 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.17.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.5
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.17.5
-
-  /babel-preset-jest/27.5.1:
-    resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.0.1
-    dev: true
 
   /babel-preset-jest/27.5.1_@babel+core@7.17.5:
     resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
@@ -9548,18 +9423,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.14.7_debug@4.3.3:
-    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.3
-    dev: false
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0"
+    "@senecacdot/satellite": "^1.26.0"
   },
   "devDependencies": {
     "env-cmd": "10.1.0",

--- a/src/api/feed-discovery/package.json
+++ b/src/api/feed-discovery/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "cheerio": "1.0.0-rc.10",
     "got": "11.8.3"
   },

--- a/src/api/image/package.json
+++ b/src/api/image/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "celebrate": "15.0.1",
     "got": "11.8.3",
     "sharp": "0.29.3"

--- a/src/api/parser/package.json
+++ b/src/api/parser/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@bull-board/api": "3.7.0",
     "@bull-board/express": "3.7.0",
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "bull": "3.22.0",
     "clean-whitespace": "0.1.2",
     "highlight.js": "11.4.0",

--- a/src/api/planet/package.json
+++ b/src/api/planet/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "express": "4.17.3",
     "express-handlebars": "5.3.5"
   },

--- a/src/api/posts/package.json
+++ b/src/api/posts/package.json
@@ -16,7 +16,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "bull": "3.29.3",
     "express-validator": "6.14.0",
     "ioredis": "4.28.5",

--- a/src/api/search/package.json
+++ b/src/api/search/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "express-validator": "6.14.0"
   },
   "engines": {

--- a/src/api/sso/package.json
+++ b/src/api/sso/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "@supabase/supabase-js": "1.29.4",
     "celebrate": "15.0.1",
     "connect-redis": "6.0.0",

--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -22,7 +22,7 @@
     "@octokit/plugin-retry": "3.0.9",
     "@octokit/plugin-throttling": "3.5.2",
     "@popperjs/core": "2.10.2",
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "bootstrap": "5.1.3",
     "express": "4.17.3",
     "express-handlebars": "6.0.2",

--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -6,7 +6,7 @@
   "main": "server.js",
   "dependencies": {
     "@octokit/webhooks": "9.15.0",
-    "@senecacdot/satellite": "1.26.0",
+    "@senecacdot/satellite": "^1.26.0",
     "date-fns": "2.26.0",
     "dotenv": "10.0.0",
     "merge-stream": "2.0.0",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Could potentially fix #2959 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

Changed the `rangeStrategy` of Satellite on Renovate to `bump`
As discussed in #3049 , and [documented here](https://docs.renovatebot.com/configuration-options/#rangestrategy)
I then changed all the Satellite dependencies from `1.26.0` to `^1.26.0`, and then ran `pnpm install`

## Description

After the merge, we might be able to re-trigger the Renovate dependency scan, and see if Satellite will show up as a dependency. After that, we can manually click on the Satellite checkbox on the dependency dashboard, instead of having to run `pnpm update -r --latest @senecacdot/satellite`, and create PRs ourselves.
