### PR TITLE
Add missing server-token to ci workflows

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -20,3 +20,5 @@ jobs:
   # Make sure eslint passes
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
+    secrets:
+      server-token: ${{ secrets.TURBO_SERVER_TOKEN }}

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -15,6 +15,8 @@ jobs:
   # Make sure eslint passes
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
+    secrets:
+      server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   publish:
     needs: [prettier, eslint]


### PR DESCRIPTION
Fix fallout from #3458.  We need to pass the `server-token` into our workflows in more places to fix https://github.com/Seneca-CDOT/telescope/actions/runs/2154847106/workflow, etc.