### PR TITLE
Fixes #3125 add `clean` scripts to delete node_modules and build outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "pnpm dev --prefix src/web --",
     "develop": "pnpm dev",
     "lint": "pnpm turbo run lint",
+    "clean": "pnpm turbo run clean && pnpm -r exec rm -rf node_modules",
     "prettier": "prettier --write \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "prettier-check": "prettier --check \"./**/*.{md,jsx,json,html,css,js,yml}\"",
     "test": "pnpm jest",

--- a/src/api/image/package.json
+++ b/src/api/image/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
-    "clean": "del \"./photos/*.jpg\" \"!./photos/default.jpg\""
+    "clean": "find ./photos -type f -not -name 'default.jpg' -delete"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",

--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -7,6 +7,7 @@
     "dev": "run-p watch:*",
     "build": "run-s compile:*",
     "start": "node src/server.js",
+    "clean": "rm -rf .turbo public/dist",
     "watch:server": "env-cmd -f env.local nodemon src/server.js",
     "compile:js": "vite build",
     "watch:js": "vite build --watch"

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -11,6 +11,7 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --port 4631 --host 0.0.0.0",
     "lint": "pnpm eslint",
+    "clean": "rm -rf .docusaurus .turbo build",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -5,7 +5,8 @@
     "build": "next build && next export",
     "dev": "next dev -p 8000",
     "start": "next start -p 8000",
-    "lint": "pnpm eslint"
+    "lint": "pnpm eslint",
+    "clean": "rm -rf .next .turbo out"
   },
   "version": "3.0.0",
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,9 @@
     },
     "lint": {
       "outputs": []
+    },
+    "clean": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #3125

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

This PR adds `clean` scripts to allow us to delete `node_modules` and build outputs from our docs, next.js frontend and status board by running `pnpm clean` in the root directory. The `clean` script uses `pnpm`'s [recursive](https://pnpm.io/cli/exec#--recursive--r) method to prune `node_modules` installations for all packages and adds a `clean` step to our Turborepo's pipeline. Turborepo will through all our `package.json`'s provided by `pnpm-workspace.yaml` and find all the `clean` scripts then runs them. This PR adds `clean` scripts to the following:
- root
- src/api/image (updated because the original script uses the `del` cmd so it only works on Windows) 
- src/api/status
- src/docs
- src/web

To reiterate: 

https://github.com/Seneca-CDOT/telescope/blob/430f7715c3345f4f8ab6d1d5a9f81331b9132682/package.json#L17

`pnpm turbo run clean` deletes all the build outputs and images and `pnpm -r exec rm -rf node_modules` deletes all the `node_modules`

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

To test this PR locally:
1. Add my repository as a remote: `git remote add cindyledev https://github.com/cindyledev/telescope.git`
2. Fetch my branches: `git fetch cindyledev`
3. Checkout my branch: `git checkout issue-3125`
4. Install dependencies using pnpm in root: `pnpm install`
5. Build all the docs, next.js, status board apps: `pnpm build` This will take a long time but take note of all the `node_modules` and outputs in the following directories:
  - src/api/status/public/dist
  - src/docs/build
  - src/web/out
6. Finally, test the `clean` script: `pnpm clean`. This should delete all the node_modules and build outputs

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
