### PR TITLE
Fixed 3 small search service bugs

### DIFF
--- a/src/api/search/test/query.test.js
+++ b/src/api/search/test/query.test.js
@@ -469,7 +469,7 @@ describe('author autocomplete query routers', () => {
     res = await request(app).get('/authors/autocomplete/').query({ author: 'ro le' });
     expect(res.status).toBe(200);
     expect(res.body.results).toBe(2);
-    expect(res.body.res).toStrictEqual([
+    expect(res.body.authors).toStrictEqual([
       {
         author: 'Roxanne Lee',
         highlight: '<em>Ro</em>xanne <em>Le</em>e',
@@ -493,7 +493,7 @@ describe('author autocomplete query routers', () => {
     res = await request(app).get('/authors/autocomplete/').query({ author: 'ro le' });
     expect(res.status).toBe(200);
     expect(res.body.results).toBe(0);
-    expect(res.body.res).toStrictEqual([]);
+    expect(res.body.authors).toStrictEqual([]);
   });
 
   it('Return Error when an ElasticSearch Error occurs', async () => {

--- a/src/web/app/src/components/SearchInput/AuthorInput.tsx
+++ b/src/web/app/src/components/SearchInput/AuthorInput.tsx
@@ -99,9 +99,7 @@ const AuthorInput = ({ text, setText, labelFor }: AuthorInputInterface) => {
     async (url) => {
       const res = await fetch(url);
       if (res.ok) {
-        const results = await res.json();
-        // return up to first 10 results
-        return results.res.slice(0, 10);
+        return (await res.json()).authors;
       }
       return [];
     }


### PR DESCRIPTION
- Fixed 3290 - posts not sorting by date
- Fixed 3517 - limit author autocomplete search query results
- Fixed search results not matching full author names
- Renamed result properties for better readability

<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #3290 
Fixes #3517 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
Posts are once again sorted by published date from newest to oldest

Author autocomplete search query results are limited to 10 at the back-end and not the front-end.
Before update:
![image](https://user-images.githubusercontent.com/32626950/184456769-b669e325-7086-40b1-b22a-2f7cc68af84d.png)

After update:
![image](https://user-images.githubusercontent.com/32626950/184456774-a44c939d-b45b-4a73-b0db-18100a0c3dbb.png)



Originally there was a bug when searching the full name of an author. For example, searching for "Roxanne Lee" would return results with both "Roxanne" `OR` "Lee" as the author, resulting to 91 results. Now it will return results of both "Roxanne" `AND` "Lee" with the correct 12 results.
Before update:
![image](https://user-images.githubusercontent.com/32626950/184454784-0c980c26-0ed8-41e5-bf0c-d25dd55d0459.png)

After update:
![image](https://user-images.githubusercontent.com/32626950/184454815-cb5304bd-bf21-4ec1-b959-8759ed97606e.png)



## Steps to test the PR
- `pnpm test` passes all tests
- run and build Telescope
- correct author full name search results and sorted search results can be seen at `http://localhost:8000/search/`
- limited author autocomplete results can be tested at `http://localhost/v1/search/authors/autocomplete`

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)