### PR TITLE
Improve Dependency Page CSS

### DIFF
--- a/src/web/app/src/components/DependenciesTable/Row.tsx
+++ b/src/web/app/src/components/DependenciesTable/Row.tsx
@@ -19,9 +19,11 @@ import { dependencyDiscoveryUrl } from '../../config';
 const useStyles = makeStyles((theme) => ({
   root: {
     '& .MuiTableCell-body': {
-      fontSize: '14px',
+      fontFamily: 'Spartan',
+      fontSize: '16px',
       color: theme.palette.text.secondary,
       fontWeight: 700,
+      borderBottom: '0.01em solid #909090 !important',
     },
     cursor: 'pointer',
   },
@@ -35,6 +37,9 @@ const useStyles = makeStyles((theme) => ({
   icons: {
     color: theme.palette.text.secondary,
     fontSize: '2rem !important',
+  },
+  dependencyInfoCell: {
+    borderBottom: '0.01em solid #909090 !important',
   },
   dependencyInfo: {
     display: 'inline-flex',
@@ -142,7 +147,11 @@ export const Row = ({ dependency }: RowProps) => {
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={2}>
+        <TableCell
+          className={classes.dependencyInfoCell}
+          style={{ paddingBottom: 0, paddingTop: 0 }}
+          colSpan={2}
+        >
           <Collapse in={open} timeout="auto" unmountOnExit>
             {projectInfo && issues ? (
               <Box className={classes.collapseBox}>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

Fixes #3535 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Updated the CSS for the dependency page table to make dependencies stand out more:
- Increased font size for dependency names
- Changed font family to Spartan
- Also changed the color of the border separating dependencies so it is not as bright in dark mode

No tests were added since this is a small css change.

Current:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/67077705/194734190-8f309a0a-b727-4342-96ca-89b475d294b0.png">
<img width="900" alt="image" src="https://user-images.githubusercontent.com/67077705/194734150-3e417472-69b9-4e13-af6a-148eb7267b32.png">

Updated:
<img width="900" alt="image" src="https://user-images.githubusercontent.com/67077705/194734200-108216f9-d717-401e-abf6-eb05928db439.png">
<img width="900" alt="image" src="https://user-images.githubusercontent.com/67077705/194734213-62bcd340-79df-4ba6-aa3c-4b0cb2d63384.png">

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

- Run telescope locally
- Navigate to /dependencies
- Check the updated styles for dependency names and the border for both light theme and dark theme

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
