### PR TITLE
chore(deps): update dependency @types/node to v16.11.26

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,7 +369,7 @@ importers:
       '@material-ui/icons': 4.11.2
       '@senecacdot/eslint-config-telescope': 1.0.0
       '@testing-library/react': 12.1.3
-      '@types/node': 16.11.25
+      '@types/node': 16.11.26
       '@types/react': 17.0.39
       '@types/smoothscroll-polyfill': 0.3.1
       '@types/yup': 0.29.13
@@ -422,7 +422,7 @@ importers:
     devDependencies:
       '@senecacdot/eslint-config-telescope': link:../../tools/eslint
       '@testing-library/react': 12.1.3_react-dom@17.0.2+react@17.0.2
-      '@types/node': 16.11.25
+      '@types/node': 16.11.26
       '@types/react': 17.0.39
       babel-loader: 8.2.3_@babel+core@7.17.5
       terser-webpack-plugin: 5.3.1
@@ -5213,8 +5213,8 @@ packages:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
 
-  /@types/node/16.11.25:
-    resolution: {integrity: sha512-NrTwfD7L1RTc2qrHQD4RTTy4p0CO2LatKBEKEds3CaVuhoM/+DJzmWZl5f+ikR8cm8F5mfJxK+9rQq07gRiSjQ==}
+  /@types/node/16.11.26:
+    resolution: {integrity: sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==}
     dev: true
 
   /@types/node/17.0.12:

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@senecacdot/eslint-config-telescope": "1.0.0",
     "@testing-library/react": "12.1.3",
-    "@types/node": "16.11.25",
+    "@types/node": "16.11.26",
     "@types/react": "17.0.39",
     "babel-loader": "8.2.3",
     "terser-webpack-plugin": "5.3.1",


### PR DESCRIPTION
I fat-fingered and messed up #3054 and didn't want to bug Renovate bot to fix my mistake so here is a manual PR to update @types/node to v16.11.26.