### PR TITLE
Set up ESLint for dependency-discovery

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,15 +145,19 @@ importers:
 
   src/api/dependency-discovery:
     specifiers:
+      '@senecacdot/eslint-config-telescope': workspace:1.0.0
       '@senecacdot/satellite': ^1.26.0
       env-cmd: 10.1.0
+      eslint: 7.32.0
       nodemon: 2.0.15
       query-registry: 2.2.0
     dependencies:
       '@senecacdot/satellite': link:../../satellite
       query-registry: 2.2.0
     devDependencies:
+      '@senecacdot/eslint-config-telescope': link:../../../tools/eslint
       env-cmd: 10.1.0
+      eslint: 7.32.0
       nodemon: 2.0.15
 
   src/api/feed-discovery:

--- a/src/api/dependency-discovery/.eslintrc.js
+++ b/src/api/dependency-discovery/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '@senecacdot/eslint-config-telescope',
+
+  overrides: [
+    {
+      files: ['./**/*.js'],
+      env: {
+        jest: true,
+        commonjs: true,
+        es2021: true,
+        node: true,
+      },
+    },
+  ],
+};

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -5,7 +5,10 @@
   "description": "A dependency graph compilation service for Telescope",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "env-cmd -f env.local nodemon src/server.js"
+    "dev": "env-cmd -f env.local nodemon src/server.js",
+    "lint": "pnpm eslint",
+    "eslint": "eslint --config .eslintrc.js \"**/*.js\"",
+    "eslint-fix": "eslint --config .eslintrc.js \"**/*.js\" --fix"
   },
   "repository": {
     "type": "git",
@@ -22,7 +25,9 @@
     "query-registry": "2.2.0"
   },
   "devDependencies": {
+    "@senecacdot/eslint-config-telescope": "workspace:1.0.0",
     "env-cmd": "10.1.0",
+    "eslint": "7.32.0",
     "nodemon": "2.0.15"
   }
 }

--- a/src/api/dependency-discovery/src/dependency-list.js
+++ b/src/api/dependency-discovery/src/dependency-list.js
@@ -31,6 +31,11 @@ async function getDependencyList() {
   return Object.keys(dependencies);
 }
 
+async function isPackageDependency(packageName) {
+  const dependencies = await getDependencies();
+  return Object.prototype.hasOwnProperty.call(dependencies, packageName);
+}
+
 async function getNpmPackageInfo(packageName) {
   if (!(await isPackageDependency(packageName))) {
     return null;
@@ -44,11 +49,6 @@ async function getNpmPackageInfo(packageName) {
   }
 
   return dependencies[packageName];
-}
-
-async function isPackageDependency(packageName) {
-  const dependencies = await getDependencies();
-  return Object.prototype.hasOwnProperty.call(dependencies, packageName);
 }
 
 module.exports = {

--- a/src/api/dependency-discovery/test/dependency.test.js
+++ b/src/api/dependency-discovery/test/dependency.test.js
@@ -14,10 +14,11 @@ const depsList = [
 ];
 
 jest.mock('../src/dependency-list');
+const { __setMockDepList } = require('../src/dependency-list');
 
 describe('GET /projects', () => {
   beforeEach(() => {
-    require('../src/dependency-list').__setMockDepList(depsList);
+    __setMockDepList(depsList);
   });
 
   test('Should return 200 and an array of dependencies', async () => {


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3154 

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR sets up the eslint configuration for the `dependency-discovery` service. It also fixes current eslint issues that occurred when running the linter.

## Steps to test the PR

1. Pull my changes
2. Checkout my branch (`git checkout issue-3154`)
3. Ensure you have the proper dependencies installed (`pnpm install`)
4. Run `pnpm lint`.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
