### PR TITLE
Add --team flag to turborepo command

### DIFF
--- a/.github/workflows/eslint-ci.yml
+++ b/.github/workflows/eslint-ci.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install dependencies and run eslint
         run: |
           pnpm install
-          pnpm turbo run lint --api="http://127.0.0.1:9080" --token="${{ env.SERVER_TOKEN }}"
+          pnpm turbo run lint --api="http://127.0.0.1:9080" --token="${{ env.SERVER_TOKEN }}" --team="telescope-admins"

--- a/.github/workflows/unit-tests-ci.yml
+++ b/.github/workflows/unit-tests-ci.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Install dependencies and run tests with default env
         run: |
           pnpm install
-          pnpm turbo run test --api="http://127.0.0.1:9080" --token="${{ env.SERVER_TOKEN }}"
+          pnpm turbo run test --api="http://127.0.0.1:9080" --token="${{ env.SERVER_TOKEN }}" --team="telescope-admins"


### PR DESCRIPTION
This PR adds the `-team` flag as per recommendation: https://github.com/felixmosh/turborepo-gh-artifacts/issues/6#issuecomment-1105721055

We will be able to see if this works after it's been merged.