### PR TITLE
Add SUPABASE_URL to staging/production envs

### DIFF
--- a/config/env.production
+++ b/config/env.production
@@ -31,6 +31,9 @@ PORTAINER_HOST=portainer.telescope.cdot.systems
 # The host where supabase studio runs (e.g., https://supabase.telescope.cdot.systems)
 SUPABASE_HOST=supabase.telescope.cdot.systems
 
+# The Supabase API URL
+SUPABASE_URL=https://api.telescope.cdot.systems/v1/supabase
+
 # Front-end web URL (entry point to the next.js app). Make sure that the
 # ALLOWED_APP_ORIGINS variable below includes this URL, so that the Auth
 # service will allow redirects back to this origin.

--- a/config/env.staging
+++ b/config/env.staging
@@ -31,6 +31,9 @@ PORTAINER_HOST=dev.portainer.telescope.cdot.systems
 # The host where supabase studio runs (e.g., https://dev.supabase.telescope.cdot.systems)
 SUPABASE_HOST=dev.supabase.telescope.cdot.systems
 
+# The Supabase API URL
+SUPABASE_URL=https://dev.api.telescope.cdot.systems/v1/supabase
+
 # Front-end web URL (entry point to the next.js app). Make sure that the
 # ALLOWED_APP_ORIGINS variable below includes this URL, so that the SSO Auth
 # service will allow redirects back to this origin.


### PR DESCRIPTION
The SSO service crashes over and over because it's missing the `SUPABASE_URL` environment variable.  This adds it for staging and production, now that it exists.