### PR TITLE
Normalize and filter Planet feed urls

### DIFF
--- a/tools/migrate/feed.js
+++ b/tools/migrate/feed.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const jsdom = require('jsdom');
+const normalizeUrl = require('normalize-url');
 
 const { JSDOM } = jsdom;
 const FEED_URL = 'https://wiki.cdot.senecacollege.ca/wiki/Planet_CDOT_Feed_List';
@@ -56,9 +57,10 @@ const parsePlanetFeedList = async () => {
         new URL(feed); // If the URL is valid, continue
         [firstName, lastName] = lines[index + 1].replace(/^\s*name\s*=\s*/, '').split(' ');
 
-        if (!uniqueUrls.has(feed)) {
-          users.push({ firstName, lastName, feed });
-          uniqueUrls.add(feed);
+        const url = normalizeUrl(feed);
+        if (!uniqueUrls.has(url)) {
+          users.push({ firstName, lastName, feed: url });
+          uniqueUrls.add(url);
         }
       } catch {
         // If the URL is invalid, display error message

--- a/tools/migrate/to_supabase.js
+++ b/tools/migrate/to_supabase.js
@@ -1,6 +1,5 @@
 const { createClient } = require('@supabase/supabase-js');
 const { hash } = require('@senecacdot/satellite');
-const normalizeUrl = require('normalize-url');
 const { parsePlanetFeedList } = require('./feed');
 
 require('dotenv').config();
@@ -21,7 +20,7 @@ const { SUPABASE_URL, SERVICE_ROLE_KEY } = process.env;
     url: feed,
     wiki_author_name: `${firstName} ${lastName}`,
     type: 'blog',
-    id: hash(normalizeUrl(feed)),
+    id: hash(feed),
   }));
 
   const { error, count } = await supabase.from('feeds').upsert(feeds, {


### PR DESCRIPTION

Change `tools/migrate` service to normalize feeds URL to avoid duplicates.


## Steps to test the PR

```
   cd tools/migrate
   cp env.example .env
   pnpm to_supabase
```
