### PR TITLE
Opt-out of appendonly mode in redis

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -305,7 +305,7 @@ services:
   redis:
     image: redis:latest
     container_name: 'redis'
-    command: ['redis-server', '--appendonly', 'yes']
+    command: ['redis-server']
     volumes:
       - ../redis-data:/data
 


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #1365 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The AOF file would get corrupted during a power outage. During recovery, the redis-server would not be able to read this corrupted file, and thus end the process, making the container service unavailable.

Instead, when a power outage occurs, redis shall use the dump.rdb file, which works fine for our current use case.

## Steps to test the PR

1. Pull my changes
2. Wipe out any existing `redis-data` folder.
3. Create a new `redis-data` folder by turning the necessary services for the backend to fill in any posts (`pnpm run services:start` and then `pnpm start`)
4. Shut down all services and backend after filling the database
5. Truncate the `appendonly.aof` file to a considerably shorter length (use `truncate` command in linux and macOS)
6. Run `redis` container only (`pnpm run services:start redis`)
7. Check the logs of the container (`pnpm run services:logs redis`), and you should be able to see redis listening for connections and still alive.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
