### PR TITLE
Status service documentation

### DIFF
--- a/src/web/docusaurus/docs/api-services/status.md
+++ b/src/web/docusaurus/docs/api-services/status.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 7
+---
+
+# Status Service
+
+## Overview
+
+Status service displays various metrics about Telescope and is also referred to as **The dashboard**. It is not written using React, but has other frameworks. For HTML [Handlebars](https://handlebarsjs.com) is used to divide content into smaller and more manageable views. For CSS the following extensions are used: [SASS](https://sass-lang.com) and [Material Dashboard](https://www.creative-tim.com/learning-lab/bootstrap/overview/material-dashboard).
+
+:::note
+
+The dashboard is somewhat of a "sanctuary" development environment for those that prefer to not deal with React
+
+:::
+
+## Setup
+
+```bash
+# Install dependencies
+pnpm install
+```
+
+```bash
+# Boot up website and server
+pnpm dev
+```
+
+The website is live at `localhost:1111`
+
+### SCSS
+
+After making changes to `scss` files, run
+
+```bash
+# Compile scss to css
+pnpm compile:scss
+```
+
+Optionally: watch for scss changes
+
+```bash
+# If your IDE stuck at saving files, go with manually compiling scss
+pnpm watch:scss
+```
+
+## Views
+
+There are views for separate pages and partial views which are composite components to be mixed and matched. Each view has a `.hbs` file extension. The starting point is `elescope/src/api/status/src/views/layouts/main.hbs`.
+
+#### Main views:
+
+- **Status**: Consists of **Card partials** and the **API status board**. Currently is the default page.
+- **Builds**: A build log of Telescope Production.
+
+#### Partials:
+
+- **Sidebar**: A navigation bar that has links to views and different Telescope deployments.
+- **Header**: A templated header that changes contents based on which page you are on.
+- **API Status board**: Displays a list of Telescope's API services along with their status. If a certain part of Telescope isn't working, you would find out from this list.
+- **Cards**: Displays a single and specific statistic in a view of a "card". There are various cards with different information on them.
+
+## API status board
+
+`telescope/src/api/status/src/services.js` specifically fetches each service's status to display it on the dashboard. Currently, it requests status on the following services:
+
+- `parser`
+- `sso`
+- `image`
+- `posts`
+- `feed-discovery`
+- `search`
+- `telescope`
+- `autodeployment`
+- `dependency-discovery`
+- `rss-bridge`
+- `docusaurus`
+
+If the request gets a proper response in time, then the service is displayed to be working.
+
+:::info
+
+If you run the dashboard on a staging branch, it will display you status of services specifically on staging.
+
+:::

--- a/src/web/docusaurus/docs/api-services/status.md
+++ b/src/web/docusaurus/docs/api-services/status.md
@@ -22,6 +22,11 @@ pnpm install
 ```
 
 ```bash
+# Go to the status service directory
+cd src/api/status
+```
+
+```bash
 # Boot up website and server
 pnpm dev
 ```
@@ -50,7 +55,7 @@ There are views for separate pages and partial views which are composite compone
 
 #### Main views:
 
-- **Status**: Consists of **Card partials** and the **API status board**. Currently is the default page.
+- **Status**: Consists of **Card partials** and the **API status board**. This is the current default page.
 - **Builds**: A build log of Telescope Production.
 
 #### Partials:


### PR DESCRIPTION
## Issue This PR Addresses

#3291 Only the status part

## Type of Change

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Documentation for the status service. It is the first draft and is open to edits.

## Steps to test the PR

- `cd src/web/docusaurus`
- `pnpm start`
- localhost:4631
- Click on Docs tab
- Click on API services, then `Status`
- Read the content. Does it make sense? Can it be better?

## Checklist

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)

No tests for just docs. Prettier was okay with this.
No need for screenshots for just text.