### PR TITLE
Include github.sha for GIT_COMMIT in build args for CD

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -92,6 +92,7 @@ jobs:
               SEARCH_URL=${{ inputs.search_url }}
               FEED_DISCOVERY_URL=${{ inputs.feed_discovery_url }}
               STATUS_URL=${{ inputs.status_url }}
+              GIT_COMMIT=${{ github.sha }}
               SUPABASE_URL=${{ inputs.supabase_url }}
               ANON_KEY=${{ inputs.anon_key }}
           - context: src/api/planet


### PR DESCRIPTION
The front-end build for nginx needs the `GIT_COMMIT`, but we aren't passing it in with the build args to Docker.  This adds it.