### PR TITLE
Rename server-token to turbo_server_token

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,13 +19,13 @@ jobs:
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
     secrets:
-      server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   # Run unit tests on all platforms/versions of node
   unit:
     uses: Seneca-CDOT/telescope/.github/workflows/unit-tests-ci.yml@master
     secrets:
-      server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   # Run end-to-end tests along with the microservices in docker-compose on Linux
   e2e:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -21,4 +21,4 @@ jobs:
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
     secrets:
-      server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}

--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -3,7 +3,7 @@ name: ESLint Workflow
 on:
   workflow_call:
     secrets:
-      server-token:
+      turbo_server_token:
         description: 'The Turborepo local server token'
         required: true
 
@@ -23,7 +23,7 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ github.token }}
-          server-token: ${{ secrets.server-token }}
+          server-token: ${{ secrets.turbo_server_token }}
 
       - name: Install dependencies and run eslint
         run: |

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -16,7 +16,7 @@ jobs:
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
     secrets:
-      server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   publish:
     needs: [prettier, eslint]

--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -3,7 +3,7 @@ name: Unit Tests Workflow
 on:
   workflow_call:
     secrets:
-      server-token:
+      turbo_server_token:
         description: 'The Turborepo local server token'
         required: true
 
@@ -27,7 +27,7 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ github.token }}
-          server-token: ${{ secrets.server-token }}
+          server-token: ${{ secrets.turbo_server_token }}
 
       - name: Install dependencies and run tests with default env
         run: |


### PR DESCRIPTION
Fixes #3466.  I'm changing the name, in case that's part of it (e.g. reusing a name across the secret and arg value).