### PR TITLE
add TIMING=1 to eslint scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm turbo run build",
     "dev": "pnpm dev --prefix src/web --",
     "develop": "pnpm dev",
-    "eslint": "eslint --config .eslintrc.js \"./src/backend/**/*.js\" \"./test/**/*.js\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"./src/backend/**/*.js\" \"./test/**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"./src/backend/**/*.js\" \"./test/**/*.js\" --fix",
     "lint": "pnpm turbo run lint && pnpm eslint",
     "clean": "pnpm turbo run clean && pnpm -r exec rm -rf node_modules",

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dependency-discovery",
+  "name": "@senecacdot/dependency-discovery",
   "private": true,
   "version": "0.1.0",
   "description": "A dependency graph compilation service for Telescope",
@@ -7,7 +7,7 @@
     "start": "node src/server.js",
     "dev": "env-cmd -f env.local nodemon src/server.js",
     "lint": "pnpm eslint",
-    "eslint": "eslint --config .eslintrc.js \"**/*.js\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"**/*.js\" --fix"
   },
   "repository": {

--- a/src/api/image/package.json
+++ b/src/api/image/package.json
@@ -8,7 +8,7 @@
     "start": "node src/server.js",
     "clean": "find ./photos -type f -not -name 'default.jpg' -delete",
     "lint": "pnpm eslint",
-    "eslint": "eslint --config .eslintrc.js \"**/*.js\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"**/*.js\" --fix"
   },
   "repository": "Seneca-CDOT/telescope",

--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -11,7 +11,7 @@
     "watch:server": "env-cmd -f env.local nodemon src/server.js",
     "compile:js": "vite build",
     "watch:js": "vite build --watch",
-    "eslint": "eslint --config .eslintrc.js \"./src/**/*.js\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"./src/**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"./src/**/*.js\" --fix",
     "lint": "pnpm eslint"
   },

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -10,7 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --port 4631 --host 0.0.0.0",
-    "eslint": "eslint --config .eslintrc.js \"**/*.js\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"**/*.js\" --fix",
     "lint": "pnpm eslint",
     "clean": "rm -rf .docusaurus .turbo build",

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -8,7 +8,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "eject": "expo eject",
-    "eslint": "eslint --config .eslintrc.js \"**/*.{js,jsx}\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"**/*.{js,jsx}\"",
     "eslint-fix": "eslint --config .eslintrc.js \"**/*.{js,jsx}\" --fix",
     "lint": "pnpm eslint"
   },

--- a/src/satellite/package.json
+++ b/src/satellite/package.json
@@ -7,7 +7,7 @@
     "test:watch": "jest --watch",
     "test": "jest -c jest.config.js",
     "coverage": "jest -c jest.config.js --collect-coverage",
-    "eslint": "eslint --config .eslintrc.js \"./src/**/*.js\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"./src/**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"./src/**/*.js\" --fix",
     "lint": "pnpm eslint"
   },

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -5,7 +5,7 @@
     "build": "next build && next export",
     "dev": "next dev -p 8000",
     "start": "next start -p 8000",
-    "eslint": "eslint --config .eslintrc.js \"**/*.{js,jsx,ts,tsx}\"",
+    "eslint": "TIMING=1 eslint --config .eslintrc.js \"**/*.{js,jsx,ts,tsx}\"",
     "eslint-fix": "eslint --config .eslintrc.js \"**/*.{js,jsx,ts,tsx}\" --fix",
     "lint": "pnpm eslint",
     "clean": "rm -rf .next .turbo out"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

According to Turborepo, this is a [Pro Tip](https://turborepo.org/docs/features/caching)

![2022-03-17 22_16_04-Window](https://user-images.githubusercontent.com/36822198/158924670-c1a4f7b0-e4de-4ef6-9645-0e7d779bfb98.png)

Adds [TIMING=1](https://eslint.org/docs/1.0.0/developer-guide/working-with-rules#per-rule-performance) to track performance of individual rules. If we ever see a 0% on a rule that means we're not using that rule at all so it should be removed. We currently don't have anything that is 0% so we are using all the rules we've added


Sample result table from our Next.js app.
```
@senecacdot/telescope-frontend:lint: Rule                              | Time (ms) | Relative
@senecacdot/telescope-frontend:lint: :---------------------------------|----------:|--------:
@senecacdot/telescope-frontend:lint: prettier/prettier                 |  5011.008 |    48.9%
@senecacdot/telescope-frontend:lint: import/namespace                  |  1114.608 |    10.9%
@senecacdot/telescope-frontend:lint: import/no-cycle                   |   494.245 |     4.8%
@senecacdot/telescope-frontend:lint: @typescript-eslint/no-unused-vars |   249.607 |     2.4%
@senecacdot/telescope-frontend:lint: react/no-did-update-set-state     |   173.411 |     1.7%
@senecacdot/telescope-frontend:lint: react/destructuring-assignment    |   162.198 |     1.6%
@senecacdot/telescope-frontend:lint: import/order                      |   154.950 |     1.5%
@senecacdot/telescope-frontend:lint: react/no-deprecated               |   139.315 |     1.4%
@senecacdot/telescope-frontend:lint: react/static-property-placement   |   128.156 |     1.3%
@senecacdot/telescope-frontend:lint: no-redeclare                      |   123.126 |     1.2%
```

We currently have 6 projects in our workspace configured with ESLint and the root


## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
