### PR TITLE
Fix #3212 - allow cross-origin image loading for image service

### DIFF
--- a/src/api/image/src/index.js
+++ b/src/api/image/src/index.js
@@ -3,7 +3,14 @@ const { Satellite } = require('@senecacdot/satellite');
 const image = require('./routes/image');
 const gallery = require('./routes/gallery');
 
-const service = new Satellite();
+const service = new Satellite({
+  helmet: {
+    // Allow cross-origin image loading, see:
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+    // https://stackoverflow.com/questions/70752554/ressources-not-loaded-after-setting-csp-and-corp-headers-using-helmet/70757856#70757856
+    crossOriginEmbedderPolicy: false,
+  },
+});
 
 service.router.use('/gallery', gallery);
 service.router.use('/', image);

--- a/src/api/image/test/image.test.js
+++ b/src/api/image/test/image.test.js
@@ -111,3 +111,11 @@ describe('/image', () => {
       });
   });
 });
+
+it('should not block cross-origin resource embedding', (done) => {
+  request(app)
+    .get('/')
+    .expect(200)
+    .expect((res) => expect(res.headers['cross-origin-embedder-policy']).toBeUndefined())
+    .end(done);
+});


### PR DESCRIPTION
I think this will fix the change in helmet, stopping us from loading images cross-origin.