### PR TITLE
Fix oauth2-proxy config

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -217,6 +217,7 @@ services:
       - nginx
 
   # oauth2-proxy secure route for Supabase studio
+  # See docs for configuration https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
   oauth2-proxy:
     image: bitnami/oauth2-proxy:7.2.1
     container_name: 'oauth2-proxy'
@@ -228,7 +229,8 @@ services:
         '--upstream=http://studio:3000',
         '--http-address=0.0.0.0:8080',
         '--skip-auth-regex=/forms/*',
-        '--redirect-url=${SUPABASE_HOST}/oauth2/callback',
+        '--redirect-url=/oauth2/callback',
+        '--force-https=true',
         '--email-domain=*',
         '--github-org=Seneca-CDOT',
         '--github-team=telescope-admins',


### PR DESCRIPTION
## Description

Fix for redirect URL for oauth2-proxy not set properly (`redirect_uri=http://dev.supabase.telescope.cdot.systems/dev.supabase.telescope.cdot.systems/oauth2/callback`). 
- Changed to `'--redirect-url=/oauth2/callback'`
- Added  '--force-https=true' to have https instead of http.
