### PR TITLE
Fix Search label text cut off

### DIFF
--- a/src/web/app/src/components/SearchInput/SearchInput.tsx
+++ b/src/web/app/src/components/SearchInput/SearchInput.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
       transition: theme.transitions.create(['background-color', 'border-color'], {
         duration: '.5s',
       }),
-      fontSize: '1.2rem',
+      fontSize: '14px',
       display: 'block',
       color: theme.palette.text.primary,
     },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #3443
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Due to different font-size in `customInput` and `customInputText`, it makes the Search label text cut off.
Fixes:
 - Change font size in `customInput` to match `customInputText`
<!-- Please add a detailed description of what this PR does and why it is needed -->
![image](https://user-images.githubusercontent.com/58233223/163691089-e087bf4b-8c1d-4d6a-8568-b6e5a5a031d7.png)

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->
1. `cp config/env.staging .env`
2. pnpm dev`
3. Go to the search page 
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
