### PR TITLE
Add initial tests for /github/:project

### DIFF
--- a/src/api/dependency-discovery/src/__mocks__/dependency-list.js
+++ b/src/api/dependency-discovery/src/__mocks__/dependency-list.js
@@ -1,10 +1,23 @@
 let depsList = [];
+let depsGitHubIssuesList = {};
 
 module.exports = {
   __setMockDepList: (newDepsList) => {
     depsList = newDepsList;
   },
+  __setMockDepsGitHubIssuesList: (newDepsGitHubIssuesList) => {
+    depsGitHubIssuesList = newDepsGitHubIssuesList;
+  },
   getDependencyList: jest.fn().mockImplementation(() => {
     return Promise.resolve(depsList);
+  }),
+  isPackageDependency: jest.fn().mockImplementation((dependencyName) => {
+    return Promise.resolve(depsList.includes(dependencyName));
+  }),
+  getGitHubIssues: jest.fn().mockImplementation((dependencyName) => {
+    if (depsGitHubIssuesList[dependencyName]) {
+      return Promise.resolve(depsGitHubIssuesList[dependencyName]);
+    }
+    return Promise.resolve([]);
   }),
 };

--- a/src/api/dependency-discovery/test/dependency.test.js
+++ b/src/api/dependency-discovery/test/dependency.test.js
@@ -11,10 +11,36 @@ const depsList = [
   '@babel/helper-compilation-targets',
   '@babel/helper-create-class-features-plugin',
   '@babel/helper-create-regexp-features-plugin',
+  'faker-package',
 ];
 
+const depsGitHubIssuesList = {
+  '@babel/code-frame': [
+    {
+      htmlUrl: 'https://github.com/babel/babel/issues/123',
+      title: 'This is a babel-related issue',
+      body: 'This is urgent!!',
+      createdAt: '2019-04-24T14:10:34Z',
+    },
+  ],
+  'faker-package': [
+    {
+      htmlUrl: 'https://github.com/faker-org/faker/issues/112',
+      title: 'This is a fake issue',
+      body: 'This is the body of a fake issue',
+      createdAt: '2018-02-08T20:49:23Z',
+    },
+    {
+      htmlUrl: 'https://github.com/faker-org/faker/issues/113',
+      title: 'This is a follow up issue from a fake PR',
+      body: 'This is the body of a fake issue',
+      createdAt: '2018-01-26T16:51:33Z',
+    },
+  ],
+};
+
 jest.mock('../src/dependency-list');
-const { __setMockDepList } = require('../src/dependency-list');
+const { __setMockDepList, __setMockDepsGitHubIssuesList } = require('../src/dependency-list');
 
 describe('GET /projects', () => {
   beforeEach(() => {
@@ -26,5 +52,41 @@ describe('GET /projects', () => {
     expect(res.status).toBe(200);
     expect(typeof res.body).toEqual('object');
     expect(res.body.length).toBe(depsList.length);
+  });
+});
+
+describe('GET /github/:project', () => {
+  beforeEach(() => {
+    __setMockDepList(depsList);
+    __setMockDepsGitHubIssuesList(depsGitHubIssuesList);
+  });
+
+  test('Should return 200 and an object with the GitHub issues', async () => {
+    const dependencyName = 'faker-package';
+    const gitHubIssuesForDep = depsGitHubIssuesList[dependencyName];
+    const res = await request(app).get(`/github/${dependencyName}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(gitHubIssuesForDep);
+  });
+
+  test('Should return 200 and an object with the GitHub issues if dependency name has namespace', async () => {
+    const dependencyName = '@babel/code-frame';
+    const gitHubIssuesForDep = depsGitHubIssuesList[dependencyName];
+    const res = await request(app).get(`/github/${dependencyName}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(gitHubIssuesForDep);
+  });
+
+  test('Should return 404 if dependency does not exist', async () => {
+    const dependencyName = 'this-is-not-a-dependency';
+    const res = await request(app).get(`/github/${dependencyName}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('Should return 200 and no list if dependency does not have GitHub issues', async () => {
+    const dependencyName = '@apidevtools/json-schema-ref-parser';
+    const res = await request(app).get(`/github/${dependencyName}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
   });
 });


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3331

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [ ] **Test**: Change that adds a new test case

## Description

This PR adds some test cases to the route `/github/:project/` in the `dependency-discovery`.

## Steps to test the PR

I don't think you need to test this locally, just let CI do the checks for you 😉 

However, if you insist:

1. Get my changes,
2. Run the tests for only the service so that it is faster (`pnpm run jest dependency.test.js`).

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
