### PR TITLE
Count for \ in regex

### DIFF
--- a/tools/collect-dependencies.js
+++ b/tools/collect-dependencies.js
@@ -21,7 +21,7 @@ const output = execSync('pnpm list -w -r --parseable --depth=2', {
   maxBuffer: 1024 * 1024 * 10, // approx. 10 Megabyte = 1024 bytes per Kilobyte * 1024 Kilobytes per Megabyte * 10 Megabytes
 }).toString('utf8');
 
-const regex = /.*\.pnpm\/(@?[^@]+).*/g;
+const regex = /.*\.pnpm[\/\\](@?[^@]+).*/g;
 
 console.log('Processing file...');
 const packageNames = [


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3276 

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

In Windows, pathnames are separated by backwards slash. Since the regex cannot find a match, the script would produce an empty file.

Thus, we modify the regex to avoid this.

## Steps to test the PR

If you are in Windows (not WSL), please run the following steps:

1. Pull my changes
2. Run the command `node tools/collect-dependencies.js -- -o deps.txt` from the project root
3. Verify that the `deps.txt` is not blank.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
