### PR TITLE
Use BuildKit with all Docker build commands for cache

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -10,22 +10,33 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x]
+    env:
+      # Whichever Docker containers are needed to pass e2e tests, define them here
+      DOCKER_CONTAINERS: 'sso feed-discovery auth login kong rest meta'
+
     steps:
       - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.0.1
-        with:
-          version: 6.23.5
+
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: 3.x
+
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 6
+
       - uses: actions/setup-node@v2.5.1
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+          cache: pnpm
+
       - uses: docker/setup-buildx-action@v1
-      - uses: microsoft/playwright-github-action@v1
-      - name: Start microservices and run e2e tests
-        run: |
-          pnpm install
-          pnpm services:start
-          pnpm jest:e2e
+
+      - name: Install playwright
+        uses: microsoft/playwright-github-action@v1
+
+      # Pull, build, and run containers, then start e2e tests
+      - run: pnpm install
+      - name: Pull/Build Docker Containers Necessary for Running E2E Tests
+        run: docker compose --env-file ./config/env.development up -d ${{ env.DOCKER_CONTAINERS }}
+      - run: pnpm jest:e2e

--- a/bin/services-pull.js
+++ b/bin/services-pull.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { pull } = require('../tools/services');
+
+pull();

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -194,6 +194,7 @@ services:
       - JWT_SECRET
     depends_on:
       - traefik
+      - rss-bridge
     labels:
       # Enable Traefik
       - 'traefik.enable=true'

--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - 'traefik.http.middlewares.strip_kong_prefix.stripprefix.prefixes=/${API_VERSION}/supabase'
       - 'traefik.http.middlewares.strip_kong_prefix.stripprefix.forceSlash=true'
       - 'traefik.http.routers.kong.middlewares=strip_kong_prefix'
+
   auth:
     container_name: supabase-auth
     image: supabase/gotrue:v2.5.22

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postversion": "git push upstream master --tags",
     "services:start": "node bin/services-start.js --",
     "services:stop": "node bin/services-stop.js",
+    "services:pull": "node bin/services-pull.js",
     "services:logs": "node bin/services-logs.js --",
     "services:clean": "node bin/services-clean.js",
     "prepare": "husky install",

--- a/src/docs/docs/api-services/api.md
+++ b/src/docs/docs/api-services/api.md
@@ -25,22 +25,46 @@ In conjunction with these, there are also multiple environment files, including:
 The env files are configured to specify which variables and docker-compose files are needed to be run.
 For most developers, doing the following will work:
 
+```sh
+pnpm services:start
 ```
+
+This will `build` any containers that need to be (re)built, and `pull` any that aren't present on the local machine. It is functionally equivalent to running:
+
+```sh
 docker-compose --env-file config/env.development up -d
 ```
 
-## Running the Services via docker-compose
+:::note
 
-You can access logs for one or more services:
+Telescope runs more than a dozen Docker containers, and it can be taxing on your computer to start them all. The `pnpm services:start` command can optionally take a list of specific services to start, for example: `pnpm services:start feed-discovery status`. The names of the services comes from the various `docker-compose.yml` files listed above.
 
+:::
+
+## Managing the Services
+
+If you want to update your local Docker images based on the most recent code built in our Continuous Integration builders, you can use:
+
+```sh
+pnpm services:pull
 ```
+
+You can access logs for one or more running services:
+
+```sh
 pnpm services:logs image status
 ```
 
 To stop the services:
 
-```
+```sh
 pnpm services:stop
+```
+
+To delete old containers:
+
+```sh
+pnpm services:clean
 ```
 
 ## API Lookup Table

--- a/tools/services.js
+++ b/tools/services.js
@@ -29,6 +29,20 @@ module.exports.start = async (services) => {
   }
 };
 
+module.exports.pull = async () => {
+  // Pull images for the containers
+  try {
+    const { exitCode } = await dockerCompose.pullAll({
+      ...defaultOptions,
+      commandOptions: ['--ignore-pull-failures'],
+    });
+    process.exit(exitCode);
+  } catch (err) {
+    console.error(`Error pulling services with docker-compose: ${err.message}`);
+    process.exit(1);
+  }
+};
+
 module.exports.stop = async () => {
   // Stop the api service containers
   try {


### PR DESCRIPTION
I want to see if I can force `docker-compose` to use BuildKit and the caching behaviour we want for our image builds.  This might not work, I need to test in CI.