### PR TITLE
Wait on SAML login to be ready

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -39,6 +39,8 @@ jobs:
       - run: pnpm install
       - name: Pull/Build Docker Containers Necessary for Running E2E Tests
         run: docker compose --env-file ./config/env.development up -d ${{ env.DOCKER_CONTAINERS }}
+      - name: Wait for Postgres and Login containers to become fully ready
+        run: pnpx -y wait-on -t 60000 tcp:5432 http://localhost:8081/simplesaml
       - name: Apply database migrations
         run: pnpm db:migrate
       - run: pnpm jest:e2e

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,7 +252,6 @@ importers:
 
   src/api/sso:
     specifiers:
-      '@jcoreio/wait-for-postgres': 2.0.0
       '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
       '@supabase/supabase-js': 1.29.4
@@ -280,7 +279,6 @@ importers:
       passport: 0.5.2
       passport-saml: 3.2.1
     devDependencies:
-      '@jcoreio/wait-for-postgres': 2.0.0
       '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       env-cmd: 10.1.0
       eslint: 7.32.0
@@ -4211,23 +4209,6 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
-  /@jcoreio/poll/2.3.1:
-    resolution: {integrity: sha512-NKtnakQBJVwu5//JgR2NIL1chYSEtiSXT4qj19Ia7CXqAG7WvzRSBa8nZtNyFwnNVMMP0UXz1g1JfLq1KYXBeA==}
-    dependencies:
-      '@babel/runtime': 7.17.2
-    dev: true
-
-  /@jcoreio/wait-for-postgres/2.0.0:
-    resolution: {integrity: sha512-GbBmn9Mo/3+KABREQcM7zaESilZH16ZHSPOV0c+34RLjxU0d04EzvmkN1mQrS88wLsj0ANCO3iGr7sAADdcquw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      '@jcoreio/poll': 2.3.1
-      p-event: 4.2.0
-      pg: 8.7.3
-    transitivePeerDependencies:
-      - pg-native
-    dev: true
-
   /@jest/console/27.5.1:
     resolution: {integrity: sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -8153,11 +8134,6 @@ packages:
   /buffer-indexof/1.1.1:
     resolution: {integrity: sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==}
     dev: false
-
-  /buffer-writer/2.0.0:
-    resolution: {integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==}
-    engines: {node: '>=4'}
-    dev: true
 
   /buffer/5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -15127,16 +15103,10 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /p-event/4.2.0:
-    resolution: {integrity: sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      p-timeout: 3.2.0
-    dev: true
-
   /p-finally/1.0.0:
     resolution: {integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=}
     engines: {node: '>=4'}
+    dev: false
 
   /p-is-promise/3.0.0:
     resolution: {integrity: sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==}
@@ -15219,6 +15189,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
+    dev: false
 
   /p-try/1.0.0:
     resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}
@@ -15277,10 +15248,6 @@ packages:
       registry-auth-token: 4.2.1
       registry-url: 5.1.0
       semver: 6.3.0
-
-  /packet-reader/1.0.0:
-    resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
-    dev: true
 
   /pako/0.2.9:
     resolution: {integrity: sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=}
@@ -15506,62 +15473,6 @@ packages:
   /performance-now/2.1.0:
     resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
     dev: false
-
-  /pg-connection-string/2.5.0:
-    resolution: {integrity: sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==}
-    dev: true
-
-  /pg-int8/1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
-    dev: true
-
-  /pg-pool/3.5.1_pg@8.7.3:
-    resolution: {integrity: sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==}
-    peerDependencies:
-      pg: '>=8.0'
-    dependencies:
-      pg: 8.7.3
-    dev: true
-
-  /pg-protocol/1.5.0:
-    resolution: {integrity: sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==}
-    dev: true
-
-  /pg-types/2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
-    dependencies:
-      pg-int8: 1.0.1
-      postgres-array: 2.0.0
-      postgres-bytea: 1.0.0
-      postgres-date: 1.0.7
-      postgres-interval: 1.2.0
-    dev: true
-
-  /pg/8.7.3:
-    resolution: {integrity: sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      pg-native: '>=2.0.0'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-    dependencies:
-      buffer-writer: 2.0.0
-      packet-reader: 1.0.0
-      pg-connection-string: 2.5.0
-      pg-pool: 3.5.1_pg@8.7.3
-      pg-protocol: 1.5.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    dev: true
-
-  /pgpass/1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
-    dependencies:
-      split2: 4.1.0
-    dev: true
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -16300,28 +16211,6 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: false
-
-  /postgres-array/2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
-    dev: true
-
-  /postgres-bytea/1.0.0:
-    resolution: {integrity: sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /postgres-date/1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /postgres-interval/1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      xtend: 4.0.2
-    dev: true
 
   /posthtml-parser/0.10.2:
     resolution: {integrity: sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==}
@@ -18122,6 +18011,7 @@ packages:
   /split2/4.1.0:
     resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
     engines: {node: '>= 10.x'}
+    dev: false
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
@@ -20280,6 +20170,7 @@ packages:
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+    dev: false
 
   /xterm-addon-fit/0.5.0_xterm@4.18.0:
     resolution: {integrity: sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,7 @@ importers:
       '@senecacdot/eslint-config-telescope': 1.1.0
       '@senecacdot/satellite': ^1.27.0
       cheerio: 1.0.0-rc.10
+      eslint: 7.32.0
       got: 11.8.3
       nock: 13.2.4
       nodemon: 2.0.15
@@ -113,6 +114,7 @@ importers:
       got: 11.8.3
     devDependencies:
       '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
+      eslint: 7.32.0
       nock: 13.2.4
       nodemon: 2.0.15
       supertest: 6.1.6

--- a/src/api/feed-discovery/package.json
+++ b/src/api/feed-discovery/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@senecacdot/eslint-config-telescope": "1.1.0",
+    "eslint": "7.32.0",
     "nock": "13.2.4",
     "nodemon": "2.0.15",
     "supertest": "6.1.6"

--- a/src/api/sso/jest.config.e2e.js
+++ b/src/api/sso/jest.config.e2e.js
@@ -1,34 +1,14 @@
-// eslint-disable-next-line
-const { waitForPostgres } = require('@jcoreio/wait-for-postgres');
-
 const baseConfig = require('../../../jest.config.base');
 
-module.exports = async () => {
-  try {
-    console.log('Waiting for Supabase postgres container to become ready...');
-    await waitForPostgres({
-      host: 'localhost',
-      user: 'postgres',
-      password: process.env.POSTGRES_PASSWORD,
-      database: 'postgres',
-      timeout: 60 * 1000,
-    });
-  } catch (err) {
-    console.warn('Unable to connect to postgres container');
-    throw err;
-  }
-
-  console.log('Supabase postgres container ready.');
-  return {
-    ...baseConfig,
-    rootDir: '../../..',
-    testMatch: ['<rootDir>/src/api/sso/test/e2e/**/*.test.js'],
-    collectCoverageFrom: ['<rootDir>/src/api/sso/src/**/*.js'],
-    // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright
-    // See the jest-playwright config in the Telescope root ./jest-playwright.config.js
-    preset: 'jest-playwright-preset',
-    // Try reducing the number of tests that can run at once down to 1
-    maxConcurrency: 1,
-    maxWorkers: 1,
-  };
-};
+module.exports = () => ({
+  ...baseConfig,
+  rootDir: '../../..',
+  testMatch: ['<rootDir>/src/api/sso/test/e2e/**/*.test.js'],
+  collectCoverageFrom: ['<rootDir>/src/api/sso/src/**/*.js'],
+  // We use jest-playwright to do browser tests, https://github.com/playwright-community/jest-playwright
+  // See the jest-playwright config in the Telescope root ./jest-playwright.config.js
+  preset: 'jest-playwright-preset',
+  // Try reducing the number of tests that can run at once down to 1
+  maxConcurrency: 1,
+  maxWorkers: 1,
+});

--- a/src/api/sso/package.json
+++ b/src/api/sso/package.json
@@ -35,7 +35,6 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "@jcoreio/wait-for-postgres": "2.0.0",
     "@senecacdot/eslint-config-telescope": "1.1.0",
     "env-cmd": "10.1.0",
     "eslint": "7.32.0",


### PR DESCRIPTION
Wait for `login` container to be ready
.
Fix #3504 

I can reproduce this e2e test failure consistently locally by running the e2e test right after spinning up the containers. So one of the containers must be not ready and make the test fail.

In #3504, following my suggestion, @humphd has tried to debug the `test-web-container` but found nothing suspicious. 
I now realized it's the `login` or `test-saml` container that's not ready for tests.
I couldn't figure out why it takes so long to start up. The repo of the container itself has not been maintained for 4 years https://github.com/kristophjunge/docker-test-saml-idp.
For now, we can wait for the container to be ready before running tests. 

Here's the log of the container.

```
 
[Fri Apr 29 02:44:36.458976 2022] [ssl:warn] [pid 1] AH01906: localhost:443:0 server certificate is a CA certificate (BasicConstraints: CA == TRUE !?)
 
[Fri Apr 29 02:44:36.459226 2022] [ssl:warn] [pid 1] AH01909: localhost:443:0 server certificate does NOT include an ID which matches the server name
 
[Fri Apr 29 02:44:36.623171 2022] [ssl:warn] [pid 1] AH01906: localhost:443:0 server certificate is a CA certificate (BasicConstraints: CA == TRUE !?)
 
[Fri Apr 29 02:44:36.623202 2022] [ssl:warn] [pid 1] AH01909: localhost:443:0 server certificate does NOT include an ID which matches the server name
 
[Fri Apr 29 02:44:36.678412 2022] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.10 (Debian) PHP/7.1.13 OpenSSL/1.0.1t configured -- resuming normal operations
 
[Fri Apr 29 02:44:36.678487 2022] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
 
[Fri Apr 29 02:44:39.781121 2022] [php7:notice] [pid 17] [client 172.18.0.1:56276] simplesamlphp DEBUG [ab6d3b55bc] Session: 'admin' not valid because we are not authenticated.
 
[Fri Apr 29 02:44:39.781410 2022] [php7:notice] [pid 17] [client 172.18.0.1:56276] simplesamlphp DEBUG [ab6d3b55bc] Session: 'login-admin' not valid because we are not authenticated.
 
[Fri Apr 29 02:44:39.793346 2022] [php7:notice] [pid 17] [client 172.18.0.1:56276] simplesamlphp DEBUG [ab6d3b55bc] Localization: using old system
 
[Fri Apr 29 02:44:39.797445 2022] [php7:notice] [pid 17] [client 172.18.0.1:56276] simplesamlphp DEBUG [ab6d3b55bc] Template: Reading [/var/www/simplesamlphp/modules/core/dictionaries/frontpage]
 
[Fri Apr 29 02:44:39.803095 2022] [php7:notice] [pid 17] [client 172.18.0.1:56276] simplesamlphp DEBUG [ab6d3b55bc] Template: Reading [/var/www/simplesamlphp/modules/core/dictionaries/frontpage]
 
[Fri Apr 29 02:44:39.812422 2022] [php7:notice] [pid 17] [client 172.18.0.1:56276] simplesamlphp WARNING [ab6d3b55bc] The class or interface 'SimpleSAML_Logger' is now using namespaces, please use 'SimpleSAML\\Logger'.
 
[Fri Apr 29 02:44:56.293453 2022] [mpm_prefork:notice] [pid 1] AH00169: caught SIGTERM, shutting down
 
[Fri Apr 29 02:45:43.067555 2022] [ssl:warn] [pid 1] AH01906: localhost:443:0 server certificate is a CA certificate (BasicConstraints: CA == TRUE !?)
 
[Fri Apr 29 02:45:43.067683 2022] [ssl:warn] [pid 1] AH01909: localhost:443:0 server certificate does NOT include an ID which matches the server name
 
[Fri Apr 29 02:45:43.146337 2022] [ssl:warn] [pid 1] AH01906: localhost:443:0 server certificate is a CA certificate (BasicConstraints: CA == TRUE !?)
 
[Fri Apr 29 02:45:43.147314 2022] [ssl:warn] [pid 1] AH01909: localhost:443:0 server certificate does NOT include an ID which matches the server name
 
[Fri Apr 29 02:45:43.150282 2022] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.10 (Debian) PHP/7.1.13 OpenSSL/1.0.1t configured -- resuming normal operations
 
[Fri Apr 29 02:45:43.150685 2022] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
 
```