### PR TITLE
Move anon_key to inputs vs secrets in CI/CD

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,7 +14,6 @@ jobs:
     secrets:
       docker_username: ${{ secrets.DOCKER_CDOT_SYSTEMS_USERNAME }}
       docker_password: ${{ secrets.DOCKER_CDOT_SYSTEMS_PASSWORD }}
-      anon_key: ${{ secrets.SUPABASE_ANON_KEY }}
 
   pnpm-publish:
     uses: Seneca-CDOT/telescope/.github/workflows/pnpm-publish.yml@master

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -52,15 +52,17 @@ on:
         required: false
         default: 'https://dev.api.telescope.cdot.systems/v1/supabase'
         type: string
+      anon_key:
+        description: 'The Supabase Anonymous Key'
+        required: false
+        default: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE'
+        type: string
     secrets:
       docker_username:
         description: 'The Docker Registry username'
         required: true
       docker_password:
         description: 'The Docker Registry password'
-        required: true
-      anon_key:
-        description: 'Anon key used to initialize supabase client'
         required: true
 
 jobs:
@@ -91,7 +93,7 @@ jobs:
               FEED_DISCOVERY_URL=${{ inputs.feed_discovery_url }}
               STATUS_URL=${{ inputs.status_url }}
               SUPABASE_URL=${{ inputs.supabase_url }}
-              ANON_KEY=${{ secrets.anon_key }}
+              ANON_KEY=${{ inputs.anon_key }}
           - context: src/api/planet
             image: planet
           - context: src/api/posts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       feed_discovery_url: 'https://api.telescope.cdot.systems/v1/feed-discovery'
       status_url: 'https://api.telescope.cdot.systems/v1/status'
       supabase_url: 'https://api.telescope.cdot.systems/v1/supabase'
+      anon_key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
     secrets:
       docker_username: ${{ secrets.DOCKER_CDOT_SYSTEMS_USERNAME }}
       docker_password: ${{ secrets.DOCKER_CDOT_SYSTEMS_PASSWORD }}
-      anon_key: ${{ secrets.SUPABASE_ANON_KEY}}
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Today we learned that you can't use `secrets.*` in a build matrix with GitHub Actions, so the `ANON_KEY` has to be an `inputs.*` instead.  We think this is OK, since the anonymous key is being bundled into the front-end (e.g., it's not a secret).

When we change the anon key for production, we need to update this.