### PR TITLE
Fixes #3614 by adding marginTop prop

### DIFF
--- a/src/web/app/src/components/BannerButtons.tsx
+++ b/src/web/app/src/components/BannerButtons.tsx
@@ -56,6 +56,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ButtonTooltip = withStyles({
   tooltip: {
+    marginTop: '12px',
     fontSize: '1.5rem',
     margin: 0,
   },

--- a/src/web/app/src/components/BannerButtons.tsx
+++ b/src/web/app/src/components/BannerButtons.tsx
@@ -58,7 +58,6 @@ const ButtonTooltip = withStyles({
   tooltip: {
     marginTop: '12px',
     fontSize: '1.5rem',
-    margin: 0,
   },
 })(Tooltip);
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

This PR fixes #3614. When signed in locally, hovering over a user's avatar in the banner buttons displays the tooltip outside the user's avatar. 




<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself, and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

This PR  replaces the existing `margin` prop in `ButtonTooltip` with the `marginTop` property in the banner buttons tooltip, so it is displayed outside the avatar upon hovering. The value of `marginTop` is consistent with the `padding` value of `NavBar` tooltip. 

### Before the fix:
<img width="682" alt="Screen Shot 2022-10-06 at 4 20 36 PM" src="https://user-images.githubusercontent.com/50856799/194412777-39a47f48-ce30-4fa4-ac44-04e391e5cd4a.png">

### After:
<img width="575" alt="Screen Shot 2022-10-06 at 4 19 30 PM" src="https://user-images.githubusercontent.com/50856799/194412646-33c15ed8-c1fd-45ec-b081-d0bada23688d.png">

## Steps to test the PR

- Run Telescope locally  _with_ the changes introduced in this PR
- Hover over the avatar in banner buttons to see the updated positioning of the tooltip 

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
