### PR TITLE
Autocomplete indexing in Parser

### DIFF
--- a/src/api/parser/test/feed.test.js
+++ b/src/api/parser/test/feed.test.js
@@ -185,7 +185,7 @@ describe('Post data class tests', () => {
       mock.add(
         {
           method: ['POST', 'GET'],
-          path: '/posts/post/_search',
+          path: '/posts/_search',
         },
         () => {
           return esMockResults;
@@ -212,7 +212,7 @@ describe('Post data class tests', () => {
       mock.add(
         {
           method: ['POST', 'GET'],
-          path: '/posts/post/_search',
+          path: '/posts/_search',
         },
         () => {
           return esMockEmpty;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

extension of #3301 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change
moves autocomplete indexing to `Parser`

## Steps to test the PR

```
 rm -rf redis-data
 docker-compose --env-file ./config/env.development up --build redis elasticsearch posts traefik search nginx planet parser
```
- Wait for re-indexing
- author autocomplete query will now work at http://localhost/v1/search/authors/autocomplete/
- `pnpm test src/api/parser` will pass

I am not sure if staging still runs the backend and if it will affect indexing on staging. 
