### PR TITLE
Add GitHub schema to Postgres

### DIFF
--- a/docker/supabase/volumes/db/init/05-github-schema.sql
+++ b/docker/supabase/volumes/db/init/05-github-schema.sql
@@ -1,0 +1,36 @@
+CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA extensions;
+
+CREATE TABLE IF NOT EXISTS github_users (
+  id serial PRIMARY KEY,
+  login citext NOT NULL, -- the user name of the user, known as the `login` field in GitHub API responses
+  type citext check ( type IN ('user', 'organization') ) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS github_repositories (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  owner integer NOT NULL references github_users ON DELETE CASCADE,
+  UNIQUE (owner, name) -- a user cannot have the same repository, but a repository name can be repeated for many users (e.g. forks)
+);
+
+-- In the GitHub API, pull requests are considered issues, too.
+-- Therefore, we would group both pull requests and issues in a single
+-- table. For more information, read:
+-- https://docs.github.com/en/rest/reference/issues and
+-- https://docs.github.com/en/rest/reference/pulls
+CREATE TABLE IF NOT EXISTS github_issues (
+  id serial PRIMARY KEY,
+  number integer NOT NULL,
+  repo integer NOT NULL references github_repositories ON DELETE CASCADE,
+  type citext check ( type IN ('issue', 'pull_request') ) NOT NULL,
+  UNIQUE (repo, number) -- an issue number is unique across the whole repo, but several repos can have the same number
+);
+
+/* 
+  TODO:
+    * Add policies to restrict the users who can write into these
+      tables (preferably, only the search or parser microservice
+      should write).
+    * Add bridge tables that connect this GitHub information to
+      a posts table that contains the posts themselves.
+ */


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3215

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [X] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds a new table schema to Postgres to store the GitHub data we will scrape from the posts.

## Steps to test the PR

1. Pull the changes.
2. Start the services (`pnpm run services:start`).
3. Go to `localhost:8910`.
4. Head over the default project and then find the database tables. There should be tables named `github_users`, `github_repositories`, and `github_issues`.

## Checklist

<!-- Before submitting a PR, address each item -->

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
