### PR TITLE
Fixes #2952: Add extra padding to the content in build log in terminal

### DIFF
--- a/src/api/status/public/css/terminal.css
+++ b/src/api/status/public/css/terminal.css
@@ -14,6 +14,7 @@
 canvas {
   width: 100% !important;
   max-height: 100%;
+  padding: 1rem;
 }
 
 .build-log-title-container {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes Issue #2952 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR will add some extra padding for the content inside the build log in terminal. The picture below is currently `1rem`
<img width="729" alt="Dash Board Terminal Padding" src="https://user-images.githubusercontent.com/69607880/157262516-1fd00c35-ee2e-4b1d-b2d3-f8d4d55e3c93.png">


## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->
- Change `autodeploymentUrl` in `src\api\status\public\js\build-log\check-build-status.js`
```
const autodeploymentUrl = (path) => `//dev.telescope.cdot.systems/deploy${path}`;
```
- Allow all `connectSrc` in `src\api\status\src\server.js`
```
connectSrc: ["'self'", "*"],
```
- Change the current directory to `api` service: `cd src/api/status`
- Run `pnpm dev` and go to `localhost:1111` on your browser

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
