### PR TITLE
Pass 'SUPABASE_URL' to SSO dev docker

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -125,7 +125,7 @@ services:
     environment:
       # In development and testing, the SSO service needs to contact the Supabase
       # service directly via Docker vs through the http://localhost/v1/supabase domain.
-      - SUPABASE_URL=http://kong:8000
+      - SUPABASE_URL=${SUPABASE_URL:-http://kong:8000}
     depends_on:
       - test-web-content
       - traefik


### PR DESCRIPTION
I'm testing the signup flow using staging supabase. I'd say it works as expected. You can see my test account created on Staging here https://dev.supabase.telescope.cdot.systems/project/default/editor/17293.

I notice `SUPABASE_URL` is hardcoded in SSO docker ENV.