### PR TITLE
Fix: display buid status and total duration

### DIFF
--- a/src/api/status/public/js/build-log/build-header.js
+++ b/src/api/status/public/js/build-log/build-header.js
@@ -49,8 +49,8 @@ function renderLoadingAnimation(code) {
   }
 }
 
-function renderBuildInfo({ isCurrent, githubData, startedDate, stoppedDate, code, sha }) {
-  const { sender, compare } = githubData;
+function renderBuildInfo({ isCurrent, githubData, startedDate, stoppedDate, code }) {
+  const { sender, compare, after: sha } = githubData;
 
   /* Depending on the event type (merge vs release), we extract the message that will be displayed in the header from the appropriate prop */
   const message = githubData.ref ? githubData.head_commit.message : githubData.release.name;


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

After making changes to our `autodeployment` server, the build header stopped displaying status and total duration of current build, This PR fixes that issue.

![image](https://user-images.githubusercontent.com/23108901/160256321-a7662258-988e-44c0-9443-e1606105634e.png)

## Steps to test the PR
- Checkout the branch used for this PR.
- Make sure the build page fetches data from an autodeployment server [here](https://github.com/Seneca-CDOT/telescope/blob/7e9e2b89e884ac040f6dce2d24c248ae51943971/src/api/status/public/js/build-log/check-build-status.js#L44).
- You might need to add the `autodeployment` server's URL to helmet [here](https://github.com/Seneca-CDOT/telescope/blob/7e9e2b89e884ac040f6dce2d24c248ae51943971/src/api/status/src/server.js#L36).
- Navigate to the build page and make sure the build header displays the correct information about the current build.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
