### PR TITLE
Refactor copy button

### DIFF
--- a/src/web/app/src/components/Posts/CopyButton.tsx
+++ b/src/web/app/src/components/Posts/CopyButton.tsx
@@ -1,52 +1,45 @@
-import { useState, CSSProperties, MouseEvent } from 'react';
-import { createStyles } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/IconButton';
-import Paper from '@material-ui/core/Paper';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
-import { Transition } from 'react-transition-group';
-import clsx from 'clsx';
+import { useState, MouseEvent, AllHTMLAttributes } from 'react';
+import { Tooltip, IconButton, createStyles, Zoom } from '@material-ui/core';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+import CopyIcon from '@material-ui/icons/FileCopyOutlined';
+import Check from '@material-ui/icons/Check';
 
 const useStyles = makeStyles(() =>
   createStyles({
-    copyButton: {
-      position: 'absolute',
-      right: 0,
-      padding: '1rem',
-      marginRight: '1.5rem',
-      transitionDuration: '0.2s',
-      transitionTimingFunction: 'ease',
-      cursor: 'pointer',
-      animation: 'fade-in-out 200ms both',
+    copy: {
+      fontSize: 'inherit',
     },
-    icon: {
-      fontSize: '2rem',
+    check: {
+      fill: '#3fb950',
+      fontSize: 'inherit',
     },
-    copyBadge: {
-      position: 'absolute',
-      top: '50%',
-      right: 0,
-      transitionProperty: 'transform, opacity',
-      transitionDuration: '0.2s',
-      transitionTimingFunction: 'ease',
-      borderRadius: '5px',
-      padding: '3px',
+    iconBtn: {
+      padding: '5px',
+      color: 'inherit',
+      fontSize: 'inherit',
     },
   })
 );
 
+const ButtonTooltip = withStyles({
+  tooltip: {
+    fontSize: 'inherit',
+    margin: 0,
+  },
+})(Tooltip);
+
 type CopyButtonProps = {
   onClick: (e: MouseEvent) => void;
+  beforeCopyMessage: string;
+  afterCopyMessage?: string;
 };
 
-const transition: { [state: string]: CSSProperties } = {
-  entered: { transform: 'translate(-70%, -50%)', opacity: 1 },
-  entering: { transform: 'translate(0, -50%)', opacity: 0 },
-  exited: { transform: `translate(0, -50%)`, opacity: 0 },
-  exiting: { transform: `translate(0, -50%)`, opacity: 0 },
-};
-
-const CopyButton = ({ onClick }: CopyButtonProps) => {
+const CopyButton = ({
+  onClick,
+  beforeCopyMessage,
+  afterCopyMessage,
+  ...allOtherProps
+}: CopyButtonProps & AllHTMLAttributes<HTMLDivElement>) => {
   const [copied, setCopied] = useState(false);
   const classes = useStyles();
 
@@ -59,22 +52,26 @@ const CopyButton = ({ onClick }: CopyButtonProps) => {
     }, 2500);
   };
   return (
-    <Button
-      aria-label="copy"
-      onClick={handleClick}
-      className={clsx('copyCodeBtn', classes.copyButton)}
-      color="inherit"
-      size="small"
-    >
-      <FileCopyIcon className={classes.icon} />
-      <Transition in={copied} timeout={300} unmountOnExit>
-        {(state) => (
-          <Paper elevation={5} style={{ ...transition[state] }} className={classes.copyBadge}>
-            Copied ✓
-          </Paper>
-        )}
-      </Transition>
-    </Button>
+    <div {...allOtherProps}>
+      {!copied ? (
+        <ButtonTooltip title={beforeCopyMessage} arrow placement="top" TransitionComponent={Zoom}>
+          <IconButton className={classes.iconBtn} onClick={handleClick}>
+            <CopyIcon className={classes.copy} />
+          </IconButton>
+        </ButtonTooltip>
+      ) : (
+        <ButtonTooltip
+          title={afterCopyMessage || 'Copied!'}
+          arrow
+          placement="top"
+          TransitionComponent={Zoom}
+        >
+          <IconButton className={classes.iconBtn}>
+            <Check className={classes.check} />
+          </IconButton>
+        </ButtonTooltip>
+      )}
+    </div>
   );
 };
 

--- a/src/web/app/src/components/Posts/ShareButton.tsx
+++ b/src/web/app/src/components/Posts/ShareButton.tsx
@@ -1,32 +1,17 @@
-import { useState } from 'react';
-import { Tooltip, IconButton, createStyles, Zoom } from '@material-ui/core';
-import { makeStyles, Theme, withStyles } from '@material-ui/core/styles';
-import CopyIcon from '@material-ui/icons/FileCopyOutlined';
-import Check from '@material-ui/icons/Check';
+import { createStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import CopyButton from './CopyButton';
 
 type Props = {
   url: string;
 };
 
-const ButtonTooltip = withStyles({
-  tooltip: {
-    fontSize: '1.25rem',
-    margin: 0,
-  },
-})(Tooltip);
-
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    copy: {
-      fill: theme.palette.primary.main,
-    },
-
-    check: {
-      fill: '#3fb950',
-    },
-
-    iconBtn: {
-      padding: '5px',
+    copyButton: {
+      color: theme.palette.primary.main,
+      fontSize: '1.25rem',
+      display: 'inline',
     },
   })
 );
@@ -34,34 +19,14 @@ const useStyles = makeStyles((theme: Theme) =>
 const ShareButton = ({ url }: Props) => {
   const classes = useStyles();
 
-  const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false);
-
-  const copyToClipboardEvent = () => {
-    navigator.clipboard.writeText(url);
-    setIsCopiedToClipboard(true);
-
-    setTimeout(() => {
-      setIsCopiedToClipboard(false);
-    }, 3000);
-  };
-
-  return !isCopiedToClipboard ? (
-    <ButtonTooltip title="Copy URL" arrow placement="top" TransitionComponent={Zoom}>
-      <IconButton
-        className={classes.iconBtn}
-        onClick={() => {
-          copyToClipboardEvent();
-        }}
-      >
-        <CopyIcon className={classes.copy} />
-      </IconButton>
-    </ButtonTooltip>
-  ) : (
-    <ButtonTooltip title="Copied" arrow placement="top" TransitionComponent={Zoom}>
-      <IconButton className={classes.iconBtn}>
-        <Check className={classes.check} />
-      </IconButton>
-    </ButtonTooltip>
+  return (
+    <CopyButton
+      className={classes.copyButton}
+      onClick={() => {
+        navigator.clipboard.writeText(url);
+      }}
+      beforeCopyMessage="Copy URL"
+    />
   );
 };
 

--- a/src/web/app/src/components/Posts/Timeline.tsx
+++ b/src/web/app/src/components/Posts/Timeline.tsx
@@ -53,7 +53,26 @@ function removeButton(parent: HTMLElement) {
   parent.querySelectorAll('.copyCodeBtn').forEach((button) => button.remove());
 }
 function createCopyButton(parent: HTMLElement, onClick: (e: MouseEvent) => void) {
-  render(<CopyButton onClick={onClick} />, parent);
+  render(
+    <CopyButton
+      className="copyCodeBtn"
+      style={{
+        position: 'absolute',
+        right: 0,
+        padding: '1rem',
+        marginRight: '1.5rem',
+        transitionDuration: '0.2s',
+        transitionTimingFunction: 'ease',
+        cursor: 'pointer',
+        animation: 'fade-in-out 200ms both',
+        fontSize: '2rem',
+        color: 'inherit',
+      }}
+      onClick={onClick}
+      beforeCopyMessage="Copy code block"
+    />,
+    parent
+  );
 }
 
 function handleMouseMove(e: MouseEvent) {


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3356 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI
- [X] **Refactor**: Change which improves code quality and does not modify behaviour

## Description

This PR refactors the functionality (and styling!) of the copy button used in both the share feature and the code block feature.

## Steps to test the PR

You can test on deployment, however, you can test locally by:

1. Pulling my changes
2. Get the configuration from staging (`cp config/env.staging .env`)
3. Start the front-end (`pnpm dev`)

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
