### PR TITLE
Update Satellite ES to 8.4.0, ES-mock to 2.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,8 +354,8 @@ importers:
 
   src/satellite:
     specifiers:
-      '@elastic/elasticsearch': 7.17.0
-      '@elastic/elasticsearch-mock': 0.3.1
+      '@elastic/elasticsearch': 8.4.0
+      '@elastic/elasticsearch-mock': 2.0.0
       '@godaddy/terminus': 4.10.2
       '@senecacdot/eslint-config-telescope': 1.1.0
       cors: 2.8.5
@@ -377,8 +377,8 @@ importers:
       prettier: 2.5.1
       pretty-quick: 3.1.3
     dependencies:
-      '@elastic/elasticsearch': 7.17.0
-      '@elastic/elasticsearch-mock': 0.3.1
+      '@elastic/elasticsearch': 8.4.0
+      '@elastic/elasticsearch-mock': 2.0.0
       '@godaddy/terminus': 4.10.2
       cors: 2.8.5
       express: 4.17.3
@@ -3965,6 +3965,14 @@ packages:
       into-stream: 6.0.0
     dev: false
 
+  /@elastic/elasticsearch-mock/2.0.0:
+    resolution: {integrity: sha512-VACQF7GStt8DetY91aJhXCYog6zXM0Vyb62k592EEt3aB4plrOLot+JvlLMC4URjh2jt9qYfER9hn4AI+ULTSw==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      find-my-way: 5.6.0
+      into-stream: 6.0.0
+    dev: false
+
   /@elastic/elasticsearch/7.17.0:
     resolution: {integrity: sha512-5QLPCjd0uLmLj1lSuKSThjNpq39f6NmlTy9ROLFwG5gjyTgpwSqufDeYG/Fm43Xs05uF7WcscoO7eguI3HuuYA==}
     engines: {node: '>=12'}
@@ -3973,6 +3981,30 @@ packages:
       hpagent: 0.1.2
       ms: 2.1.3
       secure-json-parse: 2.4.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@elastic/elasticsearch/8.4.0:
+    resolution: {integrity: sha512-0QZDBePnb5a+d76zjlMYq96IDf0AOuGP7JHugFUYlYwTC7rZvROuZSpoUsvpUjNH2CzMqWgNLIekIR6EHRMIQA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@elastic/transport': 8.2.0
+      tslib: 2.4.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@elastic/transport/8.2.0:
+    resolution: {integrity: sha512-H/HmefMNQfLiBSVTmNExu2lYs5EzwipUnQB53WLr17RCTDaQX0oOLHcWpDsbKQSRhDAMPPzp5YZsZMJxuxPh7A==}
+    engines: {node: '>=14'}
+    dependencies:
+      debug: 4.3.4
+      hpagent: 1.0.0
+      ms: 2.1.3
+      secure-json-parse: 2.4.0
+      tslib: 2.4.0
+      undici: 5.11.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7487,10 +7519,8 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  /ajv-formats/2.1.1_ajv@8.11.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -8399,6 +8429,13 @@ packages:
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /busboy/1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+    dependencies:
+      streamsearch: 1.1.0
     dev: false
 
   /bytes/3.0.0:
@@ -11598,6 +11635,15 @@ packages:
       semver-store: 0.3.0
     dev: false
 
+  /find-my-way/5.6.0:
+    resolution: {integrity: sha512-pFTzbl2u+iSrvVOGtfKenvDmNIhNtEcwbzvRMfx3TGO69fbO5udgTKtAZAaUfIUrHQWLkkWvhNafNz179kaCIw==}
+    engines: {node: '>=12'}
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      safe-regex2: 2.0.0
+    dev: false
+
   /find-pkg/0.1.2:
     resolution: {integrity: sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==}
     engines: {node: '>=0.10.0'}
@@ -12360,6 +12406,11 @@ packages:
 
   /hpagent/0.1.2:
     resolution: {integrity: sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==}
+    dev: false
+
+  /hpagent/1.0.0:
+    resolution: {integrity: sha512-SCleE2Uc1bM752ymxg8QXYGW0TWtAV4ZW3TqH1aOnyi6T6YW2xadCcclm5qeVjvMvfQ2RKNtZxO7uVb9CTPt1A==}
+    engines: {node: '>=14'}
     dev: false
 
   /html-encoding-sniffer/2.0.1:
@@ -16792,12 +16843,6 @@ packages:
   /react-dev-utils/12.0.1_lp7vfajlbu2sfa5pi5ux2nsccm:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.18.6
       address: 1.2.0
@@ -16828,7 +16873,9 @@ packages:
     transitivePeerDependencies:
       - eslint
       - supports-color
+      - typescript
       - vue-template-compiler
+      - webpack
     dev: false
 
   /react-dom/17.0.2_react@17.0.2:
@@ -17675,7 +17722,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1_ajv@8.11.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.11.0
     dev: false
 
@@ -18256,6 +18303,11 @@ packages:
 
   /stream-shift/1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
+    dev: false
+
+  /streamsearch/1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
     dev: false
 
   /strict-uri-encode/2.0.0:
@@ -19138,6 +19190,13 @@ packages:
   /undefsafe/2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
+
+  /undici/5.11.0:
+    resolution: {integrity: sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==}
+    engines: {node: '>=12.18'}
+    dependencies:
+      busboy: 1.6.0
+    dev: false
 
   /unfetch/4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}

--- a/src/satellite/package.json
+++ b/src/satellite/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/Seneca-CDOT/telescope/tree/master/src/satellite",
   "dependencies": {
-    "@elastic/elasticsearch": "7.17.0",
-    "@elastic/elasticsearch-mock": "0.3.1",
+    "@elastic/elasticsearch": "8.4.0",
+    "@elastic/elasticsearch-mock": "2.0.0",
     "@godaddy/terminus": "4.10.2",
     "cors": "2.8.5",
     "express": "4.17.3",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Part one of two for #2913
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Dependency**: Update a dependency

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
We need to update and release ElasticSearch and ElasticSearch-Mock in Satellite before we can update it in Telescope.

Using `8.4.0`, as it is the latest stable version on `npm`

## Steps to test the PR
***Please note***
Telescope runs fine locally, all the docker containers will build, all the posts will show, and search will function as usual.
`Satellite` tests will pass.
However, `Search` tests will break, which is caused from ES-mock being very confused in our monorepo.
But, `Search` tests will work fine again once Telescope is using the new Satellite, with the new ES and ES-mock.

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
