### PR TITLE
Fix nginx config for oauth2-proxy

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -172,6 +172,7 @@ http {
   }
 
   # Requests to the oauth2-proxy which redirect to supabase studio app once authenticated
+  # Configuration reference: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/tls/
   server {
     listen 443 ssl http2;
     server_name ${SUPABASE_HOST};
@@ -179,6 +180,8 @@ http {
     location / {
       proxy_set_header Connection "";
       proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Scheme $scheme;
       proxy_pass http://oauth2-proxy:8080/;
     }
   }

--- a/docker/production.yml
+++ b/docker/production.yml
@@ -224,13 +224,11 @@ services:
     command:
       [
         '--provider=github',
-        '--cookie-secure=false',
+        '--cookie-secure=true',
         '--cookie-secret=${OAUTH2_SUPABASE_COOKIE_SECRET}',
         '--upstream=http://studio:3000',
         '--http-address=0.0.0.0:8080',
-        '--skip-auth-regex=/forms/*',
-        '--redirect-url=/oauth2/callback',
-        '--force-https=true',
+        '--reverse-proxy=true',
         '--email-domain=*',
         '--github-org=Seneca-CDOT',
         '--github-team=telescope-admins',


### PR DESCRIPTION
## Description 
In the previous PR https://github.com/Seneca-CDOT/telescope/pull/3378, oauth2-proxy crashed the Nginx, because of `--force-https=true`.

## Changes:
  - Removed `--skip-auth-regex=/forms/*` deprecated and not needed 
  - Removed `--force-https=true` (Not needed, can use our Nginx to put the correct protocol)
  
  ### Based on https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/tls/
  - Set `--cookie-secure` to true, we want this to be secure 
  - Set `--reverse-proxy` to true, to tell this services is under a proxy
  - Removed `--redirect-url` since it will automatically, using our domain.
