### PR TITLE
Get correct display_name for feeds

### DIFF
--- a/src/api/parser/src/utils/supabase.js
+++ b/src/api/parser/src/utils/supabase.js
@@ -25,7 +25,7 @@ module.exports = {
 
     return data.map((feed) => ({
       // Prefer the a user's display name if present, fallback to wiki name otherwise
-      author: feed.display_name || feed.wiki_author_name,
+      author: feed.telescope_profiles?.display_name || feed.wiki_author_name,
       url: feed.url,
     }));
   },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #3660 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
I used my old pal `console.log` to see the structure of the feeds that we were pulling from the db.
Turns out there wasn't any `display_name` property with each `feed` object.
```terminal
data structure is: 
 [
  {
    wiki_author_name: 'David Humphrey',
    url: 'http://blog.humphd.org/tag/seneca/rss',
    telescope_profiles: null
  },
  {
    wiki_author_name: null,
    url: 'https://dev.to/feed/rclee',
    telescope_profiles: { display_name: 'Roxanne Lee' }
  }
]
```

## Steps to test the PR
Testing locally is a bit complicated.
1. I changed [src/db/seed/feeds.json](https://github.com/Seneca-CDOT/telescope/blob/master/src/db/seed/feeds.json) to have only 1 feed (for simple testing purposes)
```js
[
  {
    "url": "http://blog.humphd.org/tag/seneca/rss",
    "user_id": null,
    "wiki_author_name": "David Humphrey",
    "html_url": null,
    "type": "blog",
    "invalid": false,
    "flagged": false,
    "id": "a2029d1f3e"
  }
]
```
2. After deleting any redis cache and doing db migration, I went to http://localhost:8910/ ,where the local db console was, to manually add myself a Telescope profile, and linked it to a Feed, making sure I kept `wiki_author_name` as `NULL`

3. Tested to make sure that before the fix my blogs wouldn't show up. (They did not)

4. Tested after the fix, and made sure my blogs showed up (They did)

We won't be able to see the fix on staging cause staging has nothing in the `telescope_profiles` table

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
