### PR TITLE
Link to Telescope documentation fix

### DIFF
--- a/src/web/docusaurus/docusaurus.config.js
+++ b/src/web/docusaurus/docusaurus.config.js
@@ -120,7 +120,7 @@ const config = async () => {
               items: [
                 {
                   label: 'Documentation',
-                  href: 'https://docusaurus.io/docs/',
+                  to: '/docs/overview',
                 },
                 {
                   label: 'Slack',


### PR DESCRIPTION
Fixes #3445 

## Type of Change

BugFix

## Description

Fixed the link to the Telescope documentation, the previous link was going to docusaurus documentation

![screenshot](https://user-images.githubusercontent.com/73063742/193938187-ae41673d-46a2-4f69-8e41-4f2c5a5dec82.png)

