### PR TITLE
Improve <BannerButtons> styles

### DIFF
--- a/src/web/app/src/components/BannerButtons.tsx
+++ b/src/web/app/src/components/BannerButtons.tsx
@@ -16,12 +16,25 @@ const useStyles = makeStyles((theme) => ({
     right: '5%',
     display: 'flex',
     justifyContent: 'space-around',
-    '& > .MuiButton-root': {
-      color: 'white',
-      border: '1.5px solid white',
-      '&:hover': {
-        color: '#9ABDFF',
-      },
+  },
+  signUpButton: {
+    color: 'white',
+    fontSize: '1.3rem',
+    border: '1.5px solid white',
+    '&:hover': {
+      color: '#9ABDFF',
+      borderColor: '#9ABDFF',
+      backgroundColor: 'transparent',
+    },
+  },
+  buttons: {
+    border: 'none',
+    color: 'white',
+    padding: 0,
+    fontSize: '1.2rem',
+    '&:hover': {
+      color: '#9ABDFF',
+      backgroundColor: 'transparent',
     },
   },
   userSignedInClass: {
@@ -54,6 +67,9 @@ const BannerButtons = () => {
 
   const router = useRouter();
 
+  const handleSignIn = () => login();
+  const handleSignOut = () => logout();
+
   return (
     <div
       className={clsx(
@@ -67,19 +83,12 @@ const BannerButtons = () => {
           message={`Hello ${user?.name}, to sign in you need to create your Telescope account. Click SIGN UP to start.`}
           agreeAction={() => router.push('/signup')}
           agreeButtonText="SIGN UP"
-          disagreeAction={() => logout()}
+          disagreeAction={handleSignOut}
           disagreeButtonText="CANCEL"
         />
       )}
       <Link href="https://dev.telescope.cdot.systems/docs/overview/" passHref>
-        <Button
-          style={{
-            border: 'none',
-            padding: 0,
-            fontSize: '1.2rem',
-          }}
-          variant="outlined"
-        >
+        <Button className={classes.buttons} variant="outlined">
           About us
         </Button>
       </Link>
@@ -89,7 +98,7 @@ const BannerButtons = () => {
           <ButtonTooltip title="Sign out" arrow placement="top" TransitionComponent={Zoom}>
             <div>
               <TelescopeAvatar
-                action={() => logout()}
+                action={handleSignOut}
                 name={user.name}
                 img={user.avatarUrl}
                 size="40px"
@@ -99,24 +108,11 @@ const BannerButtons = () => {
         </>
       ) : (
         <>
-          <Button
-            style={{
-              border: 'none',
-              padding: 0,
-              fontSize: '1.2rem',
-            }}
-            onClick={() => login()}
-            variant="outlined"
-          >
+          <Button className={classes.buttons} onClick={handleSignIn} variant="outlined">
             Sign in
           </Button>
           <Link href="/signup" passHref>
-            <Button
-              style={{
-                fontSize: '1.3rem',
-              }}
-              variant="outlined"
-            >
+            <Button className={classes.signUpButton} variant="outlined">
               Sign up
             </Button>
           </Link>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [X] **UI**: Change which improves UI

## Description

A `background-color` showed up when hovering the mouse over the banner buttons. 
Before:
<img width="387" alt="Screen Shot 2022-04-23 at 4 19 12 PM" src="https://user-images.githubusercontent.com/60857409/164944853-038532be-c122-49a0-9f51-8e0d8d0f0104.png">
After:
<img width="326" alt="Screen Shot 2022-04-23 at 4 17 53 PM" src="https://user-images.githubusercontent.com/60857409/164944851-c4b011b3-0e09-4f95-a8ce-558c87873504.png">


The button border wasn't changing its colour when hovering the mouse over the `Sign up` button.
Before:
<img width="338" alt="Screen Shot 2022-04-23 at 4 19 16 PM" src="https://user-images.githubusercontent.com/60857409/164944854-52602bec-bff8-443b-ad20-58b0d9642f6d.png">
After:
<img width="384" alt="Screen Shot 2022-04-23 at 4 18 00 PM" src="https://user-images.githubusercontent.com/60857409/164944852-83c55ef1-09c4-4165-ba79-3d78896d80aa.png">

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
