### PR TITLE
Update how kong.yml is used to configure Supabase in dev vs. prod

### DIFF
--- a/docker/supabase/docker-compose.yml
+++ b/docker/supabase/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       # https://github.com/supabase/cli/issues/14
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_PLUGINS: request-transformer,cors,key-auth,acl
-    volumes:
-      - ./supabase/volumes/api/kong.yml:/var/lib/kong/kong.yml
     depends_on:
       - traefik
     labels:

--- a/docker/supabase/supabase-development.yml
+++ b/docker/supabase/supabase-development.yml
@@ -17,3 +17,7 @@ services:
     volumes:
       - ./supabase/volumes/db/data:/var/lib/postgresql/data
       - ./supabase/volumes/db/init:/docker-entrypoint-initdb.d
+
+  kong:
+    volumes:
+      - ./supabase/volumes/api/kong.yml:/var/lib/kong/kong.yml

--- a/docker/supabase/supabase-production.yml
+++ b/docker/supabase/supabase-production.yml
@@ -8,3 +8,7 @@ services:
     volumes:
       - ../../../supabase/volumes/db/data:/var/lib/postgresql/data
       - ./supabase/volumes/db/init:/docker-entrypoint-initdb.d
+
+  kong:
+    volumes:
+      - ../../../config/kong.yml:/var/lib/kong/kong.yml

--- a/docker/supabase/supabase-production.yml
+++ b/docker/supabase/supabase-production.yml
@@ -2,13 +2,15 @@
 services:
   storage:
     volumes:
-      - ../../../supabase/volumes/storage:/var/lib/storage
+      - ../../supabase/volumes/storage:/var/lib/storage
 
   db:
     volumes:
-      - ../../../supabase/volumes/db/data:/var/lib/postgresql/data
+      # We keep the actual data in a volume outside of git, so it survives restarts
+      - ../../supabase/volumes/db/data:/var/lib/postgresql/data
+      # We pull in .sql migrations, schema files from the git repo
       - ./supabase/volumes/db/init:/docker-entrypoint-initdb.d
 
   kong:
     volumes:
-      - ../../../config/kong.yml:/var/lib/kong/kong.yml
+      - ../../config/kong.yml:/var/lib/kong/kong.yml


### PR DESCRIPTION
Yesterday @DukeManh, @Kevan-Y and I tried to insert all the feeds into Supabase on staging.  We found that our `service_role_key` wouldn't work, and even our `anon_key` won't pass verification.  The issue is that we are hard-coding the keys into our `kong.yml` config: https://github.com/Seneca-CDOT/telescope/blob/master/docker/supabase/volumes/api/kong.yml#L6-L12

These need to match the keys we use on staging and production.

I've created new `kong.yml` files for staging and production, and sent to @manekenpix to add to the servers.  Once those are in place, we can do this change.

@manekenpix, please confirm that the paths I have used for production match what you do with these files (I think I'm right, but it's untested).

Fixes #3381. 