### PR TITLE
Reduce memory usage for elasticsearch in development

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -62,10 +62,11 @@ services:
   elasticsearch:
     ports:
       - '9200:9200'
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
+    environment:
+      # Use the minimum possible RAM in development
+      - 'ES_JAVA_OPTS=-Xms256m -Xmx256m'
+      # We only run a single node
+      - discovery.type=single-node
 
   sso:
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -329,13 +329,6 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1
     container_name: 'elasticsearch'
-    environment:
-      - bootstrap.memory_lock=true
-      - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
-      - discovery.type=single-node
-    # See the following:
-    # - https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-docker.html,
-    # - https://github.com/deviantony/docker-elk/issues/243
 
   rss-bridge:
     image: rssbridge/rss-bridge:2022-01-20

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -179,6 +179,13 @@ services:
     labels:
       # Disable Elasticsearch routing via Traefik in production (we enable it in development)
       - 'traefik.enable=false'
+    environment:
+      # Prefer memory to swap (faster)
+      - bootstrap.memory_lock=true
+      # Limit the initial heap size. By default it will use 1/4 of available RAM
+      - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
+      # We only run a single node
+      - discovery.type=single-node
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
This reduces elasticsearch's memory usage in development by 50%:

```sh
$ docker stats --no-stream
CONTAINER ID   NAME            CPU %     MEM USAGE / LIMIT     MEM %     NET I/O        BLOCK I/O    PIDS
96f7cd128f72   elasticsearch   0.89%     567.6MiB / 9.718GiB   5.70%     46MB / 501kB   0B / 182MB   81
```

I don't think we can go lower than this, based on docs I've been reading today.  I've also removed the requirements to not use swap in development, since we don't care about speed as much as memory footprint.

Part of #3241.