### PR TITLE
Update Feed in parser service to talk to Supabase instead of Redis

### DIFF
--- a/docker/development.yml
+++ b/docker/development.yml
@@ -81,7 +81,7 @@ services:
       # In development and testing, the SSO service needs to contact the Supabase
       # service directly via Docker vs through the http://localhost/v1/supabase domain.
       # Using staging database
-      - SUPABASE_URL=https://dev.api.telescope.cdot.systems/v1/supabase
+      - SUPABASE_URL=http://kong:8000
     depends_on:
       - elasticsearch
       - traefik

--- a/src/api/parser/env.local
+++ b/src/api/parser/env.local
@@ -38,6 +38,7 @@ PARSER_PORT = 10000
 ################################################################################
 
 # Supabase Secrets
-# Using staging database
-#SUPABASE_URL=http://localhost/v1/supabase
-SUPABASE_URL=https://dev.supabase.telescope.cdot.systems/
+# Staging database
+#SUPABASE_URL=https://dev.supabase.telescope.cdot.systems/
+SUPABASE_URL=http://localhost/v1/supabase
+

--- a/src/api/parser/src/data/feed.js
+++ b/src/api/parser/src/data/feed.js
@@ -6,17 +6,21 @@ const {
   getFeeds,
   addFeed,
   removeFeed,
-  setInvalidFeed,
-  isInvalid,
   setDelayedFeed,
   isDelayed,
   removePost,
   getPost,
   getPosts,
+} = require('../utils/storage');
+
+const {
+  isInvalid,
+  setInvalidFeed,
   getFlaggedFeeds,
   setFlaggedFeed,
   unsetFlaggedFeed,
-} = require('../utils/storage');
+} = require('../utils/supabase');
+
 const { deletePost } = require('../utils/indexer');
 
 const urlToId = (url) => hash(normalizeUrl(url));
@@ -83,8 +87,8 @@ class Feed {
    * Adds the current Feed to the database with the specified reason
    * Returns a Promise
    */
-  setInvalid(reason) {
-    return setInvalidFeed(this.id, reason);
+  setInvalid() {
+    return setInvalidFeed(this.id);
   }
 
   /**

--- a/src/api/parser/src/index.js
+++ b/src/api/parser/src/index.js
@@ -18,7 +18,7 @@ feedQueue.on('drained', loadFeedsIntoQueue);
  */
 feedQueue.on('failed', (job, err) =>
   invalidateFeed(job.data.id, err).catch((error) =>
-    logger.error({ error }, 'Unable to invalidate feed')
+    logger.error({ error }, `Unable to invalidate feed ${job.data.id}`)
   )
 );
 

--- a/src/api/parser/src/parser.js
+++ b/src/api/parser/src/parser.js
@@ -33,7 +33,7 @@ const updateFeed = async (feedData) => {
  */
 const invalidateFeed = async (id, error) => {
   const feed = await Feed.byId(id);
-  await feed.setInvalid(error.message);
+  await feed.setInvalid();
   logger.info(`Invalidating feed ${feed.url} for the following reason: ${error.message}`);
 };
 

--- a/src/api/parser/src/utils/__mocks__/supabase.js
+++ b/src/api/parser/src/utils/__mocks__/supabase.js
@@ -1,0 +1,73 @@
+const { hash } = require('@senecacdot/satellite');
+const normalizeUrl = require('normalize-url');
+
+const urlToId = (url) => hash(normalizeUrl(url));
+
+let feeds = [];
+let feedIds = new Set();
+
+module.exports = {
+  __resetMockFeeds: () => {
+    feeds = [];
+    feedIds = new Set();
+  },
+  /**
+   * @param {Array<Feed | { url: string }>} feedObjects
+   */
+  __setMockFeeds: (feedObjects) => {
+    const mockFeeds = feedObjects.reduce((uniqueFeeds, feed) => {
+      const id = feed.id || urlToId(feed.url);
+      if (!feedIds.has(id)) {
+        feedIds.add(id);
+        return uniqueFeeds.concat({ id, invalid: false, flagged: false });
+      }
+      return uniqueFeeds;
+    }, []);
+    feeds = feeds.concat(mockFeeds);
+  },
+
+  // Invalid feed related functions
+  setInvalidFeed: (id) => {
+    feeds.forEach((feed) => {
+      if (feed.id === id) {
+        feed.invalid = true;
+      }
+    });
+    return Promise.resolve();
+  },
+  getInvalidFeeds: () => {
+    const invalidFeedIds = feeds.filter((feed) => feed.flagged).map((feed) => ({ id: feed.id }));
+    return Promise.resolve(invalidFeedIds);
+  },
+  isInvalid: (id) => {
+    const targetFeed = feeds.find((feed) => feed.id === id);
+    return Promise.resolve(!!targetFeed.invalid);
+  },
+  // Flagged feed related functions
+  getAllFeeds: jest.fn().mockImplementation(() => Promise.resolve(feeds)),
+  setFlaggedFeed: jest.fn().mockImplementation((id) => {
+    feeds.forEach((feed) => {
+      if (feed.id === id) {
+        feed.flagged = true;
+      }
+    });
+    return Promise.resolve();
+  }),
+  unsetFlaggedFeed: jest.fn().mockImplementation((id) => {
+    feeds.forEach((feed) => {
+      if (feed.id === id) {
+        feed.flagged = false;
+      }
+    });
+    return Promise.resolve();
+  }),
+
+  getFlaggedFeeds: jest.fn().mockImplementation(() => {
+    const flaggedFeedIds = feeds.filter((feed) => feed.flagged).map((feed) => feed.id);
+    return Promise.resolve(flaggedFeedIds);
+  }),
+  isFlagged: jest.fn().mockImplementation((id) => {
+    const targetFeed = feeds.find((feed) => feed.id === id);
+    return Promise.resolve(!!targetFeed.flagged);
+  }),
+};

--- a/src/api/parser/src/utils/supabase.js
+++ b/src/api/parser/src/utils/supabase.js
@@ -1,5 +1,7 @@
 const { logger } = require('@senecacdot/satellite');
+const hash = require('@senecacdot/satellite/src/hash');
 const { createClient } = require('@supabase/supabase-js');
+const normalizeUrl = require('normalize-url');
 
 const { SUPABASE_URL, SERVICE_ROLE_KEY } = process.env;
 
@@ -26,5 +28,95 @@ module.exports = {
       author: feed.display_name || feed.wiki_author_name,
       url: feed.url,
     }));
+  },
+
+  // Invalid feed related functions
+  async setInvalidFeed(id) {
+    const { error } = await supabase.from('feeds').update({ invalid: true }).eq('id', id);
+
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, `can't invalidate feed ${id} in supabase`);
+    }
+  },
+
+  async getInvalidFeeds() {
+    const { data: invalidFeeds, error } = await supabase.from('feeds').select().is('invalid', true);
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, "can't fetch invalid feeds in supabase");
+    }
+    return invalidFeeds;
+  },
+  async isInvalid(id) {
+    const { data: invalidFeed, error } = await supabase
+      .from('feeds')
+      .select('invalid')
+      .eq('id', id)
+      .limit(1);
+
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, `can't fetch feed ${id} from supabase`);
+    }
+    return invalidFeed.invalid;
+  },
+
+  // Flagged feed related functions
+  async setFlaggedFeed(id) {
+    const { error } = await supabase.from('feeds').update({ flagged: true }).eq('id', id);
+
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, `can't flag feed ${id} in supabase`);
+    }
+  },
+  async unsetFlaggedFeed(id) {
+    const { error } = await supabase.from('feeds').update({ flagged: false }).eq('id', id);
+
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, `can't unflag feed ${id} in supabase`);
+    }
+  },
+  async getFlaggedFeeds() {
+    const { data: flaggedFeeds, error } = await supabase.from('feeds').select().eq('flagged', true);
+
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, `can't flagged feeds from supabase`);
+    }
+    return flaggedFeeds.map((feed) => feed.id);
+  },
+  async isFlagged(id) {
+    const { data: flaggedFeed, error } = await supabase
+      .from('feeds')
+      .select('flagged')
+      .eq('id', id)
+      .limit(1);
+
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, `can't fetch feed ${id} from supabase`);
+    }
+    return flaggedFeed.flagged;
+  },
+  async addFeeds(feeds) {
+    const { error } = await supabase.from('feeds').insert(
+      feeds.map((feed) => ({
+        url: feed.url,
+        id: hash(normalizeUrl(feed.url)),
+        wiki_author_name: feed.author,
+        invalid: false,
+        flagged: false,
+        type: 'blog',
+        html_url: null,
+        user_id: null,
+      }))
+    );
+    if (error) {
+      logger.error({ error });
+      throw Error(error.message, "can't insert feeds to supabase");
+    }
   },
 };

--- a/src/api/parser/test/e2e/parser-flow.test.js
+++ b/src/api/parser/test/e2e/parser-flow.test.js
@@ -1,26 +1,12 @@
-const { hash, fetch, logger, Satellite } = require('@senecacdot/satellite');
+const { hash, logger, Satellite } = require('@senecacdot/satellite');
 const normalizeUrl = require('normalize-url');
 
 const { loadFeedsIntoQueue, invalidateFeed } = require('../../src/parser');
 const feedWorker = require('../../src/feed/worker');
 const { feedQueue } = require('../../src/feed/queue');
-const { getAllFeeds } = require('../../src/utils/supabase');
+const { addFeeds, getInvalidFeeds, getAllFeeds } = require('../../src/utils/supabase');
 
 const urlToId = (url) => hash(normalizeUrl(url));
-
-jest.mock('../../src/utils/supabase', () => ({
-  ...jest.requireActual('../../src/utils/supabase'),
-  getAllFeeds: jest.fn(),
-}));
-
-const fetchData = async (url) => {
-  const res = await fetch(url);
-  const data = await res.json();
-  return data;
-};
-
-// return true if check array has all elements that exist in target array
-const checker = (target, check) => check.every((value) => target.includes(value));
 
 // resolve once feedQueue has finished processing all jobs
 const waitForDrained = () =>
@@ -38,69 +24,41 @@ const processFeeds = () => {
 };
 
 let satellite;
-
+const valid = [
+  {
+    author: 'Tue Nguyen',
+    url: 'http://localhost:8888/feed.xml',
+  },
+];
+const invalid = [
+  {
+    author: 'John Doe',
+    url: 'https://johnhasinvalidfeed.com/feed',
+  },
+  {
+    author: 'Jane Doe',
+    url: 'https://janehasinvalidfeed.com/feed',
+  },
+];
 beforeAll(async () => {
   satellite = new Satellite();
   await feedQueue.empty(); // remove jobs from the queue
+  await addFeeds([...valid, ...invalid]);
   await processFeeds(); // start the feed queue for e2e test
 });
 
 afterAll(() => Promise.all([feedQueue.close(), satellite.stop()]));
-
 describe("Testing parser service's flow", () => {
-  test('Parser should process 2 valid feeds', async () => {
-    const valid = [
-      {
-        author: 'Tue Nguyen',
-        url: 'http://localhost:8888/feed.xml',
-      },
-      {
-        author: 'Antonio Bennett',
-        url: 'http://localhost:8888/feed.xml',
-      },
-    ];
-    getAllFeeds.mockImplementation(() => Promise.resolve(valid));
+  test('Parser should process 1 valid feed and 2 invalid feeds', async () => {
     loadFeedsIntoQueue();
     await waitForDrained();
+    const allFeeds = await getAllFeeds();
+    const invalidFeeds = await getInvalidFeeds();
+    const invalidIds = invalid.map((feed) => urlToId(feed.url));
 
-    const allFeeds = await fetchData(`${process.env.POSTS_URL}/feeds`);
-    const validFeeds = await Promise.all(allFeeds.map((feed) => fetchData(feed.url)));
-    const validIds = validFeeds.map((feed) => feed.id);
-
-    expect(allFeeds.length).toBeGreaterThan(0);
-    expect(
-      checker(
-        validIds,
-        valid.map((elem) => urlToId(elem.url))
-      )
-    ).toBe(true); // check if feeds from Posts service contains all valid feeds
-  });
-
-  test('Parser should process 2 invalid feeds', async () => {
-    const invalid = [
-      {
-        author: 'John Doe',
-        url: 'https://johnhasinvalidfeed.com/feed',
-      },
-      {
-        author: 'Jane Doe',
-        url: 'https://janehasinvalidfeed.com/feed',
-      },
-    ];
-    getAllFeeds.mockImplementation(() => Promise.resolve(invalid));
-    loadFeedsIntoQueue();
-    await waitForDrained();
-
-    const feeds = await fetchData(`${process.env.POSTS_URL}/feeds/invalid`);
-    const invalidFeeds = await Promise.all(feeds.map((feed) => fetchData(feed.url)));
-    const invalidIds = invalidFeeds.map((feed) => feed.id);
-
-    expect(invalidFeeds.length).toBeGreaterThan(0);
-    expect(
-      checker(
-        invalidIds,
-        invalid.map((elem) => urlToId(elem.url))
-      )
-    ).toBe(true); // check if feeds from Posts service contains all invalid feeds
+    expect(allFeeds.length).toBe(3);
+    expect(invalidFeeds.length).toBe(2);
+    expect(invalidIds.includes(invalidFeeds[0].id)).toBe(true);
+    expect(invalidIds.includes(invalidFeeds[1].id)).toBe(true);
   });
 });

--- a/src/api/parser/test/feed-processor.test.js
+++ b/src/api/parser/test/feed-processor.test.js
@@ -3,6 +3,8 @@ const processor = require('../src/feed/processor');
 const Feed = require('../src/data/feed');
 
 jest.mock('../src/utils/indexer');
+jest.mock('../src/utils/supabase');
+const { __setMockFeeds } = require('../src/utils/supabase');
 
 describe('Feed Processor Tests', () => {
   const createFeed = (url) =>
@@ -13,6 +15,7 @@ describe('Feed Processor Tests', () => {
 
   test('Passing a valid Atom feed URI should pass', async () => {
     const url = fixtures.getAtomUri();
+    __setMockFeeds([{ url }]);
     const id = await createFeed(url);
     fixtures.nockValidAtomResponse();
     const job = fixtures.createMockJobObjectFromFeedId(id);
@@ -21,6 +24,7 @@ describe('Feed Processor Tests', () => {
 
   test('Passing a valid RSS feed URI should pass', async () => {
     const url = fixtures.getRssUri();
+    __setMockFeeds([{ url }]);
     const id = await createFeed(url);
     fixtures.nockValidRssResponse();
     const job = fixtures.createMockJobObjectFromFeedId(id);
@@ -29,6 +33,7 @@ describe('Feed Processor Tests', () => {
 
   test('Passing an invalid RSS category feed should pass', async () => {
     const url = fixtures.getRssUri();
+    __setMockFeeds([{ url }]);
     const id = await createFeed(url);
     fixtures.nockInvalidRssResponse();
     const job = fixtures.createMockJobObjectFromFeedId(id);
@@ -37,6 +42,7 @@ describe('Feed Processor Tests', () => {
 
   test('Passing a valid RSS category feed should pass', async () => {
     const url = fixtures.getRssUri();
+    __setMockFeeds([{ url }]);
     const id = await createFeed(url);
     fixtures.nockValidRssResponse();
     const job = fixtures.createMockJobObjectFromFeedId(id);

--- a/src/api/parser/test/post.test.js
+++ b/src/api/parser/test/post.test.js
@@ -26,6 +26,8 @@ const Post = require('../src/data/post');
 const Feed = require('../src/data/feed');
 
 jest.mock('../src/utils/indexer');
+jest.mock('../src/utils/supabase');
+const { __setMockFeeds } = require('../src/utils/supabase');
 
 describe('Post data class tests', () => {
   let feed;
@@ -42,6 +44,7 @@ describe('Post data class tests', () => {
   };
 
   beforeAll(async () => {
+    __setMockFeeds([{ url: 'http://feed-url.com/' }]);
     const id = await Feed.create({
       author: 'Feed Author',
       url: 'http://feed-url.com/',
@@ -136,6 +139,7 @@ describe('Post data class tests', () => {
   });
 
   test('Post.create() should be able to parse an Object into a Post', async () => {
+    __setMockFeeds([{ url: data.url }]);
     const id = await Post.create(data);
     const expectedId = 'a371654c75';
     expect(id).toEqual(expectedId);
@@ -145,6 +149,7 @@ describe('Post data class tests', () => {
   });
 
   test('Posts should have a (dynamic) text property', async () => {
+    __setMockFeeds([{ url: data.url }]);
     const id = await Post.create(data);
     const post = await Post.byId(id);
     expect(post.text).toEqual(text);
@@ -154,6 +159,7 @@ describe('Post data class tests', () => {
     const missingData = { ...data, updated: null, feed };
 
     // Make sure that updated was turned into a date
+    __setMockFeeds([{ url: missingData.url }]);
     const id = await Post.create(missingData);
     const parsed = await Post.byId(id);
     expect(parsed.updated).toBeDefined();
@@ -161,6 +167,7 @@ describe('Post data class tests', () => {
   });
 
   test('Post.save() and Post.byId() should both work as expected', async () => {
+    __setMockFeeds([{ url: data.url }]);
     const id = await Post.create(data);
     const post = await Post.byId(id);
     expect(post).toEqual(data);

--- a/src/api/parser/test/storage.test.js
+++ b/src/api/parser/test/storage.test.js
@@ -3,19 +3,18 @@ const {
   addFeed,
   getFeed,
   getFeeds,
-  getFlaggedFeeds,
   getFeedsCount,
   removeFeed,
-  setFlaggedFeed,
-  unsetFlaggedFeed,
   addPost,
   getPost,
   getPosts,
   getPostsCount,
   removePost,
 } = require('../src/utils/storage');
-
 const Feed = require('../src/data/feed');
+
+jest.mock('../src/utils/supabase');
+const { __setMockFeeds } = require('../src/utils/supabase');
 
 describe('Storage tests for feeds', () => {
   const feed1 = new Feed('James Smith', 'http://seneca.co/jsmith', 'user');
@@ -30,7 +29,10 @@ describe('Storage tests for feeds', () => {
     'last-modified'
   );
 
-  beforeAll(() => Promise.all([addFeed(feed1), addFeed(feed2), addFeed(feed3), addFeed(feed4)]));
+  beforeAll(async () => {
+    __setMockFeeds([feed1, feed2, feed3, feed4]);
+    await Promise.all([addFeed(feed1), addFeed(feed2), addFeed(feed3), addFeed(feed4)]);
+  });
 
   it('should allow retrieving a feed by id after inserting', async () => {
     const feed = await getFeed(feed1.id);
@@ -84,24 +86,6 @@ describe('Storage tests for feeds', () => {
     const feeds = await getFeeds();
     expect(removedFeed.id).toBe(undefined);
     expect(feeds.includes(feed.id)).toBe(false);
-  });
-
-  it('feed3 should appear in flaggedFeed set after being flagged', async () => {
-    const feed = await getFeed(feed3.id);
-    await setFlaggedFeed(feed3.id);
-    const feeds = await getFeeds();
-    const flaggedFeeds = await getFlaggedFeeds();
-    expect(flaggedFeeds.includes(feed.id)).toBe(true);
-    expect(feeds.includes(feed.id)).toBe(false);
-  });
-
-  it('feed3 should not appear in flaggedFeed set after being unflagged', async () => {
-    const feed = await getFeed(feed3.id);
-    await unsetFlaggedFeed(feed3.id);
-    const feeds = await getFeeds();
-    const flaggedFeeds = await getFlaggedFeeds();
-    expect(feeds.includes(feed.id)).toBe(true);
-    expect(flaggedFeeds.includes(feed.id)).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #3464 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description:
- Any flagging or invaliding feeds functions will use Supabase instead of Redis
- Remove `invalid` and `flagged` feed related functions in `storage.test.js`
- Create `supabase.js` to handle invalidating and flagging
- Change imports in other files
- Create supabase mocks and fix tests
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR
- `pnpm services:start`
- ` cd src/db`
- `cp env.example .env`
- `pnpx prisma migrate dev`
- `cd ../../tools/migrate`
- `cp env.example .env`
- `pnpm to_supabase` to put all the feeds into supabase for parser to fetch
- Let `parser` run for a minute and go to `http://localhost:8910/project/default`
- Check column `invalid` of `feeds` table, you will some of them are true. Or use table filter to see
### To test the e2e test:
- `pnpm services:start`
- `pnpm migrate`
- Stop `parser` container if running
- Remove all feeds in supabase
- `rm -rf redis-data` and restart redis
- `pnpm jest:e2e src/api/parser`
<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
