### PR TITLE
Get GitHub issues from dependency repo

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,7 @@ importers:
 
   src/api/dependency-discovery:
     specifiers:
+      '@octokit/request': 5.6.3
       '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
       env-cmd: 10.1.0
@@ -163,6 +164,7 @@ importers:
       query-registry: 2.2.0
       supertest: 6.1.6
     dependencies:
+      '@octokit/request': 5.6.3
       '@senecacdot/satellite': 1.27.0
       query-registry: 2.2.0
       supertest: 6.1.6

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
+    "@octokit/request": "5.6.3",
     "@senecacdot/satellite": "^1.27.0",
     "query-registry": "2.2.0",
     "supertest": "6.1.6"

--- a/src/api/dependency-discovery/src/dependency-list.js
+++ b/src/api/dependency-discovery/src/dependency-list.js
@@ -2,6 +2,7 @@ const { readFile } = require('fs/promises');
 const { join } = require('path');
 const { cwd } = require('process');
 const { getPackument } = require('query-registry');
+const { requestGitHubInfo } = require('./github');
 
 const getDependencies = (function () {
   let dependencies = null;
@@ -51,8 +52,15 @@ async function getNpmPackageInfo(packageName) {
   return dependencies[packageName];
 }
 
+async function getGitHubIssues(packageName) {
+  const npmPackage = await getNpmPackageInfo(packageName);
+
+  return requestGitHubInfo(packageName, npmPackage.gitRepository.url);
+}
+
 module.exports = {
   getDependencyList,
   getNpmPackageInfo,
   isPackageDependency,
+  getGitHubIssues,
 };

--- a/src/api/dependency-discovery/src/github.js
+++ b/src/api/dependency-discovery/src/github.js
@@ -1,0 +1,66 @@
+const { request } = require('@octokit/request');
+
+// Check whether a specific time has reached the GitHub time limit.
+// @param {Date} datetime - a Date object representing a moment in the past
+// @returns {Boolean}
+const hasGitHubExpired = (dateTime) => new Date() - dateTime > 60 * 60 * 1000;
+
+const gitHubInformationRequestor = {};
+
+async function constructGitHubRequest(gitHubUrl) {
+  const labels = ['hacktoberfest', 'good first issue', 'help wanted'];
+
+  const [owner, repo] = new URL(gitHubUrl).pathname.substring(1).split('/');
+
+  const requestPromises = labels.map((label) => {
+    return request('GET /repos/{owner}/{repo}/issues{?assignee,state,labels}', {
+      owner,
+      repo,
+      assignee: 'none',
+      state: 'open',
+      labels: label,
+    });
+  });
+
+  // A single request might look like a response in
+  // https://docs.github.com/en/rest/reference/issues#list-repository-issues
+  const responses = await Promise.all(requestPromises);
+
+  return responses
+    .filter((response) => response.status === 200)
+    .flatMap((response) =>
+      response.data.map((issue) => {
+        return {
+          htmlUrl: issue.html_url,
+          title: issue.title,
+          body: issue.body,
+          createdAt: issue.created_at,
+        };
+      })
+    )
+    .filter((issue, index, array) => array.findIndex((i) => i.htmlUrl === issue.htmlUrl) === index);
+}
+
+function requestGitHubInfo(packageName, gitHubUrl) {
+  const cachedRequest = gitHubInformationRequestor[packageName];
+
+  if (cachedRequest && !hasGitHubExpired(cachedRequest.expireAt)) {
+    return cachedRequest.request;
+  }
+
+  const newRequest = constructGitHubRequest(gitHubUrl);
+
+  const now = new Date();
+  now.setHours(now.getHours() + 1);
+
+  gitHubInformationRequestor[packageName] = {
+    expireAt: now,
+    request: newRequest,
+  };
+
+  return newRequest;
+}
+
+module.exports = {
+  requestGitHubInfo,
+};

--- a/src/api/dependency-discovery/src/router.js
+++ b/src/api/dependency-discovery/src/router.js
@@ -1,5 +1,10 @@
 const { Router } = require('@senecacdot/satellite');
-const { getDependencyList, getNpmPackageInfo, isPackageDependency } = require('./dependency-list');
+const {
+  getDependencyList,
+  getNpmPackageInfo,
+  getGitHubIssues,
+  isPackageDependency,
+} = require('./dependency-list');
 
 const router = Router();
 
@@ -27,6 +32,23 @@ router.get('/projects/:namespace/:name?', async (req, res, next) => {
     } else {
       res.set('Cache-Control', 'max-age=3600');
       res.status(200).json(await getNpmPackageInfo(packageName));
+    }
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/github/:namespace/:name?', async (req, res, next) => {
+  const { namespace, name } = req.params;
+  const packageName = name ? `${namespace}/${name}` : namespace;
+
+  try {
+    if (!(await isPackageDependency(packageName))) {
+      res.status(404).json({ msg: `${packageName} is not a Telescope dependency` });
+      next();
+    } else {
+      res.set('Cache-Control', 'max-age=3600');
+      res.status(200).json(await getGitHubIssues(packageName));
     }
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #2827 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds the whole GitHub issue thing to collect issues that are considered newcomer friendly.

### A couple of details

This doesn't use Redis, at all. I tried to use Redis at first, but it seems that using it is somewhat redundant when the `githubInformationRequestor` is used. The reason I use this is to minimize the number of requests as possible when there are concurrent requests to the same resource. If we program this naively, when there are two or more requests really close to each other, all of those requests will ask essentially the same information, and thus we would be wasting requests.

I will file a couple of issues to address some stuff that have to be changed:
- use Redis instead of a *requestor*, this would imply some rewriting of the whole service, probably.
- use a GitHub Key for the service to use so that we have an increased rate limit on staging and production.

## Steps to test the PR

1. Pull the changes
2. Go to the `dependency-discovery` folder.
3. Start the service with `pnpm dev`.
4. You should be able to request the service from your browser. For example, `GET https://localhost:10500/github/@babel/core`

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
