### PR TITLE
Refactor- remove unused `search()` from `indexer`

### DIFF
--- a/src/api/parser/src/utils/indexer.js
+++ b/src/api/parser/src/utils/indexer.js
@@ -1,4 +1,3 @@
-const { ELASTIC_MAX_RESULTS_PER_PAGE = 5, POSTS_URL = 'http://localhost/v1/posts' } = process.env;
 const { logger, Elastic } = require('@senecacdot/satellite');
 
 const index = 'posts';
@@ -127,82 +126,6 @@ const deletePost = async (postId) => {
 };
 
 /**
- * Creates fields from filter, now the filter is used for author and post but it will be added more.
- * the fields will be used for ES
- * @param {string} filter
- */
-const createFieldsFromFilter = (filter) => {
-  switch (filter) {
-    case 'author':
-      return ['author'];
-    case 'post':
-    default:
-      return ['text', 'title'];
-  }
-};
-
-const sortFromFilter = (filter) => {
-  switch (filter) {
-    case 'author':
-      return [{ published: { order: 'desc' } }];
-    case 'post':
-    default:
-      return undefined;
-  }
-};
-
-const calculateFrom = (page, perPage) => {
-  const ES_MAX = 10000; // 10K is the upper limit of what ES will return without issue for searches
-  const wanted = page * perPage;
-  // Don't exceed 10K, and if we will, return an offset under it by one page size
-  return wanted + perPage <= ES_MAX ? wanted : ES_MAX - perPage;
-};
-
-/**
- * Searches text in elasticsearch
- * @param textToSearch
- * @param filter
- * @return all the results matching the passed text
- */
-const search = async (
-  textToSearch,
-  filter = 'post',
-  page = 0,
-  perPage = ELASTIC_MAX_RESULTS_PER_PAGE
-) => {
-  const query = {
-    query: {
-      simple_query_string: {
-        query: textToSearch,
-        default_operator: 'and',
-        fields: createFieldsFromFilter(filter),
-      },
-    },
-    sort: sortFromFilter(filter),
-  };
-
-  const {
-    body: { hits },
-  } = await client.search(
-    {
-      from: calculateFrom(page, perPage),
-      size: perPage,
-      _source: ['id'],
-      index,
-      body: query,
-    },
-    {
-      meta: true,
-    }
-  );
-
-  return {
-    results: hits.total.value,
-    values: hits.hits.map(({ _id }) => ({ id: _id, url: `${POSTS_URL}/${_id}` })),
-  };
-};
-
-/**
  * Checks elasticsearch's connectivity
  */
 const checkConnection = () => client.cluster.health();
@@ -251,6 +174,5 @@ module.exports = {
   indexPost,
   deletePost,
   checkConnection,
-  search,
   waitOnReady,
 };


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Refactor**: Change which refactors code

## Description
The `search()` function in `indexer.js` had been moved to the `Search` service a long time ago, and is no longer used anywhere else in our code.

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR
- Everything builds locally and runs as normal
- `pnpm jest`, `pnpm test`, passes all tests
<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
