### PR TITLE
Update Dockerfiles for M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,7 @@
 # as a build ARG in API_URL
 
 # Context: Build Context
-FROM node:lts-alpine as build
-
-# Tini Entrypoint for Alpine
-# util-linux required to optimize builds using multiple cores
-RUN apk add --no-cache tini util-linux
-ENTRYPOINT [ "/sbin/tini", "--"]
+FROM node:16 as build
 
 # Set Working Directory Context
 WORKDIR "/telescope"
@@ -40,7 +35,7 @@ RUN npm install --only=production --no-package-lock --ignore-scripts
 
 # -------------------------------------
 # Context: Release
-FROM build AS release
+FROM node:16-alpine3.15 AS release
 
 # GET production code from previous containers
 COPY --from=backend_dependencies /telescope/node_modules /telescope/node_modules

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
 
   # status service
   status:
+    init: true
     container_name: 'status'
     environment:
       - NODE_ENV
@@ -44,6 +45,7 @@ services:
 
   # image service
   image:
+    init: true
     container_name: 'image'
     environment:
       - NODE_ENV
@@ -68,6 +70,7 @@ services:
 
   # sso auth service (connects with Seneca's auth)
   sso:
+    init: true
     container_name: 'sso'
     environment:
       - NODE_ENV
@@ -104,6 +107,7 @@ services:
 
   # search service
   search:
+    init: true
     container_name: 'search'
     environment:
       - NODE_ENV
@@ -133,6 +137,7 @@ services:
 
   # posts service
   posts:
+    init: true
     container_name: 'posts'
     environment:
       - NODE_ENV
@@ -159,6 +164,7 @@ services:
 
   # feed discovery service
   feed-discovery:
+    init: true
     container_name: 'feed-discovery'
     environment:
       - NODE_ENV
@@ -183,6 +189,7 @@ services:
       - 'traefik.http.routers.feed-discovery.middlewares=strip_feed_discovery_prefix'
 
   parser:
+    init: true
     container_name: 'parser'
     environment:
       - NODE_ENV
@@ -213,6 +220,7 @@ services:
 
   # planet service
   planet:
+    init: true
     container_name: 'planet'
     environment:
       - NODE_ENV
@@ -220,6 +228,7 @@ services:
       - POSTS_URL
 
   dependency-discovery:
+    init: true
     container_name: 'dependency-discovery'
     environment:
       - NODE_ENV

--- a/src/api/dependency-discovery/Dockerfile
+++ b/src/api/dependency-discovery/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -16,18 +16,20 @@ RUN pnpm install --prod
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 
 COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
-ENV PORT=10500
+ENV DEPENDENCY_DISCOVERY_PORT=10500
 
 USER node
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${DEPENDENCY_DISCOVERY_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/api/feed-discovery/Dockerfile
+++ b/src/api/feed-discovery/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -16,18 +16,20 @@ RUN pnpm install --prod
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 
 COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
-ENV PORT=9999
+ENV FEED_DISCOVERY_PORT=9999
 
 USER node
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${FEED_DISCOVERY_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/api/image/Dockerfile
+++ b/src/api/image/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -12,22 +12,29 @@ FROM base as dependencies
 
 COPY package.json ./
 
-RUN pnpm install --prod
+# On M1 Macs, we need to force Sharp to use the correct binaries for
+# our container OS and architecture, see https://sharp.pixelplumbing.com/install#cross-platform.
+# However, pnpm doesn't support passing --platform=... to `install`
+# so we need to set this via an environment variable, so it isn't
+# inferred from the host.
+RUN npm_config_platform=linuxmusl pnpm install --prod --ignore-scripts=false
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 
 COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
-ENV PORT=4444
+ENV IMAGE_PORT=4444
 
 USER node
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${IMAGE_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/api/parser/Dockerfile
+++ b/src/api/parser/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -16,7 +16,9 @@ RUN pnpm install --prod
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 

--- a/src/api/planet/Dockerfile
+++ b/src/api/planet/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -16,7 +16,9 @@ RUN pnpm install --prod
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 
@@ -24,10 +26,10 @@ COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
 USER node
 
-ENV PORT=9876
+ENV PLANET_PORT=9876
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${PLANET_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/api/posts/Dockerfile
+++ b/src/api/posts/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -16,18 +16,20 @@ RUN pnpm install --prod
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 
 COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
-ENV PORT=5555
+ENV POSTS_PORT=5555
 
 USER node
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${POSTS_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/api/search/Dockerfile
+++ b/src/api/search/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -16,18 +16,20 @@ RUN pnpm install --prod
 
 ## Deploy ########################################################################
 # Stage for running our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node . .
 
 COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
-ENV PORT=4445
+ENV SEARCH_PORT=4445
 
 USER node
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${SEARCH_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/api/sso/Dockerfile
+++ b/src/api/sso/Dockerfile
@@ -34,8 +34,7 @@ RUN npm install --production
 ## Deploy ######################################################################
 # Use a smaller node image (-alpine) at runtime
 FROM node:lts-alpine as deploy
-# https://github.com/krallin/tini
-RUN apk --no-cache add tini
+
 WORKDIR /home/node/app
 # Copy what we've installed/built from production
 COPY --chown=node:node --from=production /home/node/app/node_modules /home/node/app/node_modules/
@@ -44,4 +43,4 @@ COPY --chown=node:node . /home/node/app/
 # Switch to the node user vs. root
 USER node
 # Start the app
-CMD ["tini", "node", "src/server.js"]
+CMD ["node", "src/server.js"]

--- a/src/api/status/Dockerfile
+++ b/src/api/status/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ###########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 RUN npm i -g pnpm
 
@@ -34,7 +34,9 @@ RUN pnpm build
 
 ## Deploy ########################################################################
 # Stage for that run our app
-FROM base as deploy
+FROM node:16-alpine3.15 as deploy
+
+WORKDIR /app
 
 COPY --chown=node:node --from=dependencies /app/node_modules ./node_modules
 
@@ -44,12 +46,12 @@ COPY --chown=node:node --from=builder /app/scss ./scss
 
 COPY --chown=node:node --from=builder /app/src ./src
 
-ENV PORT=1111
+ENV STATUS_PORT=1111
 
 USER node
 
 # Docker Healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-	CMD wget --no-verbose --tries=1 --spider localhost:${PORT}/healthcheck || exit 1
+	CMD wget --no-verbose --tries=1 --spider localhost:${STATUS_PORT}/healthcheck || exit 1
 
 CMD ["node", "src/server.js"]

--- a/src/web/app/Dockerfile
+++ b/src/web/app/Dockerfile
@@ -15,12 +15,7 @@ ARG WEB_URL
 ARG SUPABASE_URL
 ARG ANON_KEY
 
-FROM node:lts-alpine as base
-
-# Tini Entrypoint for Alpine
-# util-linux required to optimize builds using multiple cores
-RUN apk add --no-cache tini util-linux
-ENTRYPOINT [ "/sbin/tini", "--"]
+FROM node:16 as base
 
 WORKDIR /frontend
 

--- a/src/web/docusaurus/Dockerfile
+++ b/src/web/docusaurus/Dockerfile
@@ -1,6 +1,6 @@
 ## Base ########################################################################
 # Set up the base layer
-FROM node:16-alpine3.15 as base
+FROM node:16 as base
 
 # Reduce npm log spam and colour during install within Docker
 ENV NPM_CONFIG_LOGLEVEL=warn


### PR DESCRIPTION
I can't build our images anymore on my M1 (ARM) laptop.  This changes things to use a larger node image (with build tools like Python) for installing deps, then copies the deps over to an `-alpine` image that's smaller (no build tools, etc).

I've also removed the manual `tini` stuff, and added `init: true` instead, which does this automatically in Docker engine.

I also fixed the `PORT` stuff, since we might as well use the right port naming.