### PR TITLE
Fixes #3212: Banner image failed to load because CORS violation

### DIFF
--- a/src/api/image/src/index.js
+++ b/src/api/image/src/index.js
@@ -3,7 +3,13 @@ const { Satellite } = require('@senecacdot/satellite');
 const image = require('./routes/image');
 const gallery = require('./routes/gallery');
 
-const service = new Satellite();
+const options = {
+  helmet: {
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+  },
+};
+
+const service = new Satellite(options);
 
 service.router.use('/gallery', gallery);
 service.router.use('/', image);


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3212 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR changes the cross origin resource policy (CORP) in the image service so images can be fetched by both our servers' front-end or a locally deployed instance of our front-end

![image](https://user-images.githubusercontent.com/23108901/158713545-b4351330-ec45-406f-b810-497aab12ff11.png)

## Steps to test the PR

Run the front-end locally but using `staging` as back-end (`staging` is currently running with the changes in this PR).
1. Make `env.staging` your `.env` file
```sh
cp config/env.staging .env
```
2. Run the front-end
```sh
pnpm dev
```
Your hero banner image should be loaded.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
