### PR TITLE
[Fix]: Use proper way to require express-handlebars

### DIFF
--- a/src/api/planet/src/index.js
+++ b/src/api/planet/src/index.js
@@ -1,12 +1,12 @@
 const { static: serveStatic } = require('express');
-const expressHandlebars = require('express-handlebars');
+const { engine } = require('express-handlebars');
 const { Satellite } = require('@senecacdot/satellite');
 const path = require('path');
 const planet = require('./planet');
 
 const service = new Satellite({
   beforeRouter(app) {
-    app.engine('handlebars', expressHandlebars());
+    app.engine('handlebars', engine());
     app.set('views', path.join(__dirname, '../views'));
     app.set('view engine', 'handlebars');
   },


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

In a recent update, [express-handlebars](https://github.com/express-handlebars/express-handlebars) has change the way it needs to be imported/required. Because of this change, our `planet` service crashes at launch:

```sh
/telescope/src/api/planet/src/index.js:9
    app.engine('handlebars', expressHandlebars());
                             ^

TypeError: expressHandlebars is not a function
```

This PR changes the way `express-handlebars` is required in the `planet` service, according to their [documentation](https://github.com/express-handlebars/express-handlebars#usage).
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
