### PR TITLE
Use `replace` instead of `replaceAll`

### DIFF
--- a/tools/collect-dependencies.js
+++ b/tools/collect-dependencies.js
@@ -25,7 +25,7 @@ const regex = /.*\.pnpm\/(@?[^@]+).*/g;
 
 console.log('Processing file...');
 const packageNames = [
-  ...new Set([...output.matchAll(regex)].map((results) => results[1].replaceAll('+', '/')).sort()),
+  ...new Set([...output.matchAll(regex)].map((results) => results[1].replace('+', '/')).sort()),
 ];
 
 const buffer = packageNames.join('\n');


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3181

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Since `replaceAll` is only used in nodejs v15 or above, and npm uses nodejs v14 (for some reason that I do not know), it is impossible to use `replaceAll`.

## Steps to test the PR

1. Pull my changes
2. Change to my branch
3. Remove `postversion` command from the package.json, or modify it so that it pushes the changes to your fork (`git push origin master`).
4. Run `pnpm version 2.8.1 -m "Version 2.8.1"`.

After this, the `deps.txt` should have project names.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
