### PR TITLE
Closes #3182, #3635: highlight.js reports unescaped HTML

### DIFF
--- a/src/api/parser/src/utils/html/syntax-highlight.js
+++ b/src/api/parser/src/utils/html/syntax-highlight.js
@@ -32,6 +32,12 @@ hljs.registerLanguage('php', require('highlight.js/lib/languages/php'));
 hljs.registerLanguage('dos', require('highlight.js/lib/languages/dos'));
 
 /**
+ * Disable displaying warning message for unescaped html
+ * https://github.com/highlightjs/highlight.js/wiki/security
+ */
+hljs.configure({ ignoreUnescapedHTML: true });
+
+/**
  * Given a parsed JSDOM Object, find all <pre>...</pre> code blocks
  * and apply syntax highlight markup.
  */


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3182 
Fixes #3635 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR changes the config for `higjlightjs` to disable displaying the warning for unescaped html.

## Steps to test the PR

- Run locally
- Assert that messages about unescaped html are not displayed.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
