### PR TITLE
Wait on postgres to become ready before running sso e2e tests

### DIFF
--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -161,6 +161,11 @@ services:
     image: supabase/postgres:14.1.0
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     restart: unless-stopped
+    ports:
+      # XXX: we need access to the postgres port on localhost for our e2e tests in dev,
+      # since they need to wait on the postgres db to become ready before starting.
+      # See src/api/sso/jest.config.e2e.js
+      - '5432:5432'
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,7 @@ importers:
 
   src/api/sso:
     specifiers:
+      '@jcoreio/wait-for-postgres': 2.0.0
       '@senecacdot/satellite': ^1.27.0
       '@supabase/supabase-js': 1.29.4
       celebrate: 15.0.1
@@ -304,6 +305,7 @@ importers:
       passport: 0.5.2
       passport-saml: 3.2.1
     devDependencies:
+      '@jcoreio/wait-for-postgres': 2.0.0
       env-cmd: 10.1.0
       nodemon: 2.0.15
 
@@ -2793,6 +2795,23 @@ packages:
   /@istanbuljs/schema/0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
+
+  /@jcoreio/poll/2.3.1:
+    resolution: {integrity: sha512-NKtnakQBJVwu5//JgR2NIL1chYSEtiSXT4qj19Ia7CXqAG7WvzRSBa8nZtNyFwnNVMMP0UXz1g1JfLq1KYXBeA==}
+    dependencies:
+      '@babel/runtime': 7.17.2
+    dev: true
+
+  /@jcoreio/wait-for-postgres/2.0.0:
+    resolution: {integrity: sha512-GbBmn9Mo/3+KABREQcM7zaESilZH16ZHSPOV0c+34RLjxU0d04EzvmkN1mQrS88wLsj0ANCO3iGr7sAADdcquw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      '@jcoreio/poll': 2.3.1
+      p-event: 4.2.0
+      pg: 8.7.3
+    transitivePeerDependencies:
+      - pg-native
+    dev: true
 
   /@jest/console/27.5.1:
     resolution: {integrity: sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==}
@@ -5379,6 +5398,11 @@ packages:
   /buffer-indexof/1.1.1:
     resolution: {integrity: sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==}
     dev: false
+
+  /buffer-writer/2.0.0:
+    resolution: {integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==}
+    engines: {node: '>=4'}
+    dev: true
 
   /buffer/5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -12333,10 +12357,16 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /p-event/4.2.0:
+    resolution: {integrity: sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-timeout: 3.2.0
+    dev: true
+
   /p-finally/1.0.0:
     resolution: {integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=}
     engines: {node: '>=4'}
-    dev: false
 
   /p-is-promise/3.0.0:
     resolution: {integrity: sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==}
@@ -12419,7 +12449,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
-    dev: false
 
   /p-try/1.0.0:
     resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}
@@ -12474,6 +12503,10 @@ packages:
       registry-auth-token: 4.2.1
       registry-url: 5.1.0
       semver: 6.3.0
+
+  /packet-reader/1.0.0:
+    resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
+    dev: true
 
   /pako/0.2.9:
     resolution: {integrity: sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=}
@@ -12665,6 +12698,62 @@ packages:
   /perfect-scrollbar/1.5.5:
     resolution: {integrity: sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==}
     dev: false
+
+  /pg-connection-string/2.5.0:
+    resolution: {integrity: sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==}
+    dev: true
+
+  /pg-int8/1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+    dev: true
+
+  /pg-pool/3.5.1_pg@8.7.3:
+    resolution: {integrity: sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==}
+    peerDependencies:
+      pg: '>=8.0'
+    dependencies:
+      pg: 8.7.3
+    dev: true
+
+  /pg-protocol/1.5.0:
+    resolution: {integrity: sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==}
+    dev: true
+
+  /pg-types/2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+    dev: true
+
+  /pg/8.7.3:
+    resolution: {integrity: sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=2.0.0'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+    dependencies:
+      buffer-writer: 2.0.0
+      packet-reader: 1.0.0
+      pg-connection-string: 2.5.0
+      pg-pool: 3.5.1_pg@8.7.3
+      pg-protocol: 1.5.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    dev: true
+
+  /pgpass/1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+    dependencies:
+      split2: 4.1.0
+    dev: true
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -13404,6 +13493,28 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: false
+
+  /postgres-array/2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /postgres-bytea/1.0.0:
+    resolution: {integrity: sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /postgres-date/1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /postgres-interval/1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      xtend: 4.0.2
+    dev: true
 
   /prebuild-install/7.0.1:
     resolution: {integrity: sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==}
@@ -15154,7 +15265,6 @@ packages:
   /split2/4.1.0:
     resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
     engines: {node: '>= 10.x'}
-    dev: false
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
@@ -17269,7 +17379,6 @@ packages:
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
-    dev: false
 
   /xterm-addon-fit/0.5.0_xterm@4.18.0:
     resolution: {integrity: sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==}

--- a/src/api/sso/jest.config.e2e.js
+++ b/src/api/sso/jest.config.e2e.js
@@ -1,14 +1,33 @@
+const { waitForPostgres } = require('@jcoreio/wait-for-postgres');
+
 const baseConfig = require('../../../jest.config.base');
 
-module.exports = {
-  ...baseConfig,
-  rootDir: '../../..',
-  testMatch: ['<rootDir>/src/api/sso/test/e2e/**/*.test.js'],
-  collectCoverageFrom: ['<rootDir>/src/api/sso/src/**/*.js'],
-  // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright
-  // See the jest-playwright config in the Telescope root ./jest-playwright.config.js
-  preset: 'jest-playwright-preset',
-  // Try reducing the number of tests that can run at once down to 1
-  maxConcurrency: 1,
-  maxWorkers: 1,
+module.exports = async () => {
+  try {
+    console.log('Waiting for Supabase postgres container to become ready...');
+    await waitForPostgres({
+      host: 'localhost',
+      user: 'postgres',
+      password: process.env.POSTGRES_PASSWORD,
+      database: 'postgres',
+      timeout: 60 * 1000,
+    });
+  } catch (err) {
+    console.warn('Unable to connect to postgres container');
+    throw err;
+  }
+
+  console.log('Supabase postgres container ready.');
+  return {
+    ...baseConfig,
+    rootDir: '../../..',
+    testMatch: ['<rootDir>/src/api/sso/test/e2e/**/*.test.js'],
+    collectCoverageFrom: ['<rootDir>/src/api/sso/src/**/*.js'],
+    // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright
+    // See the jest-playwright config in the Telescope root ./jest-playwright.config.js
+    preset: 'jest-playwright-preset',
+    // Try reducing the number of tests that can run at once down to 1
+    maxConcurrency: 1,
+    maxWorkers: 1,
+  };
 };

--- a/src/api/sso/package.json
+++ b/src/api/sso/package.json
@@ -28,6 +28,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
+    "@jcoreio/wait-for-postgres": "2.0.0",
     "env-cmd": "10.1.0",
     "nodemon": "2.0.15"
   }


### PR DESCRIPTION
We discovered that the `postgres` db container that Supabase runs needs a long time to become ready, even after Docker says that the container is up.  If we run our tests during this time, they will fail.  This explains why they sometimes fail and sometimes are OK.

This change will have our e2e tests wait on the postgres db to become actually ready (able to handle a connection).

We will need to leave the postgres port open for local dev, but close it in production for Supabase.

Fixes #3031