### PR TITLE
Fix #3435 - Dockerize src/db

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -109,6 +109,8 @@ jobs:
             image: search
           - context: src/api/sso
             image: sso
+          - context: src/db
+            image: db-migrations
     steps:
       - uses: actions/checkout@v2
 

--- a/src/db/.dockerignore
+++ b/src/db/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+env.*

--- a/src/db/Dockerfile
+++ b/src/db/Dockerfile
@@ -1,0 +1,9 @@
+# NOTE: we assume that the environment variable DATABASE_URL will
+# be defined when a new container is run.  It should take the form:
+# DATABASE_URL=postgresql://postgres:postgress_password@localhost/postgres
+FROM node:16-alpine3.15
+
+WORKDIR /db-migrations
+COPY . .
+RUN npm install
+CMD ["npm", "run", "migrate"]


### PR DESCRIPTION
This adds a `Dockerfile` to `src/db` so that we can run the Prisma migrations on staging and production via Portainer in a new container.  This will build and push a new image every time we push to `master` or create a new `tag` for production.

On Portainer, we would create a new container, and specify the correct `DATABASE_URL` environment variable to use for the given environment (staging/production):

<img width="1165" alt="Screen Shot 2022-04-08 at 3 39 49 PM" src="https://user-images.githubusercontent.com/427398/162515378-dcc337f4-7bce-4359-92ef-c49afc575cda.png">

This needs to be tested, but it's a start. 