### PR TITLE
Add TypeScript types to github-url-parser for front-end use

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,6 @@ src/web/docusaurus/build
 src/web/docusaurus/node_modules/
 src/web/docusaurus/package.json
 src/web/docusaurus/package-lock.json
+
+# Don't update the generated types
+src/github-url-parser/dist

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,8 +412,10 @@ importers:
   src/github-url-parser:
     specifiers:
       jsdom: 18.1.1
+      typescript: 4.4.4
     devDependencies:
       jsdom: 18.1.1
+      typescript: 4.4.4
 
   src/satellite:
     specifiers:

--- a/src/github-url-parser/dist/extract-github-info.d.ts
+++ b/src/github-url-parser/dist/extract-github-info.d.ts
@@ -1,0 +1,9 @@
+declare function _exports(gitHubUrls: any): {
+    repos: any[];
+    issues: any[];
+    pullRequests: any[];
+    commits: any[];
+    users: any[];
+};
+export = _exports;
+//# sourceMappingURL=extract-github-info.d.ts.map

--- a/src/github-url-parser/dist/extract-github-info.d.ts.map
+++ b/src/github-url-parser/dist/extract-github-info.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"extract-github-info.d.ts","sourceRoot":"","sources":["../src/extract-github-info.js"],"names":[],"mappings":"AAGiB;;;;;;EA6DhB"}

--- a/src/github-url-parser/dist/html-to-urls.d.ts
+++ b/src/github-url-parser/dist/html-to-urls.d.ts
@@ -1,0 +1,3 @@
+declare function _exports(htmlString: any, parser: any): any[];
+export = _exports;
+//# sourceMappingURL=html-to-urls.d.ts.map

--- a/src/github-url-parser/dist/html-to-urls.d.ts.map
+++ b/src/github-url-parser/dist/html-to-urls.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"html-to-urls.d.ts","sourceRoot":"","sources":["../src/html-to-urls.js"],"names":[],"mappings":"AAAiB,+DAUhB"}

--- a/src/github-url-parser/dist/index.d.ts
+++ b/src/github-url-parser/dist/index.d.ts
@@ -1,0 +1,10 @@
+declare function _exports(htmlString: string, parser?: DOMParser): GitHubInfo;
+export = _exports;
+export type GitHubInfo = {
+    issues: string[];
+    pullRequests: string[];
+    repos: string[];
+    commits: string[];
+    users: string[];
+};
+//# sourceMappingURL=index.d.ts.map

--- a/src/github-url-parser/dist/index.d.ts.map
+++ b/src/github-url-parser/dist/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.js"],"names":[],"mappings":"AAkBiB,sCAJN,MAAM,WACN,SAAS,GACP,UAAU,CAStB;;;YApBa,MAAM,EAAE;kBACR,MAAM,EAAE;WACR,MAAM,EAAE;aACR,MAAM,EAAE;WACR,MAAM,EAAE"}

--- a/src/github-url-parser/dist/parse-github-url.d.ts
+++ b/src/github-url-parser/dist/parse-github-url.d.ts
@@ -1,0 +1,3 @@
+declare function _exports(url: any): URL;
+export = _exports;
+//# sourceMappingURL=parse-github-url.d.ts.map

--- a/src/github-url-parser/dist/parse-github-url.d.ts.map
+++ b/src/github-url-parser/dist/parse-github-url.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"parse-github-url.d.ts","sourceRoot":"","sources":["../src/parse-github-url.js"],"names":[],"mappings":"AAAiB,yCAUhB"}

--- a/src/github-url-parser/dist/reserved-names.d.ts
+++ b/src/github-url-parser/dist/reserved-names.d.ts
@@ -1,0 +1,3 @@
+export = names;
+declare const names: string[];
+//# sourceMappingURL=reserved-names.d.ts.map

--- a/src/github-url-parser/dist/reserved-names.d.ts.map
+++ b/src/github-url-parser/dist/reserved-names.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"reserved-names.d.ts","sourceRoot":"","sources":["../src/reserved-names.js"],"names":[],"mappings":";AACA,8BA0BE"}

--- a/src/github-url-parser/package.json
+++ b/src/github-url-parser/package.json
@@ -8,7 +8,9 @@
     "coverage": "jest -c jest.config.js --collect-coverage",
     "eslint": "eslint --config .eslintrc.js \"./**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"./**/*.js\" --fix",
-    "lint": "pnpm eslint"
+    "lint": "pnpm eslint",
+    "preversion": "pnpm types",
+    "types": "tsc"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -16,6 +18,8 @@
     "url": "https://github.com/Seneca-CDOT/telescope/issues"
   },
   "devDependencies": {
-    "jsdom": "18.1.1"
-  }
+    "jsdom": "18.1.1",
+    "typescript": "4.4.4"
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/src/github-url-parser/src/index.js
+++ b/src/github-url-parser/src/index.js
@@ -2,11 +2,21 @@ const extractGitHubInfo = require('./extract-github-info');
 const htmlToUrls = require('./html-to-urls');
 
 /**
+ * @typedef {Object} GitHubInfo
+ * @property {string[]} issues
+ * @property {string[]} pullRequests
+ * @property {string[]} repos
+ * @property {string[]} commits
+ * @property {string[]} users
+ */
+
+/**
  * Extract all GitHub URL info from an HTML string
  * @param {string} htmlString - a string of HTML
- * @param {{ DOMParser }} parser - an HTML DOM Parser
+ * @param {DOMParser} [parser] - an HTML DOM Parser
+ * @returns {GitHubInfo}
  */
-module.exports = (htmlString, { parser }) => {
+module.exports = (htmlString, parser) => {
   if (!parser && !('DOMParser' in globalThis)) {
     throw new Error('Missing parser property and environment does not support DOMParser');
   }

--- a/src/github-url-parser/src/reserved-names.js
+++ b/src/github-url-parser/src/reserved-names.js
@@ -1,4 +1,5 @@
-module.exports = [
+/* @type {string[]} */
+const names = [
   'team',
   'enterprise',
   'explore',
@@ -25,3 +26,5 @@ module.exports = [
   'about',
   'security',
 ];
+
+module.exports = names;

--- a/src/github-url-parser/test/index.test.js
+++ b/src/github-url-parser/test/index.test.js
@@ -12,7 +12,7 @@ describe('githubUrlParser', () => {
       <a href="https://github.com/Seneca-CDOT/telescope/issues/3452">Telescope Issue #3452</a>
       <a href="https://github.com/Seneca-CDOT/telescope/pull/3455/commits/82f16594caa2d81442accd2a891a3d514f2ff39b">Telescope PR commit 82f1659</a>
       `;
-    expect(githubUrlParser(html, { parser: parser() })).toEqual({
+    expect(githubUrlParser(html, parser())).toEqual({
       users: ['Seneca-CDOT'],
       repos: ['Seneca-CDOT/telescope'],
       commits: [

--- a/src/github-url-parser/tsconfig.json
+++ b/src/github-url-parser/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html
+  "include": ["./src/index.js"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
I want to use the new github-url-parser module in the front-end, but it needs types defined. This adds type definitions for what I need.

See steps I followed in https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html.