### PR TITLE
Implement Author Autocomplete (legacy backend and Search)

### DIFF
--- a/src/api/search/src/bin/validation.js
+++ b/src/api/search/src/bin/validation.js
@@ -44,14 +44,25 @@ const ValidationRules = [
     .bail(),
 ];
 
+const authorRules = [
+  check('author')
+    .exists({ checkFalsy: true })
+    .withMessage('author should exist')
+    .bail()
+    .isLength({ max: 100, min: 1 })
+    .withMessage('invalid author value')
+    .bail(),
+];
+
 /**
  * Validates query by passing rules. The rules are different based on the pathname
- * of the request. If the pathname is '/' it is the basic route.
- * Otherwise, if '/advanced/' it is the advanced search
+ * of the request. If the pathname is '/' it is the advanced search route.
+ * Otherwise, if '/authors/autocomplete, it is the author autocomplete route
  */
 const validateQuery = () => {
   return async (req, res, next) => {
-    await Promise.all(ValidationRules.map((rule) => rule.run(req)));
+    const rules = req.route.path === '/' ? ValidationRules : authorRules;
+    await Promise.all(rules.map((rule) => rule.run(req)));
 
     const result = validationResult(req);
     if (result.isEmpty()) {

--- a/src/api/search/src/routes/query.js
+++ b/src/api/search/src/routes/query.js
@@ -1,12 +1,21 @@
 const { Router, createError } = require('@senecacdot/satellite');
 const { validateQuery } = require('../bin/validation');
-const { search } = require('../search');
+const { search, authorAutocomplete } = require('../search');
 
 const router = Router();
 
 router.get('/', validateQuery, async (req, res, next) => {
   try {
     res.send(await search(req.query));
+  } catch (error) {
+    next(createError(503, error));
+  }
+});
+
+// query for author autocomplete
+router.get('/authors/autocomplete', validateQuery, async (req, res, next) => {
+  try {
+    res.send(await authorAutocomplete(req.query));
   } catch (error) {
     next(createError(503, error));
   }

--- a/src/api/search/test/query.test.js
+++ b/src/api/search/test/query.test.js
@@ -292,7 +292,7 @@ describe('query routers', () => {
         mock.add(
           {
             method: ['POST', 'GET'],
-            path: '/posts/post/_search',
+            path: '/posts/_search',
           },
           () => {
             return mockResults;
@@ -352,7 +352,7 @@ describe('query routers', () => {
       mock.add(
         {
           method: ['POST', 'GET'],
-          path: '/posts/post/_search',
+          path: '/posts/_search',
         },
         () => {
           return mockResults;
@@ -383,7 +383,7 @@ describe('query routers', () => {
       mock.add(
         {
           method: ['POST', 'GET'],
-          path: '/posts/post/_search',
+          path: '/posts/_search',
         },
         () => {
           return mockResults;

--- a/src/backend/utils/indexer.js
+++ b/src/backend/utils/indexer.js
@@ -7,7 +7,86 @@ const { client } = require('../lib/elastic');
 const { logger } = require('./logger');
 
 const index = 'posts';
-const type = 'post';
+
+/*
+  Creates 'posts' index and add settings and mapping for autocomplete if the index doesn't already exist
+  exists API: https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html
+  create API: https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html
+
+  Analysis settings are used to define our custom analyzers and tokenizers
+  analyzer: https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer.html
+  search_analyzer: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-analyzer.html
+
+  Token filters are built in filters to build customized analyzers
+  'lowercase' changes text to lowercase: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lowercase-tokenfilter.html
+  'remove_duplicates' removes duplicate tokens in the same position: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-remove-duplicates-tokenfilter.html
+  creating a custom analyzer: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-custom-analyzer.html
+
+  Edge n-gram tokenizer is used for our custom autocomplete tokenizer
+  tokenizer reference: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenizers.html
+  Edge n-gram tokenizer: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-edgengram-tokenizer.html
+
+  'min_gram' and 'max_gram' are the minimum and maximum length of characters in a gram.
+  There are some max_gram limitations: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-edgengram-tokenizer.html#max-gram-limits
+
+  'token_chars' are character classes that are included in a token.
+  Currently set at 'letter' and 'digit'
+
+  Mapping is used to set the custom author.autocomplete field to use our custom analyzers
+  mapping: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
+  fields: https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html
+*/
+const setupPostsIndex = async () => {
+  try {
+    const response = await client.indices.exists({ index });
+    // If the index doesn't exist, 404 statusCode is returned
+    if (response.statusCode === 404) {
+      await client.indices.create({
+        index,
+        body: {
+          settings: {
+            analysis: {
+              analyzer: {
+                autocomplete_analyzer: {
+                  tokenizer: 'autocomplete',
+                  filter: ['lowercase', 'remove_duplicates'],
+                },
+                autocomplete_search_analyzer: {
+                  tokenizer: 'lowercase',
+                },
+              },
+              tokenizer: {
+                autocomplete: {
+                  type: 'edge_ngram',
+                  min_gram: 1,
+                  max_gram: 20,
+                  token_chars: ['letter', 'digit'],
+                },
+              },
+            },
+          },
+          mappings: {
+            properties: {
+              author: {
+                type: 'text',
+                fields: {
+                  autocomplete: {
+                    type: 'text',
+                    analyzer: 'autocomplete_analyzer',
+                    search_analyzer: 'autocomplete_search_analyzer',
+                  },
+                },
+                analyzer: 'standard',
+              },
+            },
+          },
+        },
+      });
+    }
+  } catch (error) {
+    logger.error({ error }, `Error setting up ${index} index`);
+  }
+};
 
 /**
  * Indexes the text and id from a post
@@ -22,7 +101,6 @@ const indexPost = async ({ text, id, title, published, author }) => {
   try {
     await client.index({
       index,
-      type,
       id,
       body: {
         text,
@@ -44,7 +122,6 @@ const deletePost = async (postId) => {
   try {
     await client.delete({
       index,
-      type,
       id: postId,
     });
   } catch (error) {
@@ -114,7 +191,6 @@ const search = async (
     size: perPage,
     _source: ['id'],
     index,
-    type,
     body: query,
   });
 
@@ -164,6 +240,9 @@ const waitOnReady = async () => {
 
   await clearIntervalAsync(intervalId);
   clearTimeout(timerId);
+
+  // Once elasticsearch is connected, set up `posts` index for autocomplete
+  await setupPostsIndex();
 };
 
 module.exports = {


### PR DESCRIPTION
- Add author autocomplete settings for indexer.js in backend
- refactor Search service to work with new indexing
- create new search query for author autocomplete
- add supertest as a dev-dependency to pass ESLint

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #1417 
also a part of issue #3225 (no new tests are added just yet)

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **New Feature**: Change which adds functionality

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
- In the legacy `backend`, I've added `settings` and `mapping` for the `posts` index to use [edge n-gram](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-edgengram-tokenizer.html) for author autocomplete
- Because we couldn't specify `type` on index creation, I've refactored the `Search` service and tests to work with the new indexing. The current search query is not affected by this new change. `pnpm test search` would pass all tests.
- To get author autocomplete suggestions, I've created a new query out of `Search`, and ways to test it and see it in action is as follows

## Steps to test the PR

- get on my branch, `pnpm install`
- **\*\*Important\*\*** remove `redis` cache `rm -rf redis-data`, this is so the posts can be re-indexed
- build Docker Images
```terminal
 docker-compose --env-file ./config/env.development up --build redis elasticsearch posts traefik search nginx planet
```
- Wait for a bit for ElasticSearch to connect, then `pnpm start`
- Wait a bit for the posts to be indexed
- Can now test `Search` queries at http://localhost/v1/search
- The original Search queries shouldn't be affected. The new query can be tested at  http://localhost/v1/search/authors/autocomplete/
- When `author` is queried, it will return the number of suggested authors, and an array of suggested authors. As the query gets longer, results will be more precise

![image](https://user-images.githubusercontent.com/32626950/159820051-b2e25a34-375d-4e16-b5aa-3b0bfb7bc1ad.png)
![image](https://user-images.githubusercontent.com/32626950/159820068-4636864e-1687-487c-8f1d-784b783a9dd1.png)
![image](https://user-images.githubusercontent.com/32626950/159820178-bd283fb0-495f-4eea-92c5-22ecf0bb04d8.png)
![image](https://user-images.githubusercontent.com/32626950/159820209-2e6f87e3-4445-46a2-be6c-8cab7e0032a2.png)
![image](https://user-images.githubusercontent.com/32626950/159820235-94c09589-6c74-4bf2-982f-74f83668bdc3.png)


<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->
 
## Problems
There is still a lot of tweaking that can be done
- A strict validation for the  http://localhost/v1/search/authors/autocomplete/ isn't yet in place. Currently I am only hijacking the old search validation. If we don't have an `author` query and it passes validation, we'll get a `Error 400`
![image](https://user-images.githubusercontent.com/32626950/159821037-2c2183a3-0ba3-4857-9d5a-3db80ef8afb9.png)
- A query of only one letter won't pass validation, it has to be 2 or more letters. This is part of our rules in `validation.js`
![image](https://user-images.githubusercontent.com/32626950/159821236-b67bad4b-ad56-4091-878b-8eee57f6edee.png)

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)variables are added/changed or an explanation of why it does not(if applicable)
