### PR TITLE
Disable e2e tests in Chromium until we fix #3504

### DIFF
--- a/jest-playwright.config.js
+++ b/jest-playwright.config.js
@@ -8,5 +8,9 @@ module.exports = {
     // slowMo: 1000,
     headless: true,
   },
-  browsers: ['chromium', 'firefox', 'webkit'],
+  browsers: [
+    /* 'chromium' - chromium disabled until we fix https://github.com/Seneca-CDOT/telescope/issues/3504 */
+    'firefox',
+    'webkit',
+  ],
 };

--- a/src/api/sso/test/e2e/signup-flow.test.js
+++ b/src/api/sso/test/e2e/signup-flow.test.js
@@ -63,8 +63,7 @@ describe('Signup Flow', () => {
   it('should have none of the users in the Users service for test data accounts', () =>
     ensureUsers(users, false));
 
-  // https://github.com/Seneca-CDOT/telescope/issues/3504
-  it.skip('signup flow works to login and register a new Telescope user', async () => {
+  it('signup flow works to login and register a new Telescope user', async () => {
     // Part 1: login using SSO, as a user who does not have a Telescope account.
     // Confirm that the payload of the token we get back matches what we expect.
     // NOTE: the data comes from config/simplesamlphp-users.php.


### PR DESCRIPTION
Trying to disable Chromium in e2e tests until we fix #3504.