### PR TITLE
Resize stars depending on screen width

### DIFF
--- a/src/web/app/src/components/StarField.tsx
+++ b/src/web/app/src/components/StarField.tsx
@@ -1,7 +1,7 @@
 import { NamedExoticComponent, useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { request } from '@octokit/request';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import { P5Instance, P5WrapperProps } from 'react-p5-wrapper';
 
 const ReactP5Wrapper = dynamic(
@@ -17,10 +17,13 @@ const ReactP5Wrapper = dynamic(
 
 const P5_WRAPPER_ELEM_ID = 'p5-wrapper';
 
-const useStyles = makeStyles(() => {
+const useStyles = makeStyles((theme: Theme) => {
   return {
     root: {
       width: '70vw',
+      [theme.breakpoints.down('xs')]: {
+        width: '90vw',
+      },
       aspectRatio: '16 / 9',
     },
   };
@@ -90,7 +93,7 @@ class Star {
     const sx = p5.map(x / z, 0, 1, 0, p5.width);
     const sy = p5.map(y / z, 0, 1, 0, p5.height);
 
-    const r = p5.map(this.z, 0, p5.width, 75, 0);
+    const r = p5.map(this.z, 0, p5.width, p5.width * 0.09, 0);
     p5.image(imageGraphic, sx, sy, r, r);
   }
 }


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3194 

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

This PR adapts the sizes of the star profile pictures in the star field so that they are proportional to the screen's width.

## Steps to test the PR

You can test in deployment, however, to test locally:

1. Pull my changes,
2. Copy the `staging` configuration (`cp config/env.staging .env`)
3. Run with `pnpm dev`

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
