### PR TITLE
Fixes #3348: Added GIT_COMMIT override for local environments

### DIFF
--- a/config/env.development
+++ b/config/env.development
@@ -33,6 +33,9 @@ WEB_URL=http://localhost:8000
 # The API Version, used as a prefix on all routes: /v1
 API_VERSION=v1
 
+# GIT_COMMIT, used to retrieve data on the current commit on the master branch, set to master for local enviroments only
+GIT_COMMIT=master
+
 ################################################################################
 # Secrets
 #


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR closes #3348 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

This PR adds the `GIT_COMMIT` env variable to our env.development file so that we can override the value in local development. The staging and production env files retrieve this variable through the auto-deployment server so this change is not needed there.

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

Simply checkout into my PR (`gh pr checkout -insertPRNumber`) and run the application. The front-end current commit should point to master.

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
