### PR TITLE
[React Native] Change default environment file

### DIFF
--- a/src/mobile/app.config.js
+++ b/src/mobile/app.config.js
@@ -1,4 +1,6 @@
-import 'dotenv/config';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: './.env.development' });
 
 export default {
   expo: {


### PR DESCRIPTION
Our latest mobile app build doesn't have any `env` so it cannot fetch anything.

Fix:
- Change default environment file to use `.env.development`
