### PR TITLE
Fix planet to use Supabase, remove feedsUrl/userFeedsUrl from front-end

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -225,6 +225,8 @@ services:
       - NODE_ENV
       - PLANET_PORT
       - POSTS_URL
+      - SERVICE_ROLE_KEY
+      - SUPABASE_URL
 
   dependency-discovery:
     init: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,12 +263,14 @@ importers:
     specifiers:
       '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
+      '@supabase/supabase-js': 1.29.4
       env-cmd: 10.1.0
       express: 4.17.3
       express-handlebars: 6.0.4
       nodemon: 2.0.15
     dependencies:
       '@senecacdot/satellite': 1.27.0
+      '@supabase/supabase-js': 1.29.4
       express: 4.17.3
       express-handlebars: 6.0.4
     devDependencies:

--- a/src/api/planet/env.local
+++ b/src/api/planet/env.local
@@ -1,2 +1,7 @@
+LOG_LEVEL=debug
 PLANET_PORT=9876
-POSTS_URL=http://localhost/v1/posts
+# In development and testing, use the staging Supabase instance
+POSTS_URL=https://dev.api.telescope.cdot.systems/v1/posts
+SUPABASE_URL=https://dev.api.telescope.cdot.systems/v1/supabase
+# NOTE: this is the anon key, not service role key, but is fine for testing
+SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UiLAogICAgImlhdCI6IDE2NDg2MTI4MDAsCiAgICAiZXhwIjogMTgwNjM3OTIwMAp9.mCKt384B1BIKP6DFUgC3bwcFGY8HdbWNUAsPTVQbQxo

--- a/src/api/planet/package.json
+++ b/src/api/planet/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/Seneca-CDOT/telescope#readme",
   "dependencies": {
     "@senecacdot/satellite": "^1.27.0",
+    "@supabase/supabase-js": "1.29.4",
     "express": "4.17.3",
     "express-handlebars": "6.0.4"
   },

--- a/src/api/planet/src/planet.js
+++ b/src/api/planet/src/planet.js
@@ -1,77 +1,13 @@
-const { Router, logger, fetch } = require('@senecacdot/satellite');
+const { Router } = require('@senecacdot/satellite');
+const { getFeeds, getPosts } = require('./util');
 
 const router = Router();
 
-const { POSTS_URL } = process.env;
-const FEEDS_URL = `${POSTS_URL}/feeds`;
-
-// Format a Date into a String like `Saturday, September 17, 2016`
-const formatDate = (date) => {
-  const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-  return date.toLocaleDateString('en-US', options);
-};
-
-/**
- * Get most recent 50 posts, and group them according to
- * day, channel, date.
- */
-const getPostDataGrouped = (posts) => {
-  // We group the posts into nested objects: days > authors > posts
-  const grouped = { days: {} };
-  posts?.forEach((post) => {
-    if (!post) {
-      return;
-    }
-
-    // Top level is formatted Day strings
-    post.updated = new Date(post.updated);
-    const formatted = formatDate(post.updated);
-    if (!grouped.days[formatted]) {
-      grouped.days[formatted] = {};
-    }
-
-    // Days contain Author strings
-    const day = grouped.days[formatted];
-    if (!day[post.feed.author]) {
-      day[post.feed.author] = {};
-    }
-
-    // Authors contain guid strings, which are references to post Objects
-    const author = day[post.feed.author];
-    if (!author[post.guid]) {
-      author[post.guid] = post;
-    }
-  });
-
-  return grouped;
-};
-
-const sort = (feeds) => {
-  return feeds?.sort((a, b) => {
-    if (a.author < b.author) return -1;
-    if (a.author > b.author) return 1;
-    return 0;
-  });
-};
-
-const fetchData = async (dataUrl) => {
-  try {
-    const response = await fetch(dataUrl);
-    const data = await response.json();
-    return Promise.all(data.map((item) => fetch(`${dataUrl}/${item.id}`).then((r) => r.json())));
-  } catch (e) {
-    return logger.error(e);
-  }
-};
-
 router.get('/', async (req, res, next) => {
   try {
-    const [feeds, posts] = await Promise.all([fetchData(FEEDS_URL), fetchData(POSTS_URL)]);
-
-    const grouped = getPostDataGrouped(posts);
-    res.render('planet', { feeds: sort(feeds), ...grouped });
+    const [feeds, posts] = await Promise.all([getFeeds(), getPosts()]);
+    res.render('planet', { feeds, ...posts });
   } catch (error) {
-    logger.error({ error }, 'Error processing posts from Redis');
     next(error);
   }
 });

--- a/src/api/planet/src/util.js
+++ b/src/api/planet/src/util.js
@@ -85,7 +85,7 @@ module.exports.getFeeds = async () => {
   return sort(
     data.map((feed) => ({
       // Prefer the a user's display name if present, fallback to wiki name otherwise
-      author: feed.display_name || feed.wiki_author_name,
+      author: feed.telescope_profiles?.display_name || feed.wiki_author_name,
       url: feed.url,
     }))
   );

--- a/src/api/planet/src/util.js
+++ b/src/api/planet/src/util.js
@@ -1,0 +1,92 @@
+const { logger, fetch } = require('@senecacdot/satellite');
+const { createClient } = require('@supabase/supabase-js');
+
+const { SERVICE_ROLE_KEY, SUPABASE_URL, POSTS_URL } = process.env;
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+// Format a Date into a String like `Saturday, September 17, 2016`
+const formatDate = (date) => {
+  const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+  return date.toLocaleDateString('en-US', options);
+};
+
+// Group posts according to day, channel, date.
+const getPostDataGrouped = (posts) => {
+  // We group the posts into nested objects: days > authors > posts
+  const grouped = { days: {} };
+
+  posts?.forEach((post) => {
+    if (!post) {
+      return;
+    }
+
+    // Top level is formatted Day strings
+    post.updated = new Date(post.updated);
+    const formatted = formatDate(post.updated);
+    if (!grouped.days[formatted]) {
+      grouped.days[formatted] = {};
+    }
+
+    // Days contain Author strings
+    const day = grouped.days[formatted];
+    if (!day[post.feed.author]) {
+      day[post.feed.author] = {};
+    }
+
+    // Authors contain guid strings, which are references to post Objects
+    const author = day[post.feed.author];
+    if (!author[post.guid]) {
+      author[post.guid] = post;
+    }
+  });
+
+  return grouped;
+};
+
+// Sort by author name
+const sort = (feeds) => {
+  return feeds?.sort((a, b) => {
+    if (a.author < b.author) return -1;
+    if (a.author > b.author) return 1;
+    return 0;
+  });
+};
+
+module.exports.getPosts = async () => {
+  try {
+    const response = await fetch(POSTS_URL);
+    const posts = await response.json();
+    return Promise.all(
+      posts.map((item) =>
+        fetch(item.url).then((r) => {
+          if (!r.ok) {
+            throw new Error(`unable to get post ${item.id}`);
+          }
+          return r.json();
+        })
+      )
+    ).then(getPostDataGrouped);
+  } catch (err) {
+    return logger.error({ err }, 'Error getting posts');
+  }
+};
+
+module.exports.getFeeds = async () => {
+  const { data, error } = await supabase
+    .from('feeds')
+    .select('wiki_author_name, url, telescope_profiles (display_name)');
+
+  if (error) {
+    logger.warn({ error });
+    throw Error(error.message, "can't fetch feeds from supabase");
+  }
+
+  return sort(
+    data.map((feed) => ({
+      // Prefer the a user's display name if present, fallback to wiki name otherwise
+      author: feed.display_name || feed.wiki_author_name,
+      url: feed.url,
+    }))
+  );
+};

--- a/src/web/app/src/config.ts
+++ b/src/web/app/src/config.ts
@@ -29,8 +29,6 @@ const imageAlt = `Telescope Logo`;
 
 const loginUrl = `${ssoServiceUrl}/login`;
 const logoutUrl = `${ssoServiceUrl}/logout`;
-const userFeedsUrl = `${telescopeUrl}/user/feeds`;
-const feedsUrl = `${telescopeUrl}/feeds`;
 
 export {
   title,
@@ -44,8 +42,6 @@ export {
   anonKey,
   loginUrl,
   logoutUrl,
-  userFeedsUrl,
-  feedsUrl,
   keywords,
   image,
   imageAlt,


### PR DESCRIPTION
Fixes #3463.  This updates the `planet` service to use Supabase for the feeds info vs. Redis (cc @TueeNguyen, you can steal my code for getting author names for the parser, and @DukeManh is going to turn this into a stored procedure in the future).

I've also removed the unneeded `feedsUrl` and `userFeedsUrl` from the front-end.

@JerryHue After this I'm not sure if anything is using `posts/feeds` anymore.