### PR TITLE
Ignore img tag when using linkifier

### DIFF
--- a/src/api/parser/src/data/post.js
+++ b/src/api/parser/src/data/post.js
@@ -151,7 +151,7 @@ class Post {
     }
 
     // Wrap an <a> tag on any link inside our content
-    article.content = linkifyHtml(article.content);
+    article.content = linkifyHtml(article.content, { ignoreTags: ['img'] });
 
     let html;
     try {

--- a/src/web/src/components/Posts/Post.tsx
+++ b/src/web/src/components/Posts/Post.tsx
@@ -327,13 +327,6 @@ function handleZoom(e: MouseEvent) {
     e.preventDefault();
     zoomInImage(e.target);
   }
-  // if the user clicks an anchor with an image inside, do not open the image link in a new tab.
-  else if (
-    e.target instanceof HTMLAnchorElement &&
-    e.target.firstChild instanceof HTMLImageElement
-  ) {
-    e.preventDefault();
-  }
 }
 
 const PostComponent = ({ postUrl, currentPost, totalPosts }: Props) => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixed #2941 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
Ignore `img` tag when `linkify`
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR
At the `root` directory remove `redis-data`

```
rm -r redis-data
```

Rebuild images, `pnpm services:start` and wait for `redis` to cache the feeds 
<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
