### PR TITLE
Use docker.cdot.systems image for feed-discovery in production

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -115,6 +115,10 @@ services:
   dependency-discovery:
     restart: unless-stopped
 
+  feed-discovery:
+    image: docker.cdot.systems/feed-discovery
+    restart: unless-stopped
+
   ##############################################################################
   # Third-Party Dependencies and Support Services
   ##############################################################################


### PR DESCRIPTION
This will have production/staging prefer the image on docker.cdot.systems instead of building from source.