### PR TITLE
Add URL hash id to Feeds table

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,15 +654,19 @@ importers:
 
   tools/migrate:
     specifiers:
+      '@senecacdot/satellite': ^1.27.0
       '@supabase/supabase-js': 1.29.4
       dotenv: 10.0.0
       jsdom: 18.1.1
       node-fetch: 2.6.7
+      normalize-url: 6.1.0
     dependencies:
+      '@senecacdot/satellite': 1.27.0
       '@supabase/supabase-js': 1.29.4
       dotenv: 10.0.0
       jsdom: 18.1.1
       node-fetch: 2.6.7
+      normalize-url: 6.1.0
 
 packages:
 

--- a/src/db/prisma/migrations/20220412180736_add_id_to_feeds/migration.sql
+++ b/src/db/prisma/migrations/20220412180736_add_id_to_feeds/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "feeds" ADD COLUMN     "id" TEXT NOT NULL DEFAULT E'';

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -16,6 +16,7 @@ enum FeedType {
 // Planet CDOT Feed List, see https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List
 model feeds {
   url                String              @id
+  id                 String              @default("")
   user_id            String? // optional, a user can claim an existing feed when they register
   wiki_author_name   String? // wiki owner of a feed, maybe unused when the feed is linked with an actual user
   html_url           String? //actual URL the feed refers to, could be a blog URL, a Youtube or Twitch channel

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -2,10 +2,12 @@
   "author": "",
   "private": true,
   "dependencies": {
+    "@senecacdot/satellite": "^1.27.0",
     "@supabase/supabase-js": "1.29.4",
     "dotenv": "10.0.0",
     "jsdom": "18.1.1",
-    "node-fetch": "2.6.7"
+    "node-fetch": "2.6.7",
+    "normalize-url": "6.1.0"
   },
   "description": "Migrates users from the planet feed wiki list to a JSON file or supabase-db",
   "license": "ISC",

--- a/tools/migrate/to_supabase.js
+++ b/tools/migrate/to_supabase.js
@@ -1,4 +1,6 @@
 const { createClient } = require('@supabase/supabase-js');
+const { hash } = require('@senecacdot/satellite');
+const normalizeUrl = require('normalize-url');
 const { parsePlanetFeedList } = require('./feed');
 
 require('dotenv').config();
@@ -19,6 +21,7 @@ const { SUPABASE_URL, SERVICE_ROLE_KEY } = process.env;
     url: feed,
     wiki_author_name: `${firstName} ${lastName}`,
     type: 'blog',
+    id: hash(normalizeUrl(feed)),
   }));
 
   const { error, count } = await supabase.from('feeds').upsert(feeds, {


### PR DESCRIPTION
Fix #3462

Added migrations to add a URL `hash` column generated by Satellite to the Feeds table.

To add a field to the existing DB, we'll need:

1. First migration to add the field in the table with a default value of `""`
2. Run `to_supabase` script to add hash ids for each row
3. Second migration to drop the default hash id to make it mandatory