### PR TITLE
Adapt star field to docusaurus

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,7 @@ importers:
       '@docusaurus/preset-classic': 2.0.0-beta.17
       '@docusaurus/types': 2.0.0-beta.17
       '@mdx-js/react': 1.6.22
+      '@octokit/request': 5.6.3
       '@senecacdot/eslint-config-telescope': 1.1.0
       '@types/react': 17.0.44
       clsx: 1.1.1
@@ -595,6 +596,7 @@ importers:
       prism-react-renderer: 1.3.1
       react: 17.0.2
       react-dom: 17.0.2
+      react-p5-wrapper: 3.1.0
       typescript: 4.4.4
       unist-util-visit: 2.0.0
     dependencies:
@@ -602,12 +604,14 @@ importers:
       '@docusaurus/plugin-content-docs': 2.0.0-beta.17_f315c2d88d281911b1fd83660389de05
       '@docusaurus/preset-classic': 2.0.0-beta.17_e659d6b5e555996e015cdab3a346f7f4
       '@mdx-js/react': 1.6.22_react@17.0.2
+      '@octokit/request': 5.6.3
       clsx: 1.1.1
       mdx-mermaid: 1.2.2_86225b747a04048675421f37325d0553
       mermaid: 8.13.8
       prism-react-renderer: 1.3.1_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      react-p5-wrapper: 3.1.0_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@algolia/client-search': 4.9.1
       '@docusaurus/types': 2.0.0-beta.17

--- a/src/web/docusaurus/docs/overview.md
+++ b/src/web/docusaurus/docs/overview.md
@@ -2,7 +2,15 @@
 sidebar_position: 0
 ---
 
+import StarField from '@site/src/components/StarField';
+
 # Telescope Overview
+
+## Our Contributors
+
+The result of Telescope is thanks to the combined work of all these talented people (and robots).
+
+<StarField />
 
 ## Introduction
 

--- a/src/web/docusaurus/package.json
+++ b/src/web/docusaurus/package.json
@@ -22,12 +22,14 @@
     "@docusaurus/plugin-content-docs": "2.0.0-beta.17",
     "@docusaurus/preset-classic": "2.0.0-beta.17",
     "@mdx-js/react": "1.6.22",
+    "@octokit/request": "5.6.3",
     "clsx": "1.1.1",
     "mdx-mermaid": "1.2.2",
     "mermaid": "8.13.8",
     "prism-react-renderer": "1.3.1",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-p5-wrapper": "3.1.0"
   },
   "devDependencies": {
     "@algolia/client-search": "4.9.1",
@@ -35,9 +37,9 @@
     "@senecacdot/eslint-config-telescope": "1.1.0",
     "@types/react": "17.0.44",
     "eslint": "7.32.0",
+    "eslint-plugin-import": "2.25.4",
     "typescript": "4.4.4",
-    "unist-util-visit": "2.0.0",
-    "eslint-plugin-import": "2.25.4"
+    "unist-util-visit": "2.0.0"
   },
   "browserslist": {
     "production": [

--- a/src/web/docusaurus/src/components/StarField.jsx
+++ b/src/web/docusaurus/src/components/StarField.jsx
@@ -1,0 +1,142 @@
+import React, { useState, useEffect } from 'react';
+import { request } from '@octokit/request';
+import { ReactP5Wrapper } from 'react-p5-wrapper';
+import styles from './StarField.module.css';
+
+// The original idea of the process to calculate the position and size of the
+// stars is from Daniel Shiffman (http://codingtra.in).
+// The original video can be found here: https://youtu.be/17WoOqgXsRM
+
+const P5_WRAPPER_ELEM_ID = 'p5-wrapper';
+
+class Star {
+  constructor(profileImage, p5) {
+    const side = 100;
+    const innerCircleRadius = side / 2;
+
+    const starGraphic = p5.createGraphics(side, side);
+    starGraphic.image(profileImage, 0, 0, side, side);
+
+    // Inner circle delineates the border of the picture
+    starGraphic.noFill();
+    starGraphic.strokeWeight(1);
+    starGraphic.stroke('black');
+    starGraphic.square(0, 0, side, innerCircleRadius);
+
+    // Draw a bigger square that will erase the
+    // outside corners
+    const strokeWeight = innerCircleRadius * (p5.sqrt(2) - 1) * 2;
+    starGraphic.blendMode(starGraphic.REMOVE);
+    starGraphic.stroke(0, 0, 0, 255);
+    starGraphic.strokeWeight(strokeWeight);
+    starGraphic.square(
+      -strokeWeight / 2,
+      -strokeWeight / 2,
+      side + strokeWeight,
+      innerCircleRadius + strokeWeight / 2
+    );
+
+    this.imageGraphic = starGraphic;
+    this.p5 = p5;
+    this.x = p5.random(-p5.width / 2, p5.width / 2);
+    this.y = p5.random(-p5.height / 2, p5.height / 2);
+    this.z = p5.random(p5.width * 0.1, p5.width * 0.95);
+  }
+
+  update(speed) {
+    const { p5 } = this;
+
+    this.z -= speed;
+    if (this.z < 1) {
+      this.x = p5.random(-p5.width / 2, p5.width / 2);
+      this.y = p5.random(-p5.height / 2, p5.height / 2);
+      this.z = p5.random(p5.width * 0.1, p5.width * 0.95);
+    }
+  }
+
+  draw() {
+    const { p5, x, y, z, imageGraphic } = this;
+
+    p5.fill(255);
+    p5.noStroke();
+
+    const sx = p5.map(x / z, 0, 1, 0, p5.width);
+    const sy = p5.map(y / z, 0, 1, 0, p5.height);
+
+    const r = p5.map(this.z, 0, p5.width, p5.width * 0.09, 0);
+    p5.image(imageGraphic, sx, sy, r, r);
+  }
+}
+
+const sketch = (p5) => {
+  const stars = [];
+  const speed = 3;
+
+  p5.setup = () => {
+    const { width, height } = document.getElementById(P5_WRAPPER_ELEM_ID).getBoundingClientRect();
+    p5.createCanvas(width, height);
+  };
+
+  p5.windowResized = () => {
+    const { width, height } = document.getElementById(P5_WRAPPER_ELEM_ID).getBoundingClientRect();
+    p5.resizeCanvas(width, height);
+  };
+
+  p5.updateWithProps = (props) => {
+    if (props.contributorList) {
+      props.contributorList.forEach((urlImage) => {
+        p5.loadImage(urlImage, (profileImage) => {
+          stars.push(new Star(profileImage, p5));
+        });
+      });
+    }
+  };
+
+  p5.draw = () => {
+    p5.background(0);
+
+    p5.translate(p5.width / 2, p5.height / 2);
+
+    p5.push();
+    stars.forEach((star) => {
+      star.draw();
+      star.update(speed);
+    });
+    p5.pop();
+  };
+};
+
+const StarField = () => {
+  const [contributorList, setContributorList] = useState(['dummy']);
+  const [contributorPage, setContributorPage] = useState(1);
+
+  useEffect(() => {
+    request('GET /repos/{owner}/{repo}/contributors{?page}', {
+      owner: 'Seneca-CDOT',
+      repo: 'telescope',
+      page: contributorPage,
+    })
+      .then((res) => {
+        const contributorImages = res.data
+          .map((contributor) => contributor.avatar_url)
+          .filter((url) => url !== undefined);
+
+        setContributorList(contributorImages);
+
+        if (contributorImages.length > 0) {
+          setCOntributorPage(contributorPage + 1);
+        }
+
+        return null;
+      })
+      .catch((err) => console.error(err));
+  }, [contributorPage]);
+
+  return (
+    <div id={P5_WRAPPER_ELEM_ID} className={styles.p5Canvas}>
+      <ReactP5Wrapper sketch={sketch} contributorList={contributorList} />
+    </div>
+  );
+};
+
+export default StarField;

--- a/src/web/docusaurus/src/components/StarField.module.css
+++ b/src/web/docusaurus/src/components/StarField.module.css
@@ -1,0 +1,4 @@
+.p5Canvas {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+}


### PR DESCRIPTION
## Issue This PR Addresses

#3407 (this PR just adapts the Star field component)

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [X] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adapts the `StarField` component found on the component to Docusaurus. The deletion of the component can be done when moving the entire `About` page to docusaurus.

## Steps to test the PR

1. Pull the changes
2. Run `pnpm i` (because there are new packages to be added to the docusaurus package).
3. Go to the docusaurus workspace (`cd src/web/docusaurus`)
4. Start the docusaurus app (`pnpm start`).
5. If you go to overview, you should be able to see the star field.

## Checklist

- [X] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
