### PR TITLE
Pass anon_key secret in continuous-delivery.yml workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,6 +14,7 @@ jobs:
     secrets:
       docker_username: ${{ secrets.DOCKER_CDOT_SYSTEMS_USERNAME }}
       docker_password: ${{ secrets.DOCKER_CDOT_SYSTEMS_PASSWORD }}
+      anon_key: ${{ secrets.SUPABASE_ANON_KEY }}
 
   pnpm-publish:
     uses: Seneca-CDOT/telescope/.github/workflows/pnpm-publish.yml@master


### PR DESCRIPTION
We forgot to pass the `SUPBASE_ANON_KEY` secret in the Continuous Delivery workflow, which is required after @joelazwar's supabase front-end changes that just landed.