### PR TITLE
fix: update dependency react-lite-youtube-embed to 2.2.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,7 +386,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2
       react-icons: 4.3.1
-      react-lite-youtube-embed: 2.1.3
+      react-lite-youtube-embed: 2.2.1
       react-transition-group: 4.4.2
       react-use: 17.3.2
       smoothscroll-polyfill: 0.4.4
@@ -413,7 +413,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-icons: 4.3.1_react@17.0.2
-      react-lite-youtube-embed: 2.1.3_react-dom@17.0.2+react@17.0.2
+      react-lite-youtube-embed: 2.2.1_react-dom@17.0.2+react@17.0.2
       react-transition-group: 4.4.2_react-dom@17.0.2+react@17.0.2
       react-use: 17.3.2_react-dom@17.0.2+react@17.0.2
       smoothscroll-polyfill: 0.4.4
@@ -14012,8 +14012,8 @@ packages:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
 
-  /react-lite-youtube-embed/2.1.3_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-pTWl7bcRnnxj1Tz0zHEn1SG0sW9+ucumF9m8zrm2qx6lYDuSPsLN+GCTuAFHn0KuKV9N3nUIvVwCfC0Zx9tNWA==}
+  /react-lite-youtube-embed/2.2.1_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-BcD1e9l3QgI+a1MhFeqCt+HoXmPIg31bwUzYdWYVfEfI7WLEA5MkDB6/XCZnkKRuSebJsFp+NV0axh9WUUGMKQ==}
     peerDependencies:
       react: '>=16.0.8'
       react-dom: '>=16.0.8'

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -27,7 +27,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-icons": "4.3.1",
-    "react-lite-youtube-embed": "2.1.3",
+    "react-lite-youtube-embed": "2.2.1",
     "react-transition-group": "4.4.2",
     "react-use": "17.3.2",
     "smoothscroll-polyfill": "0.4.4",


### PR DESCRIPTION
## Description

This PR updates `react-lite-youtube-embed` to version 2.2.1, since version 2.2.0 has a type issue that causes our build to crash. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
