### PR TITLE
Fix #3516: don't link outside src/web/docusaurus

### DIFF
--- a/src/web/docusaurus/docs/getting-started/vscode-ssh.md
+++ b/src/web/docusaurus/docs/getting-started/vscode-ssh.md
@@ -2,7 +2,7 @@
 
 :::info
 
-This guide has also been translated into a [CloudFormation](https://aws.amazon.com/cloudformation/) Template that can be used to automatically create the same resources. See [config/e2c-template.yml](../../../../../config/ec2-template.yml).
+This guide has also been translated into a [CloudFormation](https://aws.amazon.com/cloudformation/) Template that can be used to automatically create the same resources. See `config/e2c-template.yml`.
 
 :::
 


### PR DESCRIPTION
Fixes #3516.  We can't link outside the src/web/docusaurus directory, or Docker can't resolve it.