### PR TITLE
Fix colour palette in docs

### DIFF
--- a/src/docs/docs/tools-and-technologies/nextjs.md
+++ b/src/docs/docs/tools-and-technologies/nextjs.md
@@ -2,6 +2,31 @@
 sidebar_position: 4
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+export const Palette = ({children, color}) => (
+<Fragment
+style={{
+  display: 'flex'
+}}>
+<span
+style={{
+  display: 'inline-block',
+  width: '1.6rem',
+  height: '1.6rem',
+  backgroundColor: color,
+  borderRadius: '0.5rem',
+  border: '1px solid black'
+}}/><p
+style={{
+  color: 'black',
+  fontWeight: 'bold',
+  paddingLeft: '0.5rem'
+}}>{children}</p>
+</Fragment>
+)
+
 # Frontend Development with Next.js
 
 The Telescope frontend is currently being developed using Typescript and NextJS. We encourage all new developers to read the [NextJS docs](https://nextjs.org/docs) in order to familiarize themselves with how Next works as well as the [Typescript docs](https://www.typescriptlang.org/docs/) in order to understand how the language operates.
@@ -24,66 +49,74 @@ When working on a new component for the Telescope frontend, please consider the 
 
 Here is the colour palette that we use to make our web site looks pretty and up-to-date.
 
+<Tabs className="unique-tabs">
+  <TabItem value="light" label="Light">
+
 ### Light Palette
 
-![#121D59](https://placehold.it/15/121D59/000000?text=+) **Primary**
+<Palette color="#121D59">Primary</Palette>
 
 - hex: #121D59
-- rgb: (18, 29, 89)
+- rgb: (18,29,89)
 
-![#A0D1FB](https://placehold.it/15/A0D1FB/000000?text=+) **Secondary**
+<Palette color="#A0D1FB">Secondary</Palette>
 
 - hex: #A0D1FB
 - rgb: (160,209,251)
 
-![#FFFFFF](https://placehold.it/15/FFFFFF/000000?text=+) **Background**
+<Palette color="#FFFFFF">Background</Palette>
 
 - hex: #FFFFFF
-- rgb: (255, 255, 255)
+- rgb: (255,255,255)
 
 #### Typography
 
-![#A0D1FB](https://placehold.it/15/A0D1FB/000000?text=+) **Primary**
-
-- hex: #A0D1FB
-- rgb:
-
-![#121D59](https://placehold.it/15/121D59/000000?text=+) **Secondary**
-
-- hex: #121D59
-- rgb: (18, 29, 89)
-
-“The Free Image Placeholder Service Favoured By Designers.” Placeholder.com, 17 Dec. 2019, placeholder.com/.
-
-### Dark Palette
-
-![#A0D1FB](https://placehold.it/15/A0D1FB/000000?text=+) **Primary**
+<Palette color="#A0D1FB">Primary</Palette>
 
 - hex: #A0D1FB
 - rgb: (160,209,251)
 
-![#4f96d8](https://placehold.it/15/4f96d8/000000?text=+) **Secondary**
+<Palette color="#121D59">Secondary</Palette>
 
-- hex: #4f96d8
+- hex: #121D59
+- rgb: (18,29,89)
+
+</TabItem>
+
+  <TabItem value="dark" label="Dark">
+
+### Dark Palette
+
+<Palette color="#A0D1FB">Primary</Palette>
+
+- hex: #A0D1FB
+- rgb: (160,209,251)
+
+<Palette color="#4F96D8">Secondary</Palette>
+
+- hex: #4F96D8
 - rgb: (79,150,216)
 
-![#000000](https://placehold.it/15/000000/000000?text=+) **Background**
+<Palette color="#000000">Background</Palette>
 
 - hex: #000000
 - rgb: (0,0,0)
 
 #### Typography
 
-![#FFFFFF](https://placehold.it/15/FFFFFF/000000?text=+) **Primary**
+<Palette color="#FFFFFF">Primary</Palette>
 
 - hex: #FFFFFF
 - rgb: (255,255,255)
 
-![#121D59](https://placehold.it/15/A0D1FB/000000?text=+) **Secondary**
+<Palette color="#121D59">Secondary</Palette>
 
 - hex: #A0D1FB
 - rgb: (160,209,251)
   <br/>
+
+</TabItem>
+</Tabs>
 
 # Theming Palette
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #2938

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

This PR fixes the missing colours for the palette in the docs and reorganizes it with tabs for Light and Dark mode.

<!-- Please add a detailed description of what this PR does and why it is needed -->
![Screen Shot 2022-02-26 at 11 27 17 PM](https://user-images.githubusercontent.com/53121061/155868228-c28a48d5-4063-473e-8264-41ecd3e6baa4.jpg)

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

- Change directory to /src/docs: `cd src/docs`
- Start the server: `pnpm start`
- Visit `localhost:4631` in browser

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
