### PR TITLE
Fixes #3658: About Us button in all environments redirect to the Docusaurus site in staging

### DIFF
--- a/src/web/app/src/components/BannerButtons.tsx
+++ b/src/web/app/src/components/BannerButtons.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import useAuth from '../hooks/use-auth';
 import TelescopeAvatar from './TelescopeAvatar';
 import PopUp from './PopUp';
+import { webUrl } from '../config';
 
 const useStyles = makeStyles((theme) => ({
   buttonsContainer: {
@@ -87,7 +88,7 @@ const BannerButtons = () => {
           disagreeButtonText="CANCEL"
         />
       )}
-      <Link href="https://dev.telescope.cdot.systems/docs/overview/" passHref>
+      <Link href={`${webUrl}/docs/overview/`} passHref>
         <Button className={classes.buttons} variant="outlined">
           About us
         </Button>


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3658 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR fixes the uses [webUrl](https://github.com/Seneca-CDOT/telescope/blob/538ed2b2457754462d270c97480109760072d3e8/src/web/app/src/config.ts#L5) as opposed to a hardcoded url for the `About us` link.

## Steps to test the PR

- Run locally
- Assert that using different `env` files in [config](https://github.com/Seneca-CDOT/telescope/tree/master/config) to create a local `.env` changes the base `url` used in the `About us` link.
 
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
