### PR TITLE
[satellite]: use Satellite from npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,3 +8,5 @@ tag-version-prefix=""
 # Don't use ^ when adding packages, prefix with nothing, see:
 # https://pnpm.io/npmrc#save-prefix
 save-prefix=""
+
+link-workspace-packages=false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
       '@babel/preset-env': 7.16.11_@babel+core@7.17.5
       '@babel/preset-react': 7.16.7_@babel+core@7.17.5
       '@babel/preset-typescript': 7.16.7_@babel+core@7.17.5
-      '@senecacdot/eslint-config-telescope': 1.0.0
+      '@senecacdot/eslint-config-telescope': link:tools/eslint
       '@types/jest': 27.4.1
       '@typescript-eslint/eslint-plugin': 4.33.0_2951ba233cd46bb4e0f2f0a3f7fe108e
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
@@ -159,7 +159,7 @@ importers:
       '@senecacdot/satellite': 1.27.0
       query-registry: 2.2.0
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.0
+      '@senecacdot/eslint-config-telescope': link:../../../tools/eslint
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -345,7 +345,7 @@ importers:
       xterm-addon-web-links: 0.5.1_xterm@4.18.0
       xterm-addon-webgl: 0.11.4_xterm@4.18.0
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.0
+      '@senecacdot/eslint-config-telescope': link:../../../tools/eslint
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -378,7 +378,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@docusaurus/types': 2.0.0-beta.17
-      '@senecacdot/eslint-config-telescope': 1.0.0
+      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
       eslint: 7.32.0
 
   src/satellite:
@@ -421,7 +421,7 @@ importers:
       pino-http: 6.6.0
       pino-pretty: 7.5.3
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.0
+      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
       eslint: 7.32.0
       get-port: 5.1.1
       jest: 27.5.1
@@ -494,7 +494,7 @@ importers:
       swr: 1.2.2_react@17.0.2
       yup: 0.32.11
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.0
+      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
       '@testing-library/react': 12.1.4_react-dom@17.0.2+react@17.0.2
       '@types/node': 16.11.26
       '@types/react': 17.0.40
@@ -3571,10 +3571,6 @@ packages:
       picomatch: 2.3.1
       rollup: 2.64.0
     dev: false
-
-  /@senecacdot/eslint-config-telescope/1.0.0:
-    resolution: {integrity: sha512-YgxzZb1c4lz9JQVI89ajMD7COgjbNeIKZXOLnfCqSQxtkb91o4D9/uf1fVdzjZ8FIWvpmLPHIwwtrREVp/UtkA==}
-    dev: true
 
   /@senecacdot/satellite/1.27.0:
     resolution: {integrity: sha512-Eq8g6dKMYRV2EDEcYApodHOlqOcYV0kVKqMF+DJZsGgFJjQFXYqrLhc2zQ+3Ms9AbjjhL3rso9GAuRxsy5A+zQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
       '@babel/preset-env': 7.16.11_@babel+core@7.17.5
       '@babel/preset-react': 7.16.7_@babel+core@7.17.5
       '@babel/preset-typescript': 7.16.7_@babel+core@7.17.5
-      '@senecacdot/eslint-config-telescope': link:tools/eslint
+      '@senecacdot/eslint-config-telescope': 1.0.0
       '@types/jest': 27.4.1
       '@typescript-eslint/eslint-plugin': 4.33.0_2951ba233cd46bb4e0f2f0a3f7fe108e
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
@@ -156,10 +156,10 @@ importers:
       nodemon: 2.0.15
       query-registry: 2.2.0
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       query-registry: 2.2.0
     devDependencies:
-      '@senecacdot/eslint-config-telescope': link:../../../tools/eslint
+      '@senecacdot/eslint-config-telescope': 1.0.0
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -171,7 +171,7 @@ importers:
       got: 11.8.3
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       cheerio: 1.0.0-rc.10
       got: 11.8.3
     devDependencies:
@@ -186,7 +186,7 @@ importers:
       nodemon: 2.0.15
       sharp: 0.30.2
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       celebrate: 15.0.1
       got: 11.8.3
       sharp: 0.30.2
@@ -214,7 +214,7 @@ importers:
     dependencies:
       '@bull-board/api': 3.10.0
       '@bull-board/express': 3.10.0
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       bull: 3.29.3
       clean-whitespace: 0.1.2
       highlight.js: 11.4.0
@@ -237,7 +237,7 @@ importers:
       express-handlebars: 6.0.3
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       express: 4.17.3
       express-handlebars: 6.0.3
     devDependencies:
@@ -255,7 +255,7 @@ importers:
       normalize-url: 6.1.0
       supertest: 6.1.6
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       bull: 3.29.3
       express-validator: 6.14.0
       ioredis: 4.28.5
@@ -271,7 +271,7 @@ importers:
       express-validator: 6.14.0
       nodemon: 2.0.15
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       express-validator: 6.14.0
     devDependencies:
       nodemon: 2.0.15
@@ -290,7 +290,7 @@ importers:
       passport: 0.5.2
       passport-saml: 3.2.1
     dependencies:
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       '@supabase/supabase-js': 1.29.4
       celebrate: 15.0.1
       connect-redis: 6.1.1
@@ -331,7 +331,7 @@ importers:
       '@octokit/plugin-retry': 3.0.9
       '@octokit/plugin-throttling': 3.5.2_@octokit+core@3.5.1
       '@popperjs/core': 2.11.3
-      '@senecacdot/satellite': link:../../satellite
+      '@senecacdot/satellite': 1.27.0
       bootstrap: 5.1.3_@popperjs+core@2.11.3
       express: 4.17.3
       express-handlebars: 6.0.3
@@ -345,7 +345,7 @@ importers:
       xterm-addon-web-links: 0.5.1_xterm@4.18.0
       xterm-addon-webgl: 0.11.4_xterm@4.18.0
     devDependencies:
-      '@senecacdot/eslint-config-telescope': link:../../../tools/eslint
+      '@senecacdot/eslint-config-telescope': 1.0.0
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -378,7 +378,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@docusaurus/types': 2.0.0-beta.17
-      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
+      '@senecacdot/eslint-config-telescope': 1.0.0
       eslint: 7.32.0
 
   src/satellite:
@@ -421,7 +421,7 @@ importers:
       pino-http: 6.6.0
       pino-pretty: 7.5.3
     devDependencies:
-      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
+      '@senecacdot/eslint-config-telescope': 1.0.0
       eslint: 7.32.0
       get-port: 5.1.1
       jest: 27.5.1
@@ -494,7 +494,7 @@ importers:
       swr: 1.2.2_react@17.0.2
       yup: 0.32.11
     devDependencies:
-      '@senecacdot/eslint-config-telescope': link:../../tools/eslint
+      '@senecacdot/eslint-config-telescope': 1.0.0
       '@testing-library/react': 12.1.4_react-dom@17.0.2+react@17.0.2
       '@types/node': 16.11.26
       '@types/react': 17.0.40
@@ -515,7 +515,7 @@ importers:
       shelljs: 0.8.5
     dependencies:
       '@octokit/webhooks': 9.15.0
-      '@senecacdot/satellite': link:../../src/satellite
+      '@senecacdot/satellite': 1.27.0
       date-fns: 2.28.0
       dotenv: 10.0.0
       merge-stream: 2.0.0
@@ -3570,6 +3570,34 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.3.1
       rollup: 2.64.0
+    dev: false
+
+  /@senecacdot/eslint-config-telescope/1.0.0:
+    resolution: {integrity: sha512-YgxzZb1c4lz9JQVI89ajMD7COgjbNeIKZXOLnfCqSQxtkb91o4D9/uf1fVdzjZ8FIWvpmLPHIwwtrREVp/UtkA==}
+    dev: true
+
+  /@senecacdot/satellite/1.27.0:
+    resolution: {integrity: sha512-Eq8g6dKMYRV2EDEcYApodHOlqOcYV0kVKqMF+DJZsGgFJjQFXYqrLhc2zQ+3Ms9AbjjhL3rso9GAuRxsy5A+zQ==}
+    engines: {node: '>=14.0.0', pnpm: '>=6'}
+    dependencies:
+      '@elastic/elasticsearch': 7.17.0
+      '@elastic/elasticsearch-mock': 0.3.1
+      '@godaddy/terminus': 4.10.2
+      cors: 2.8.5
+      express: 4.17.3
+      express-jwt: 6.1.1
+      helmet: 5.0.2
+      http-errors: 2.0.0
+      ioredis: 4.28.5
+      ioredis-mock: 7.1.0_ioredis@4.28.5
+      jsonwebtoken: 8.5.1
+      node-fetch: 2.6.7
+      pino: 7.8.0
+      pino-http: 6.6.0
+      pino-pretty: 7.5.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: false
 
   /@sideway/address/4.1.3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,5 @@ packages:
   - 'src/satellite'
   # autodeployment
   - 'tools/*'
+
+link-workspace-packages: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,3 @@ packages:
   - 'src/satellite'
   # autodeployment
   - 'tools/*'
-
-link-workspace-packages: false

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -28,8 +28,8 @@
     "react-native-web": "0.17.6"
   },
   "devDependencies": {
-    "@senecacdot/eslint-config-telescope": "1.0.0",
     "@babel/core": "7.17.5",
+    "@senecacdot/eslint-config-telescope": "1.0.0",
     "eslint": "7.32.0"
   },
   "private": true


### PR DESCRIPTION
fix #3191

By default, available packages listed in pnpm-workspaces are linked to node_modules instead of being downloaded from the registry to save space.

This adds an option to make pnpm to use Satellite on npm vs the package.