### PR TITLE
Fix docker legacy backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ FROM node:16-alpine3.15 AS release
 # GET production code from previous containers
 COPY --from=backend_dependencies /telescope/node_modules /telescope/node_modules
 COPY ./src/backend ./src/backend
+COPY package.json .
 
 # Directory for log files
 RUN mkdir /log


### PR DESCRIPTION
## Description 
Our legacy backend containers keep restating due to missing `package.json` in the last stage where we run the container

Logs of the issue:
```plain
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '//package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
npm ERR! A complete log of this run can be found in:
```

## Fix Description 

- Add ` ackage.json` to the last stage.
