### PR TITLE
Add missing dependency_discovery_url in CD

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'https://dev.api.telescope.cdot.systems/v1/status'
         type: string
+      dependency_discovery_url:
+        description: 'The feed-discovery microservice URL (defaults to staging)'
+        required: false
+        default: 'https://dev.api.telescope.cdot.systems/v1/dependency-discovery'
+        type: string
       supabase_url:
         description: 'The Supabase URL'
         required: false
@@ -93,6 +98,7 @@ jobs:
               GIT_COMMIT=${{ github.sha }}
               SUPABASE_URL=${{ inputs.supabase_url }}
               ANON_KEY=${{ inputs.anon_key }}
+              DEPENDENCY_DISCOVERY_URL=${{ inputs.dependency_discovery_url }}
           - context: src/api/planet
             image: planet
           - context: src/api/posts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       search_url: 'https://api.telescope.cdot.systems/v1/search'
       feed_discovery_url: 'https://api.telescope.cdot.systems/v1/feed-discovery'
       status_url: 'https://api.telescope.cdot.systems/v1/status'
+      dependency_discovery_url: 'https://api.telescope.cdot.systems/v1/dependency-discovery'
       supabase_url: 'https://api.telescope.cdot.systems/v1/supabase'
       anon_key: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UiLAogICAgImlhdCI6IDE2NDg2MTI4MDAsCiAgICAiZXhwIjogMTgwNjM3OTIwMAp9.YMOYR_8pZqqDRJkoAFuEWp-FaQfvmHXTOXKncBlRjdE'
     secrets:


### PR DESCRIPTION
After https://github.com/Seneca-CDOT/telescope/pull/3487 merged. I noticed the fetch for fetching dependencies URL was not correct. 
![image](https://user-images.githubusercontent.com/58233223/164291192-a3ed24cb-93f4-4bb3-9914-75633ea7e2b9.png)

Fix: 
- Added the missing dependency_discovery_url in CD