### PR TITLE
docker-compose for Supabase in dev/prod

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -15,7 +15,7 @@ DOCKER_BUILDKIT=1
 # so it will work on Windows and Unix, see
 # https://docs.docker.com/compose/reference/envvars/#compose_file
 COMPOSE_PATH_SEPARATOR=;
-COMPOSE_FILE=docker/docker-compose.yml;docker/development.yml;docker/supabase/docker-compose.yml
+COMPOSE_FILE=docker/docker-compose.yml;docker/development.yml;docker/supabase/docker-compose.yml;docker/supabase/supabase-development.yml
 
 
 # The host where the Telescope 1.0 front-end and back-end are run.

--- a/config/env.production
+++ b/config/env.production
@@ -15,7 +15,7 @@ DOCKER_BUILDKIT=1
 # so it will work on Windows and Unix, see
 # https://docs.docker.com/compose/reference/envvars/#compose_file
 COMPOSE_PATH_SEPARATOR=;
-COMPOSE_FILE=docker/docker-compose.yml;docker/production.yml
+COMPOSE_FILE=docker/docker-compose.yml;docker/production.yml;docker/supabase/docker-compose.yml;docker/supabase/supabase-production.yml
 
 
 # The host where the Telescope 1.0 front-end and back-end are run.

--- a/config/env.staging
+++ b/config/env.staging
@@ -15,7 +15,7 @@ DOCKER_BUILDKIT=1
 # so it will work on Windows and Unix, see
 # https://docs.docker.com/compose/reference/envvars/#compose_file
 COMPOSE_PATH_SEPARATOR=;
-COMPOSE_FILE=docker/docker-compose.yml;docker/production.yml
+COMPOSE_FILE=docker/docker-compose.yml;docker/production.yml;docker/supabase/docker-compose.yml;docker/supabase/supabase-production.yml
 
 
 # The host where the Telescope 1.0 front-end and back-end are run.

--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -1,18 +1,11 @@
-# Usage
-#   Start:          docker-compose up
-#   With helpers:   docker-compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up
-#   Stop:           docker-compose down
-#   Destroy:        docker-compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml down -v --remove-orphans
-
-version: '3.8'
+# This is the main Supabase container definition, and is meant to
+# be run with one of supabase-development.yml or supabase-production.yml.
 
 services:
   studio:
     container_name: supabase-studio
     image: supabase/studio:latest
     restart: unless-stopped
-    ports:
-      - ${STUDIO_PORT}:3000/tcp
     environment:
       SUPABASE_URL: http://kong:8000
       STUDIO_PG_META_URL: http://meta:8080
@@ -143,8 +136,6 @@ services:
       # TODO: https://github.com/supabase/storage-api/issues/55
       REGION: stub
       GLOBAL_S3_BUCKET: stub
-    volumes:
-      - ./supabase/volumes/storage:/var/lib/storage
 
   meta:
     container_name: supabase-meta
@@ -162,13 +153,5 @@ services:
     image: supabase/postgres:14.1.0
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     restart: unless-stopped
-    ports:
-      # XXX: we need access to the postgres port on localhost for our e2e tests in dev,
-      # since they need to wait on the postgres db to become ready before starting.
-      # See src/api/sso/jest.config.e2e.js
-      - '5432:5432'
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes:
-      # - ./supbase/volumes/db/data:/var/lib/postgresql/data
-      - ./supabase/volumes/db/init:/docker-entrypoint-initdb.d

--- a/docker/supabase/supabase-development.yml
+++ b/docker/supabase/supabase-development.yml
@@ -1,0 +1,19 @@
+# This is meant to be used with ./docker-compose.yml in development
+services:
+  studio:
+    ports:
+      - ${STUDIO_PORT}:3000/tcp
+
+  storage:
+    volumes:
+      - ./supabase/volumes/storage:/var/lib/storage
+
+  db:
+    ports:
+      # XXX: we need access to the postgres port on localhost for our e2e tests in dev,
+      # since they need to wait on the postgres db to become ready before starting.
+      # See src/api/sso/jest.config.e2e.js
+      - '5432:5432'
+    volumes:
+      - ./supabase/volumes/db/data:/var/lib/postgresql/data
+      - ./supabase/volumes/db/init:/docker-entrypoint-initdb.d

--- a/docker/supabase/supabase-production.yml
+++ b/docker/supabase/supabase-production.yml
@@ -1,0 +1,10 @@
+# This is meant to be used with ./docker-compose.yml in production
+services:
+  storage:
+    volumes:
+      - ../../../supabase/volumes/storage:/var/lib/storage
+
+  db:
+    volumes:
+      - ../../../supabase/volumes/db/data:/var/lib/postgresql/data
+      - ./supabase/volumes/db/init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
We had a meeting today about things that need to happen for Supabase to get put into production. One of them was to fix how we do volumes for postgres in dev vs. staging/prod.

I've created override files for dev and prod environments, which disable ports and fix the location of persistent volumes we mount.

We need to do the `secrets.env` before we can land this, but I hope @manekenpix and I can do that soon.