### PR TITLE
Do not drop DB when restoring from backup

### DIFF
--- a/docker/supabase/backup/restore-backup.sh
+++ b/docker/supabase/backup/restore-backup.sh
@@ -21,7 +21,6 @@ BACKUP_FILE="$1"
 # too much if you drop the database.
 pg_restore --format=custom \
 	   --clean \
-	   --create \
 	   --if-exists \
 	   --enable-row-security \
 	   --disable-triggers \


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3497 

## Type of Change

- [X] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Instead of dropping the whole database and restoring the database (which happens when `--clean` and `--create` are both used), we just drop all the database objects, leaving the database clean, by only allowing the `--clean` flag.

## Steps to test the PR

1. Run the services (`pnpm run services:start`),
2. Go to the Supabase dashboard (`localhost:8910`),
3. Add several records to the `feed` table in the database.
4. Connect to the `pg-backup-cron-job` container with `docker exec -it pg-backup-cron-job sh`.
5. Create a back up with `/etc/periodic/daily/create-backup`. The dump file will be in `/var/opt/pg_dumps`, take a note of it.
6. Go back to the Supabase dashboard and remove a single record.
7. Go back to the container and run the command `./restore-backup <dump_file>`, where `<dump_file>` should be replaced with the file that you generated in `/var/opt/pg_dumps`.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
