### PR TITLE
Run 'redis-check-aof' before starting redis

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -305,7 +305,12 @@ services:
   redis:
     image: redis:latest
     container_name: 'redis'
-    command: ['redis-server', '--appendonly', 'yes']
+    command:
+      [
+        'bash',
+        '-c',
+        'printf "y\n" | redis-check-aof --fix /data/appendonly.aof ; redis-server --appendonly yes',
+      ]
     volumes:
       - ../redis-data:/data
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -305,6 +305,9 @@ services:
   redis:
     image: redis:latest
     container_name: 'redis'
+    # The following command invokes "redis-check-aof" to fix the AOF file in the case
+    # of corruption due to a power outage.
+    # We also need the "printf" command to confirm the prompt of "redis-check-aof"
     command:
       [
         'bash',


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #1365

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

In the case of a power failure, we run the 'redis-check-aof' command to check and fix the 'aof' file that got corrupted after the power failure.

## Steps to test the PR

1. Pull my changes.
2. Ensure that you have no `redis-data` folder (delete if that's the case).
3. Start up the containers (`pnpm run services:start`)
4. Fill the redis DB with posts (`pnpm start`).
5. After running for a while, you may stop the backend.
6. Truncate the `redis-data/appendonly.aof` file (`truncate` in linux and macos, I am not sure in Windows...)
7. Start up the `redis` container now (`pnpm run services:start redis`)
8. Check the logs of the container (`pnpm run services:logs redis`)
8.1. If the log says that redis is waiting for connection, then `redis-check-aof` successfully fixed the file.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
