### PR TITLE
Switch deploy webhook URL to deal with redirects

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -26,6 +26,6 @@ jobs:
     uses: Seneca-CDOT/telescope/.github/workflows/deploy-webhook.yml@master
     with:
       deploy_tag: staging
-      webhook_url: https://dev.telescope.cdot.systems/deploy
+      webhook_url: https://dev.telescope.cdot.systems:4000
     secrets:
       webhook_token: ${{ secrets.STAGING_WEBHOOK_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,6 @@ jobs:
     uses: Seneca-CDOT/telescope/.github/workflows/deploy-webhook.yml@master
     with:
       deploy_tag: production
-      webhook_url: https://telescope.cdot.systems/deploy
+      webhook_url: https://telescope.cdot.systems:4000
     secrets:
       webhook_token: ${{ secrets.PRODUCTION_WEBHOOK_SECRET }}


### PR DESCRIPTION
I was using the `/deploy` URLs for the deploy webhook, but testing tonight with @manekenpix makes me think that it's not handling the redirect properly.  So I'm going to try changing it to use the actual webhook URLs at port 4000.