### PR TITLE
feat: Banner image placeholder and fallback background

### DIFF
--- a/src/api/image/src/lib/photos.js
+++ b/src/api/image/src/lib/photos.js
@@ -37,6 +37,15 @@ function getRandomPhotoFilename() {
   return path.join(photosDir, photoFilename);
 }
 
+// If users want to get a specific photo but don't know the file name, they have an option
+// to specify the index of the photo to get a consistent photo vs a random one everytime
+// Treat photos as a circular array, any index value >= 0 is valid
+function getPhotoAt(index) {
+  const atIndex = index < 0 ? 0 : index % photos.length;
+  const photoFilename = photos[atIndex];
+  return path.join(photosDir, photoFilename);
+}
+
 // Get a specific image filename from the photos/ directory.
 function getPhotoFilename(image) {
   return path.join(photosDir, image);
@@ -45,5 +54,6 @@ function getPhotoFilename(image) {
 exports.download = download;
 exports.getRandomPhotoFilename = getRandomPhotoFilename;
 exports.getPhotoFilename = getPhotoFilename;
+exports.getPhotoAt = getPhotoAt;
 exports.photosDir = photosDir;
 exports.getPhotos = () => [...photos];

--- a/src/api/image/test/image.test.js
+++ b/src/api/image/test/image.test.js
@@ -11,6 +11,14 @@ describe('/image', () => {
     request(app).get('/default.jpg').expect(200, done);
   });
 
+  it('should return 200 when requesting an image at an index', (done) => {
+    request(app).get('/138').expect(200, done);
+  });
+
+  it('should return the default image when requesting an image at a negative index', (done) => {
+    request(app).get('/-23').expect(200, done);
+  });
+
   it('should return 200 when requesting no image', (done) => {
     request(app).get('/').expect(200, done);
   });
@@ -67,8 +75,8 @@ describe('/image', () => {
     request(app).get('/?w=one').expect(400, done);
   });
 
-  it('should return 400 if width is under 200', (done) => {
-    request(app).get('/?w=199').expect(400, done);
+  it('should return 400 if width is under 40', (done) => {
+    request(app).get('/?w=39').expect(400, done);
   });
 
   it('should return 400 if width is over 2000', (done) => {
@@ -79,8 +87,8 @@ describe('/image', () => {
     request(app).get('/?h=one').expect(400, done);
   });
 
-  it('should return 400 if height is under 200', (done) => {
-    request(app).get('/?h=199').expect(400, done);
+  it('should return 400 if height is under 40', (done) => {
+    request(app).get('/?h=39').expect(400, done);
   });
 
   it('should return 400 if height is over 3000', (done) => {

--- a/src/web/src/components/Banner.tsx
+++ b/src/web/src/components/Banner.tsx
@@ -116,9 +116,10 @@ const useStyles = makeStyles((theme: Theme) =>
 
 type BannerProps = {
   onVisibilityChange: (visible: boolean) => void;
+  bannerVisible: boolean;
 };
 
-export default function Banner({ onVisibilityChange }: BannerProps) {
+export default function Banner({ onVisibilityChange, bannerVisible }: BannerProps) {
   const classes = useStyles();
   const [gitInfo, setGitInfo] = useState({
     gitHubUrl: '',
@@ -180,7 +181,7 @@ export default function Banner({ onVisibilityChange }: BannerProps) {
   return (
     <>
       <div className={classes.heroBanner} ref={bannerAnchor}>
-        <BannerDynamicItems />
+        <BannerDynamicItems visible={bannerVisible} />
         <BannerButtons />
       </div>
       <div className={classes.textsContainer}>

--- a/src/web/src/components/BannerButtons.tsx
+++ b/src/web/src/components/BannerButtons.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { makeStyles, Tooltip, withStyles, Zoom } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
+import clsx from 'clsx';
 import useAuth from '../hooks/use-auth';
 import TelescopeAvatar from './TelescopeAvatar';
 import PopUp from './PopUp';
@@ -55,9 +56,10 @@ const BannerButtons = () => {
 
   return (
     <div
-      className={`${classes.buttonsContainer} ${
+      className={clsx(
+        classes.buttonsContainer,
         user?.isRegistered ? classes.userSignedInClass : classes.userNotSignedClass
-      }`}
+      )}
     >
       {user && !user?.isRegistered && (
         <PopUp

--- a/src/web/src/components/BannerDynamicItems.tsx
+++ b/src/web/src/components/BannerDynamicItems.tsx
@@ -1,29 +1,44 @@
-import { makeStyles, Theme } from '@material-ui/core/styles';
-import DynamicImage from './DynamicImage';
+import { makeStyles } from '@material-ui/core/styles';
+import NoSsr from '@material-ui/core/NoSsr';
 
-const useStyles = makeStyles((theme: Theme) => ({
+import DynamicImage from './DynamicImage';
+import { imageServiceUrl } from '../config';
+
+const useStyles = makeStyles((theme) => ({
   dynamic: {
     height: '100vh',
     transition: 'opacity 1s ease-in-out',
     backgroundColor: theme.palette.primary.main,
     opacity: 0.9,
-    [theme.breakpoints.down(1024)]: {
-      height: 'calc(100vh - 64px)',
-    },
-    [theme.breakpoints.down('xs')]: {
-      height: 'calc(100vh - 56px)',
-    },
+    backgroundSize: 'cover',
+    backgroundPosition: '50% 0',
+    backgroundImage:
+      'linear-gradient(to right bottom, #51f2e4, #00cbea, #00a0ee, #0071e0, #0c39b7);',
   },
 }));
 
-const BannerDynamicText = () => {
+// the placeholder and the main image must refer to the same source
+// we use this to request a consistent image vs a random one
+const index = Math.floor(Math.random() * 999);
+
+type BannerImageProps = {
+  visible?: boolean;
+};
+
+const BannerDynamicItems = ({ visible = true }: BannerImageProps) => {
   const classes = useStyles();
+
+  const imageURL = `${imageServiceUrl}/${index}/`;
+  const placeholderURL = `${imageURL}?w=40`;
 
   return (
     <div className={classes.dynamic}>
-      <DynamicImage />
+      {/** prevent server-side rendering of the random banner images, which won't match with the client */}
+      <NoSsr>
+        <DynamicImage imageURL={imageURL} placeholderURL={placeholderURL} visible={visible} />
+      </NoSsr>
     </div>
   );
 };
 
-export default BannerDynamicText;
+export default BannerDynamicItems;

--- a/src/web/src/pages/index.tsx
+++ b/src/web/src/pages/index.tsx
@@ -5,13 +5,16 @@ import Posts from '../components/Posts';
 import NavBar from '../components/NavBar';
 
 const Home = () => {
-  const [bannerIsVisible, setBannerVisibility] = useState(true);
+  const [bannerVisible, setBannerVisibility] = useState(true);
   return (
     <>
       <SEO pageTitle="Telescope" />
-      <Banner onVisibilityChange={(visible) => setBannerVisibility(visible)} />
+      <Banner
+        onVisibilityChange={(visible) => setBannerVisibility(visible)}
+        bannerVisible={bannerVisible}
+      />
       <main className="main">
-        <NavBar disabled={bannerIsVisible} />
+        <NavBar disabled={bannerVisible} />
         <Posts />
       </main>
     </>

--- a/src/web/src/pages/signup.tsx
+++ b/src/web/src/pages/signup.tsx
@@ -10,7 +10,7 @@ import BasicInfo from '../components/SignUp/Forms/BasicInfo';
 import GitHubAccount from '../components/SignUp/Forms/GitHubAccount';
 import RSSFeeds from '../components/SignUp/Forms/RSSFeeds';
 import Review from '../components/SignUp/Forms/Review';
-import DynamicImage from '../components/DynamicImage';
+import DynamicImage from '../components/BannerDynamicItems';
 
 import { SignUpForm } from '../interfaces';
 import formModels from '../components/SignUp/Schema/FormModel';
@@ -65,11 +65,6 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     imageContainer: {
-      minHeight: '100vh',
-      width: '100vw',
-      position: 'absolute',
-      top: '0',
-      bottom: '0',
       zIndex: -1,
       [theme.breakpoints.down(600)]: {
         display: 'none',

--- a/tools/eslint/index.js
+++ b/tools/eslint/index.js
@@ -118,5 +118,7 @@ module.exports = {
      * https://github.com/lirantal/eslint-plugin-anti-trojan-source
      */
     'anti-trojan-source/no-bidi': 'error',
+
+    'no-bitwise': ['error', { int32Hint: true }],
   },
 };


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #2925

- Add loading banner image background by displaying a tiny 40px wide image (minimal loading time) and transitioning  in the main 2000px wide image (long loading time) when it finishes loading 
- Add fallback gradient banner background
- Fix inconsistent image src, request a specific photo versus a random image chosen by the backend

## Test
- Pull this change locally
- Run server: 
 ```
    cd src/api/image && pnpm dev

    // in another terminal
    cp config/env.staging .env

    // change IMAGE_URL in .env
    # Image Service URL
    IMAGE_URL=http://localhost:4444

   // Run the frontend
   pnpm dev
```
- to see that a gradient background is shown first, followed by a placeholder image, and then the high resolution image.
- If you are not able to see the difference, your internet is probably too fast, good. Go to the Network tab, click `disable cache`, and choose one of the `throttling` options.

## Screenshot

https://user-images.githubusercontent.com/51073515/158033934-5b8e2ca1-6a07-43be-9c0f-ba5c27bb7fa6.mp4


