### PR TITLE
Update eslint-config-telescope dependencies to 1.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
 
   src/api/dependency-discovery:
     specifiers:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
       env-cmd: 10.1.0
       eslint: 7.32.0
@@ -157,7 +157,7 @@ importers:
       query-registry: 2.2.0
       supertest: 6.1.6
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -177,7 +177,7 @@ importers:
 
   src/api/image:
     specifiers:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
       celebrate: 15.0.1
       del-cli: 4.0.1
@@ -193,7 +193,7 @@ importers:
       sharp: 0.30.2
       supertest: 6.1.6
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       del-cli: 4.0.1
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -315,7 +315,7 @@ importers:
       '@octokit/plugin-retry': 3.0.9
       '@octokit/plugin-throttling': 3.5.2
       '@popperjs/core': 2.11.3
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
       bootstrap: 5.1.3
       env-cmd: 10.1.0
@@ -351,7 +351,7 @@ importers:
       xterm-addon-web-links: 0.5.1_xterm@4.18.0
       xterm-addon-webgl: 0.11.4_xterm@4.18.0
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.15
@@ -364,7 +364,7 @@ importers:
       '@docusaurus/preset-classic': 2.0.0-beta.17
       '@docusaurus/types': 2.0.0-beta.17
       '@mdx-js/react': 1.6.22
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0
       '@types/react': 17.0.40
       clsx: 1.1.1
       eslint: 7.32.0
@@ -390,7 +390,7 @@ importers:
     devDependencies:
       '@algolia/client-search': 4.9.1
       '@docusaurus/types': 2.0.0-beta.17
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       '@types/react': 17.0.40
       eslint: 7.32.0
       eslint-plugin-import: 2.25.4_eslint@7.32.0
@@ -402,7 +402,7 @@ importers:
       '@elastic/elasticsearch': 7.17.0
       '@elastic/elasticsearch-mock': 0.3.1
       '@godaddy/terminus': 4.10.2
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0
       cors: 2.8.5
       eslint: 7.32.0
       express: 4.17.3
@@ -437,7 +437,7 @@ importers:
       pino-http: 6.6.0
       pino-pretty: 7.5.3
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       eslint: 7.32.0
       get-port: 5.1.1
       jest: 27.5.1
@@ -455,7 +455,7 @@ importers:
       '@mui/icons-material': 5.5.1
       '@mui/material': 5.5.1
       '@mui/styles': 5.5.1
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0
       '@testing-library/react': 12.1.4
       '@types/node': 16.11.26
       '@types/react': 17.0.40
@@ -524,7 +524,7 @@ importers:
       swr: 1.2.2_react@17.0.2
       yup: 0.32.11
     devDependencies:
-      '@senecacdot/eslint-config-telescope': 1.0.1
+      '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       '@types/node': 16.11.26
       '@types/react': 17.0.40
       '@typescript-eslint/eslint-plugin': 4.33.0_cc617358c89d3f38c52462f6d809db4c
@@ -3925,6 +3925,14 @@ packages:
 
   /@senecacdot/eslint-config-telescope/1.0.1:
     resolution: {integrity: sha512-3z+lsxelKP9keBoI57SgS7r3gFCsLscNGRL5FpBqXEdk2+0ogw6tazQNIeeE1n4lrNPjdxh4quxfxvdtOm+3kA==}
+    dev: true
+
+  /@senecacdot/eslint-config-telescope/1.1.0_eslint@7.32.0:
+    resolution: {integrity: sha512-JOwz2UJOoKlPDRDNEzX8KwKNZFuJITFTX0Y/R6GxOSl3YRqqUL5Rv07jOSsjsYHkOxDN8uhURLNDchkc38ZrwA==}
+    peerDependencies:
+      eslint: 7.32.0
+    dependencies:
+      eslint: 7.32.0
     dev: true
 
   /@senecacdot/satellite/1.27.0:

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -26,7 +26,7 @@
     "supertest": "6.1.6"
   },
   "devDependencies": {
-    "@senecacdot/eslint-config-telescope": "1.0.1",
+    "@senecacdot/eslint-config-telescope": "1.1.0",
     "env-cmd": "10.1.0",
     "eslint": "7.32.0",
     "nodemon": "2.0.15"

--- a/src/api/image/package.json
+++ b/src/api/image/package.json
@@ -28,7 +28,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-   "@senecacdot/eslint-config-telescope": "1.0.1",
+   "@senecacdot/eslint-config-telescope": "1.1.0",
     "del-cli": "4.0.1",
     "eslint": "7.32.0",
     "nodemon": "2.0.15"

--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -44,7 +44,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "@senecacdot/eslint-config-telescope": "1.0.1",
+    "@senecacdot/eslint-config-telescope": "1.1.0",
     "env-cmd": "10.1.0",
     "eslint": "7.32.0",
     "nodemon": "2.0.15",

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@algolia/client-search": "4.9.1",
     "@docusaurus/types": "2.0.0-beta.17",
-    "@senecacdot/eslint-config-telescope": "1.0.1",
+    "@senecacdot/eslint-config-telescope": "1.1.0",
     "@types/react": "17.0.40",
     "eslint": "7.32.0",
     "typescript": "4.4.4",

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.17.5",
-    "@senecacdot/eslint-config-telescope": "1.0.0",
+    "@senecacdot/eslint-config-telescope": "1.1.0",
     "eslint": "7.32.0",
     "eslint-plugin-react-native": "4.0.0"
   },

--- a/src/satellite/package.json
+++ b/src/satellite/package.json
@@ -39,7 +39,7 @@
     "pnpm": ">=6"
   },
   "devDependencies": {
-    "@senecacdot/eslint-config-telescope": "1.0.1",
+    "@senecacdot/eslint-config-telescope": "1.1.0",
     "eslint": "7.32.0",
     "get-port": "5.1.1",
     "jest": "27.5.1",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -47,7 +47,7 @@
     "yup": "0.32.11"
   },
   "devDependencies": {
-    "@senecacdot/eslint-config-telescope": "1.0.1",
+    "@senecacdot/eslint-config-telescope": "1.1.0",
     "@testing-library/react": "12.1.4",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",


### PR DESCRIPTION
Fix ESlint error by using the latest `eslint-config-telescope` version.