### PR TITLE
Use Turbo Server Token secret via environment variable

### DIFF
--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -12,6 +12,8 @@ jobs:
   eslint:
     name: ESLint Check
     runs-on: ubuntu-latest
+    env:
+      SERVER_TOKEN: ${{ secrets.turbo_server_token }}
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.2.1
@@ -23,9 +25,9 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ github.token }}
-          server-token: ${{ secrets.turbo_server_token }}
+          server-token: ${{ env.SERVER_TOKEN }}
 
       - name: Install dependencies and run eslint
         run: |
           pnpm install
-          pnpm turbo run lint --api="http://127.0.0.1:9080" --token="${{ secrets.server-token }}"
+          pnpm turbo run lint --api="http://127.0.0.1:9080" --token="${{ env.SERVER_TOKEN }}"

--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -11,6 +11,8 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ${{matrix.os}}
+    env:
+      SERVER_TOKEN: ${{ secrets.turbo_server_token }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -27,9 +29,9 @@ jobs:
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:
           repo-token: ${{ github.token }}
-          server-token: ${{ secrets.turbo_server_token }}
+          server-token: ${{ env.SERVER_TOKEN }}
 
       - name: Install dependencies and run tests with default env
         run: |
           pnpm install
-          pnpm turbo run test --api="http://127.0.0.1:9080" --token="${{ secrets.server-token }}"
+          pnpm turbo run test --api="http://127.0.0.1:9080" --token="${{ env.SERVER_TOKEN }}"


### PR DESCRIPTION
I don't think we're allowed to pass a `secret` into an `input` value.  This accomplishes it (or tries to, not sure it will work) by doing it via an environment variable.

If this fails, I'll move it out of secrets--it's just an opaque string.