### PR TITLE
Set up buildx before running containers in e2e tests for caching

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
+      - uses: docker/setup-buildx-action@v1
       - uses: microsoft/playwright-github-action@v1
       - name: Start microservices and run e2e tests
         run: |


### PR DESCRIPTION
In order for the Docker layer caching to work, we need to use the `buildx` Docker plugin.  This adds it to our e2e tests so that we can pull cached layers from our docker.cdot.systems registry that were created by CI.

When I do this locally with `buildx`, I can see the cached layers being used for some of the build steps:

```
...
#7 [auth] image:pull token for docker.cdot.systems
#7 DONE 0.0s

#6 importing cache manifest from docker.cdot.systems/image:buildcache
#6 DONE 1.0s
...
```