### PR TITLE
Fix unique feeds id constraint error

### DIFF
--- a/src/api/sso/src/middleware.js
+++ b/src/api/sso/src/middleware.js
@@ -133,7 +133,7 @@ const createNewProfile = async (id, body) => {
         html_url: blogUrl,
         type: type || 'blog',
       })),
-      { returning: 'minimal' }
+      { returning: 'minimal', onConflict: 'id' }
     );
   }
   return result;


### PR DESCRIPTION
Fix #3560 by adding `onConflict` option to tell Supabase to update existing feeds that has a UNIQUE `id` constraint.

https://supabase.com/docs/reference/javascript/upsert