### PR TITLE
Update Satellite to ElasticSearch 8.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,8 +379,8 @@ importers:
 
   src/satellite:
     specifiers:
-      '@elastic/elasticsearch': 7.17.0
-      '@elastic/elasticsearch-mock': 0.3.1
+      '@elastic/elasticsearch': 8.1.0
+      '@elastic/elasticsearch-mock': 2.0.0
       '@godaddy/terminus': 4.10.2
       '@senecacdot/eslint-config-telescope': latest
       cors: 2.8.5
@@ -401,8 +401,8 @@ importers:
       pino-pretty: 7.5.3
       pretty-quick: 3.1.3
     dependencies:
-      '@elastic/elasticsearch': 7.17.0
-      '@elastic/elasticsearch-mock': 0.3.1
+      '@elastic/elasticsearch': 8.1.0
+      '@elastic/elasticsearch-mock': 2.0.0
       '@godaddy/terminus': 4.10.2
       cors: 2.8.5
       express: 4.17.3
@@ -2718,6 +2718,14 @@ packages:
       into-stream: 6.0.0
     dev: false
 
+  /@elastic/elasticsearch-mock/2.0.0:
+    resolution: {integrity: sha512-VACQF7GStt8DetY91aJhXCYog6zXM0Vyb62k592EEt3aB4plrOLot+JvlLMC4URjh2jt9qYfER9hn4AI+ULTSw==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      find-my-way: 5.2.0
+      into-stream: 6.0.0
+    dev: false
+
   /@elastic/elasticsearch/7.16.0:
     resolution: {integrity: sha512-lMY2MFZZFG3om7QNHninxZZOXYx3NdIUwEISZxqaI9dXPoL3DNhU31keqjvx1gN6T74lGXAzrRNP4ag8CJ/VXw==}
     engines: {node: '>=12'}
@@ -2730,14 +2738,26 @@ packages:
       - supports-color
     dev: false
 
-  /@elastic/elasticsearch/7.17.0:
-    resolution: {integrity: sha512-5QLPCjd0uLmLj1lSuKSThjNpq39f6NmlTy9ROLFwG5gjyTgpwSqufDeYG/Fm43Xs05uF7WcscoO7eguI3HuuYA==}
+  /@elastic/elasticsearch/8.1.0:
+    resolution: {integrity: sha512-IiZ6u77C7oYYbUkx/YFgEJk6ZtP+QDI97VaUWiYD14xIdn/w9WJtmx/Y1sN8ov0nZzrWbqScB2Z7Pb8oxo7vqw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@elastic/transport': 8.0.2
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@elastic/transport/8.0.2:
+    resolution: {integrity: sha512-OlDz3WO3pKE9vSxW4wV/mn7rYCtBmSsDwxr64h/S1Uc/zrIBXb0iUsRMSkiybXugXhjwyjqG2n1Wc7jjFxrskQ==}
     engines: {node: '>=12'}
     dependencies:
       debug: 4.3.3
       hpagent: 0.1.2
       ms: 2.1.3
       secure-json-parse: 2.4.0
+      tslib: 2.3.1
+      undici: 4.15.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4987,7 +5007,7 @@ packages:
   /axios/0.21.4_debug@4.3.3:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.7_debug@4.3.3
+      follow-redirects: 1.14.7
     transitivePeerDependencies:
       - debug
     dev: false
@@ -8577,6 +8597,16 @@ packages:
       semver-store: 0.3.0
     dev: false
 
+  /find-my-way/5.2.0:
+    resolution: {integrity: sha512-YLocRSSJJ1PCnrupBmaw2pUcFkU125QTWfFfpdLq11h7bQ+r+Ke4D1/4v7UkERlw0037VkYMd+1RMGTbhFCbPw==}
+    engines: {node: '>=12'}
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      safe-regex2: 2.0.0
+      semver-store: 0.3.0
+    dev: false
+
   /find-pkg/0.1.2:
     resolution: {integrity: sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=}
     engines: {node: '>=0.10.0'}
@@ -8655,18 +8685,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.14.7_debug@4.3.3:
-    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.3
-    dev: false
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -16177,6 +16195,11 @@ packages:
   /undefsafe/2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
+
+  /undici/4.15.1:
+    resolution: {integrity: sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==}
+    engines: {node: '>=12.18'}
+    dev: false
 
   /unfetch/4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}

--- a/src/satellite/jest.config.js
+++ b/src/satellite/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
   rootDir: '../..',
   testMatch: ['<rootDir>/src/satellite/test.js'],
   collectCoverageFrom: ['<rootDir>/src/satellite/src/**/*.js'],
+  moduleDirectories: ['<rootDir>/src/satellite/node_modules', 'node_modules'],
 };

--- a/src/satellite/package.json
+++ b/src/satellite/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/satellite#readme",
   "dependencies": {
-    "@elastic/elasticsearch": "7.17.0",
-    "@elastic/elasticsearch-mock": "0.3.1",
+    "@elastic/elasticsearch": "8.1.0",
+    "@elastic/elasticsearch-mock": "2.0.0",
     "@godaddy/terminus": "4.10.2",
     "cors": "2.8.5",
     "express": "4.17.3",

--- a/src/satellite/test.js
+++ b/src/satellite/test.js
@@ -992,72 +992,118 @@ describe('Redis()', () => {
 });
 
 describe('Elastic()', () => {
-  describe('Tests for regular Elastic()', () => {
-    test('Testing the name property which should be a string', async () => {
-      const client = Elastic();
+  let client;
+  let mock;
 
-      const clientInfo = await client.info();
-
-      expect(clientInfo.statusCode).toBe(200);
-    });
+  beforeEach(() => {
+    client = Elastic();
+    mock = client.mock;
+    mock.clearAll();
   });
 
-  describe('Tests for mock Elastic()', () => {
-    let client;
-    let mock;
+  afterAll(() => {
+    mock.clearAll();
+  });
 
-    beforeEach(() => {
-      client = Elastic();
-      mock = client.mock;
-      mock.clearAll();
-    });
-
-    afterAll(() => {
-      mock.clearAll();
-    });
-
-    test('Should mock an API', async () => {
-      mock.add(
-        {
-          method: 'GET',
-          path: '/_cat/indices',
-        },
-        () => {
-          return { status: 'ok' };
-        }
-      );
-
-      const response = await client.cat.indices();
-      expect(response.body).toStrictEqual({ status: 'ok' });
-      expect(response.statusCode).toBe(200);
-    });
-
-    test('If an API is not mocked correctly, it should return a 404', async () => {
-      let response;
-
-      mock.add(
-        {
-          method: 'GET',
-          path: '/_cat/health',
-          querystring: { pretty: 'true' },
-        },
-        () => {
-          return { status: 'ok' };
-        }
-      );
-
-      try {
-        response = await client.cat.health();
-      } catch (err) {
-        expect(err instanceof errors.ResponseError).toBe(true);
-        expect(err.body).toStrictEqual({ error: 'Mock not found' });
-        expect(err.statusCode).toBe(404);
+  test('Should mock an API', async () => {
+    mock.add(
+      {
+        method: 'GET',
+        path: '/_cat/indices',
+      },
+      () => {
+        return { status: 'ok' };
       }
+    );
 
-      response = await client.cat.health({ pretty: true });
-      expect(response.body).toStrictEqual({ status: 'ok' });
-      expect(response.statusCode).toBe(200);
+    const response = await client.cat.indices({}, { meta: true });
+    expect(response.body).toStrictEqual({ status: 'ok' });
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('If an API is not mocked correctly, it should return a 404', async () => {
+    let response;
+
+    mock.add(
+      {
+        method: 'GET',
+        path: '/_cat/health',
+        querystring: { pretty: 'true' },
+      },
+      () => {
+        return { status: 'ok' };
+      }
+    );
+
+    try {
+      response = await client.cat.health();
+    } catch (err) {
+      expect(err instanceof errors.ResponseError).toBe(true);
+      expect(err.body).toStrictEqual({ error: 'Mock not found' });
+      expect(err.statusCode).toBe(404);
+    }
+
+    response = await client.cat.health({ pretty: true }, { meta: true });
+    expect(response.body).toStrictEqual({ status: 'ok' });
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('mock.clearAll() will work for mocks that share the same client', async () => {
+    const mockResults1 = { text: 'first result' };
+    const mockResults2 = { text: 'second result' };
+
+    mock.add(
+      {
+        method: ['POST', 'GET'],
+        path: '/posts/_search',
+      },
+      () => {
+        return mockResults1;
+      }
+    );
+
+    let response = await client.search({
+      index: 'posts',
+      query: { match_all: {} },
     });
+    expect(response).toStrictEqual(mockResults1);
+
+    // Adding a second mock without clearing
+    mock.add(
+      {
+        method: ['POST', 'GET'],
+        path: '/posts/_search',
+      },
+      () => {
+        return mockResults2;
+      }
+    );
+
+    response = await client.search({
+      index: 'posts',
+      query: { match_all: {} },
+    });
+    // Will not get the results of the new mock
+    expect(response).toStrictEqual(mockResults1);
+
+    // Clearing mocks before adding a new mock
+    mock.clearAll();
+    mock.add(
+      {
+        method: ['POST', 'GET'],
+        path: '/posts/_search',
+      },
+      () => {
+        return mockResults2;
+      }
+    );
+
+    response = await client.search({
+      index: 'posts',
+      query: { match_all: {} },
+    });
+    // Will get the results of the new mock as expected
+    expect(response).toStrictEqual(mockResults2);
   });
 });
 


### PR DESCRIPTION
Other changes in the Satellite folder
- update ElasticSearch-mock to 2.0.0 
- update jest.config.js
- fixup ES tests

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR is part of #2913 
The idea is to update ElasticSearch and ElasticSearch-mock first in Satellite, release Satellite, and then use the updated version of Satellite. 
In the PR Satellite is updated and the Satellite tests will pass. 
```
pnpm test satellite
```
However, Search tests are breaking. Do note I only updated ES and ES-mock inside Satellite, and have not touched the Search service or any other Telescope code outside of Satellite. 
This is a result of having Satellite within our monorepo and `pnpm` creating conflicts between Satellite and Telescope. 
Details of the bug are in #3191 


