### PR TITLE
chore: upgrade traefik image to v2.9.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -289,7 +289,7 @@ services:
 
   # API Gateway
   traefik:
-    image: traefik:v2.6.6
+    image: traefik:v2.9.1
     container_name: 'traefik'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Description

`Traefik` [ended support for v2.6](https://doc.traefik.io/traefik/deprecation/releases/) and the end of May of this year. This PR upgrades the version of the image we use to v2.9.1.

## Steps to test the PR

- Run telescope locally
- Assert that everything works as expected

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
