### PR TITLE
Rework configs, docker, envs, CI/CD for production secrets

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -55,7 +55,7 @@ on:
       anon_key:
         description: 'The Supabase Anonymous Key'
         required: false
-        default: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE'
+        default: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UiLAogICAgImlhdCI6IDE2NDg2MTI4MDAsCiAgICAiZXhwIjogMTgwNjM3OTIwMAp9.mCKt384B1BIKP6DFUgC3bwcFGY8HdbWNUAsPTVQbQxo'
         type: string
     secrets:
       docker_username:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       feed_discovery_url: 'https://api.telescope.cdot.systems/v1/feed-discovery'
       status_url: 'https://api.telescope.cdot.systems/v1/status'
       supabase_url: 'https://api.telescope.cdot.systems/v1/supabase'
-      anon_key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+      anon_key: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UiLAogICAgImlhdCI6IDE2NDg2MTI4MDAsCiAgICAiZXhwIjogMTgwNjM3OTIwMAp9.YMOYR_8pZqqDRJkoAFuEWp-FaQfvmHXTOXKncBlRjdE'
     secrets:
       docker_username: ${{ secrets.DOCKER_CDOT_SYSTEMS_USERNAME }}
       docker_password: ${{ secrets.DOCKER_CDOT_SYSTEMS_PASSWORD }}

--- a/config/env.development
+++ b/config/env.development
@@ -40,13 +40,11 @@ API_VERSION=v1
 # NOTE: Prod/Staging secrets are loaded from a seperate file
 ################################################################################
 
-# SECRET = cookie session SECRET. If left empty, one will be set automatically
-SECRET=secret-sauce
-
-
 # Supabase Secrets
 POSTGRES_PASSWORD=your-super-secret-and-long-postgres-password
 JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
+# NOTE: to generate these keys, use https://supabase.com/docs/guides/hosting/overview#api-keys
+# and the JWT_SECRET to create the new key types.
 ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
 SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       # Satellite authentication/authorization support
       - JWT_ISSUER
       - JWT_AUDIENCE
-      - SECRET
       - GITHUB_TOKEN
       - JWT_SECRET
     depends_on:

--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -22,9 +22,6 @@ services:
       # https://github.com/supabase/cli/issues/14
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_PLUGINS: request-transformer,cors,key-auth,acl
-      JWT_ISSUER: ${JWT_ISSUER}
-      JWT_AUDIENCE: ${JWT_AUDIENCE}
-      SECRET: ${SECRET}
     volumes:
       - ./supabase/volumes/api/kong.yml:/var/lib/kong/kong.yml
     depends_on:

--- a/src/api/sso/env.local
+++ b/src/api/sso/env.local
@@ -26,9 +26,6 @@ SSO_IDP_PUBLIC_KEY_CERT=MIIDXTCCAkWgAwIBAgIJALmVVuDWu4NYMA0GCSqGSIb3DQEBCwUAMEUx
 # Our apps's Entity ID, which is also the URL to our metadata.
 SAML_ENTITY_ID=http://localhost:7777/sp
 
-# SECRET = cookie session SECRET. If left empty, one will be set automatically
-SECRET=secret-sauce
-
 # ADMINISTRATORS is a list (space delimited) of users who have administrator
 # rights. Use the user's nameID (user2@example.com) or hashed version of
 # nameID (2b3b2b9ce8).  Either will work.

--- a/src/web/docusaurus/docs/contributing/staging-production-deployment.md
+++ b/src/web/docusaurus/docs/contributing/staging-production-deployment.md
@@ -15,13 +15,18 @@ The steps to launch Telescope in staging or production mode are almost identical
 
 ## Directory Structure
 
-The project needs to be set up using a specific directory structure to make sure that Telescope has access to the SSL certificates, redis data and elasticsearch data, and to prevent the certificates and the stored data from being deleted during a redeployment.
+The project needs to be set up using a specific directory structure to make sure that Telescope has access to the SSL certificates and shared data volumes (redis, elasticsearch, postgres), and to prevent the certificates and the stored data from being deleted during a redeployment.
+
+Also, we use an extra `env` file to store secrets in `config/env.production.secrets` (production) and `config/env.staging.secrets` (staging). These do **not** go in git, and must be maintained manually.
 
 ```sh
 ├── parent-directory
 │   ├── autodeployment
 │   ├── certbot
+│   ├── config
+│   │   └── env.production.secrets
 │   ├── elastic-data
+|   ├── postgres-data
 │   ├── redis-data
 │   └── telescope
 ```
@@ -57,6 +62,7 @@ sudo chown -R <user_name>: certbot
 ### 3.- Autodeployment server
 
 Telescope uses [GitHub webhooks](https://docs.github.com/en/developers/webhooks-and-events/about-webhooks) to automate deployments whenever a pull requests is merged or a new version is released.
+
 When a GitHub event is triggered, it sends a POST request payload to the webhook's configured URL. Telescope's autodeployment server receives that POST request and updates Telescope with the latest merged changes or with a new release.
 
 After [creating a GitHub webhook](https://docs.github.com/en/developers/webhooks-and-events/creating-webhooks), copy the `autodeployment` directory in `tools` in the repository to the chosen directory where the project lives, as indicated above.

--- a/tools/autodeployment/README.md
+++ b/tools/autodeployment/README.md
@@ -1,15 +1,14 @@
 # Auto Deployment
 
 Telescope uses a separate HTTP server to listen for
-[GitHub Webhook](https://developer.github.com/webhooks/)Events. The server's
+[GitHub Webhook](https://developer.github.com/webhooks/) Events. The server's
 configuration is stored in an `.env` file, which must be created based on
 `env.example`.
 
-On our staging (https://dev.telescope.cdot.systems) and production
-(https://telescope.cdot.systems) machines we use these webhooks to trigger a new
-build and deploy. For staging, this happens on every push to the `master`
-branch. On production, we listen for GitHub releases (e.g., when a new release
-is created on GitHub).
+On our staging (<https://dev.telescope.cdot.systems>) and production
+(<https://telescope.cdot.systems>) machines listen for a `push` to the webhook, and then trigger a new build and deploy using the `deploy.sh` script.
+
+## Routes
 
 There are also a few other routes you can use to get information about the
 auto deployment server:
@@ -19,27 +18,27 @@ auto deployment server:
 
 On staging you can go to:
 
-- https://dev.telescope.cdot.systems/deploy/status to check the deployment status,
-- https://dev.telescope.cdot.systems/deploy/log to check the deployment log of
-  the current deployment (you can also use https://dev.telescope.cdot.systems/deploy/log/current),
-- https://dev.telescope.cdot.systems/deploy/log/previous to check the deployment log of
+- <https://dev.telescope.cdot.systems/deploy/status> to check the deployment status,
+- <https://dev.telescope.cdot.systems/deploy/log> to check the deployment log of
+  the current deployment (you can also use <https://dev.telescope.cdot.systems/deploy/log/current>),
+- <https://dev.telescope.cdot.systems/deploy/log/previous> to check the deployment log of
   the previous deployment,
 
 and on production you can use
 
-- https://telescope.cdot.systems/deploy/status to check the deployment status,
-- https://telescope.cdot.systems/deploy/log to check the deployment log of the
-  current deployment (you can also use https://telescope.cdot.systems/deploy/log/current),
-- https://telescope.cdot.systems/deploy/log/previous to check the deployment log of
+- <https://telescope.cdot.systems/deploy/status> to check the deployment status,
+- <https://telescope.cdot.systems/deploy/log> to check the deployment log of the
+  current deployment (you can also use <https://telescope.cdot.systems/deploy/log/current>),
+- <https://telescope.cdot.systems/deploy/log/previous> to check the deployment log of
   the previous deployment.
 
 ## Real-time build log
 
 In the dashboard, you can check the log in real-time through the following links:
 
-- https://dev.api.telescope.cdot.systems/v1/status/build for `staging`
-- https://api.telescope.cdot.systems/v1/status/build for `production`
+- <https://dev.api.telescope.cdot.systems/v1/status/build> for `staging`
+- <https://api.telescope.cdot.systems/v1/status/build> for `production`
 
-```
-$ curl https://dev.telescope.cdot.systems/deploy/log
+```sh
+curl https://dev.telescope.cdot.systems/deploy/log
 ```

--- a/tools/autodeployment/deploy.sh
+++ b/tools/autodeployment/deploy.sh
@@ -15,12 +15,12 @@ if [ $1 = 'production' ]
 then
   ENV_FILE=config/env.production
   # The env.secrets file doesn't live in git
-  SECRETS_ENV_FILE=../env.production.secrets
+  SECRETS_ENV_FILE=../config/env.production.secrets
 elif [ $1 = 'staging' ]
 then
   ENV_FILE=config/env.staging
   # The env.secrets file doesn't live in git
-  SECRETS_ENV_FILE=../env.staging.secrets
+  SECRETS_ENV_FILE=../config/env.staging.secrets
 else
   echo $1 is not a valid argument. Please use either production or staging.
   exit 1


### PR DESCRIPTION
This is needed for #3098, #3361 (which @TueeNguyen needs to land manually again).

In this PR, I'm updating our code to use the new secrets @manekenpix and I are adding to staging and production.  I'm going to give the secrets to @manekenpix separate to this PR, for obvious reasons.  Here, I'm doing the following:

1. Update the `anon_key`s we use in staging and production.  These had to be regenerated, since I changed the `JWT_TOKEN` we use.
2. Added a note about how to generate new Supabase keys
3. Removed all uses of `SECRET`, which we don't use anymore (we use `JWT_SECRET`)
4. Removed from env vars that got added to Kong, which @Kevan-Y and I don't think are required.
5. Updated our autodeployment `deploy.sh` script to use two additional env files.  NOTE: these files do **not** live in git, and only exist on the servers.  @manekenpix, let me know if these paths make sense to you (i.e., one level higher than the repo):
    1. `SECRETS_ENV_FILE=../env.production.secrets` for production
    2. `SECRETS_ENV_FILE=../env.staging.secrets` for staging. 

I need to have @manekenpix install the new secrets files on staging/production **before** we land this (looking at you, @TueeNguyen). 