### PR TITLE
Add pnpm lock file check to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,9 @@ on:
       - 'src/docs/**'
 
 jobs:
+  lockfile:
+    uses: Seneca-CDOT/telescope/.github/workflows/pnpm-lock-check-ci.yml@master
+
   # Confirm that prettier was run on the changes
   prettier:
     uses: Seneca-CDOT/telescope/.github/workflows/prettier-ci.yml@master

--- a/.github/workflows/pnpm-lock-check-ci.yml
+++ b/.github/workflows/pnpm-lock-check-ci.yml
@@ -1,0 +1,21 @@
+name: pnpm lock file check
+
+on:
+  workflow_call:
+
+jobs:
+  # Make sure that the pnpm lock-file of the PR is not broken
+  lockfile:
+    name: Lock file check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.23.5
+      - uses: actions/setup-node@v2.5.1
+        with:
+          cache: 'pnpm'
+      - name: Check lock file with pnpm list
+        run: |
+          pnpm list


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3311 

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds a new CI check to make sure that the `pnpm-lock.yml` is never broken.

## Steps to test the PR

Let the CI run, I guess...

## Checklist

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
