### PR TITLE
Update deploy.sh to pull vs. build images

### DIFF
--- a/tools/autodeployment/deploy.sh
+++ b/tools/autodeployment/deploy.sh
@@ -44,8 +44,8 @@ echo "GITHUB_TOKEN=$3" >> $ENV_FILE
 echo "JWT_SECRET=$(uuidgen)" >> $ENV_FILE
 
 
-echo "Building $ENV Container"
-docker-compose --env-file $ENV_FILE --project-name=$ENV build
+echo "Pulling $ENV Containers"
+docker-compose --env-file $ENV_FILE --project-name=$ENV pull
 
 # Delete associated project orphans (services) and volumes
 echo "Stopping "$OLD" Environment"


### PR DESCRIPTION
Our `deploy.sh` autodeployment script needs to be updated for pulling vs. building our containers, now that we have the registry.  This switches the build to use [pull](https://docs.docker.com/compose/reference/pull/) instead.