### PR TITLE
Use git sha as token for Turbo Repo (no secrets)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,14 +18,10 @@ jobs:
   # Make sure eslint passes
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
-    secrets:
-      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   # Run unit tests on all platforms/versions of node
   unit:
     uses: Seneca-CDOT/telescope/.github/workflows/unit-tests-ci.yml@master
-    secrets:
-      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   # Run end-to-end tests along with the microservices in docker-compose on Linux
   e2e:

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -20,5 +20,3 @@ jobs:
   # Make sure eslint passes
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
-    secrets:
-      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}

--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -2,10 +2,6 @@ name: ESLint Workflow
 
 on:
   workflow_call:
-    secrets:
-      turbo_server_token:
-        description: 'The Turborepo local server token'
-        required: true
 
 jobs:
   # Make sure eslint passes
@@ -13,7 +9,8 @@ jobs:
     name: ESLint Check
     runs-on: ubuntu-latest
     env:
-      SERVER_TOKEN: ${{ secrets.turbo_server_token }}
+      # Use the git sha as a unique token for Turbo Repo
+      SERVER_TOKEN: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2.2.1

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -15,8 +15,6 @@ jobs:
   # Make sure eslint passes
   eslint:
     uses: Seneca-CDOT/telescope/.github/workflows/eslint-ci.yml@master
-    secrets:
-      turbo_server_token: ${{ secrets.TURBO_SERVER_TOKEN }}
 
   publish:
     needs: [prettier, eslint]

--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -2,17 +2,14 @@ name: Unit Tests Workflow
 
 on:
   workflow_call:
-    secrets:
-      turbo_server_token:
-        description: 'The Turborepo local server token'
-        required: true
 
 jobs:
   unit:
     name: Unit Tests
     runs-on: ${{matrix.os}}
     env:
-      SERVER_TOKEN: ${{ secrets.turbo_server_token }}
+      # Use the git sha as a unique token for Turbo Repo
+      SERVER_TOKEN: ${{ github.sha }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
New plan: I'm not going to use a secret here, because I can't get it to pass through to the linked action.  The `server-token` just has to be a unique string per-run, so the `github.sha` is perfect.