### PR TITLE
Fixes #3565: Post user avatar not using proper GitHub image

### DIFF
--- a/src/api/parser/src/data/feed.js
+++ b/src/api/parser/src/data/feed.js
@@ -26,7 +26,7 @@ const { deletePost } = require('../utils/indexer');
 const urlToId = (url) => hash(normalizeUrl(url));
 
 class Feed {
-  constructor(author, url, user, link, etag, lastModified) {
+  constructor(author, url, user, link, etag, lastModified, githubUsername) {
     if (!url) {
       throw new Error('missing url for feed');
     }
@@ -43,6 +43,7 @@ class Feed {
     // We may or may not have these cache values when we create a feed.
     this.etag = etag === '' ? null : etag;
     this.lastModified = lastModified === '' ? null : lastModified;
+    this.githubUsername = githubUsername || null;
   }
 
   /**
@@ -144,7 +145,8 @@ class Feed {
       feedData.user,
       feedData.link,
       feedData.etag,
-      feedData.lastModified
+      feedData.lastModified,
+      feedData.githubUsername
     );
     await feed.save();
     return feed.id;
@@ -161,7 +163,15 @@ class Feed {
     if (!(data && data.id)) {
       return null;
     }
-    return new Feed(data.author, data.url, data.user, data.link, data.etag, data.lastModified);
+    return new Feed(
+      data.author,
+      data.url,
+      data.user,
+      data.link,
+      data.etag,
+      data.lastModified,
+      data.githubUsername
+    );
   }
 
   /**

--- a/src/api/parser/src/utils/storage.js
+++ b/src/api/parser/src/utils/storage.js
@@ -68,7 +68,9 @@ module.exports = {
         'etag',
         feed.etag,
         'lastModified',
-        feed.lastModified
+        feed.lastModified,
+        'githubUsername',
+        feed.githubUsername
       )
       .sadd(feedsKey, feed.id)
       .exec();
@@ -99,7 +101,7 @@ module.exports = {
     try {
       await redis
         .multi()
-        .hdel(key, 'id', 'author', 'url', 'user', 'link', 'etag', 'lastModified')
+        .hdel(key, 'id', 'author', 'url', 'user', 'link', 'etag', 'lastModified', 'githubUsername')
         .srem(feedsKey, id)
         .exec();
     } catch (error) {

--- a/src/api/parser/src/utils/supabase.js
+++ b/src/api/parser/src/utils/supabase.js
@@ -16,7 +16,7 @@ module.exports = {
   async getAllFeeds() {
     const { data, error } = await supabase
       .from('feeds')
-      .select('wiki_author_name, url, telescope_profiles (display_name)');
+      .select('wiki_author_name, url, telescope_profiles (display_name, github_username)');
 
     if (error) {
       logger.error({ error });
@@ -27,6 +27,7 @@ module.exports = {
       // Prefer the a user's display name if present, fallback to wiki name otherwise
       author: feed.telescope_profiles?.display_name || feed.wiki_author_name,
       url: feed.url,
+      githubUsername: feed.telescope_profiles?.github_username,
     }));
   },
 

--- a/src/api/parser/test/feed.test.js
+++ b/src/api/parser/test/feed.test.js
@@ -18,6 +18,7 @@ describe('Post data class tests', () => {
     link: 'https://user.feed.com/',
     etag: null,
     lastModified: null,
+    githubUsername: 'github User 1',
   };
 
   const data2 = {
@@ -27,6 +28,7 @@ describe('Post data class tests', () => {
     link: 'https://user2.feed.com/',
     etag: null,
     lastModified: null,
+    githubUsername: 'github User 2',
   };
 
   const data3 = {
@@ -36,9 +38,11 @@ describe('Post data class tests', () => {
     link: 'https://user3.feed.com/',
     etag: null,
     lastModified: null,
+    githubUsername: 'github User 3',
   };
 
-  const createFeed = () => new Feed(data.author, data.url, data.user, data.link, null, null);
+  const createFeed = () =>
+    new Feed(data.author, data.url, data.user, data.link, null, null, data.githubUsername);
 
   const articleData1 = {
     guid: 'http://dev.telescope.cdot.systems',
@@ -80,7 +84,15 @@ describe('Post data class tests', () => {
 
   describe('Get and Set Feed objects from database', () => {
     beforeAll(async () => {
-      const feed = new Feed(data.author, data.url, data.user, data.link, null, null);
+      const feed = new Feed(
+        data.author,
+        data.url,
+        data.user,
+        data.link,
+        null,
+        null,
+        data.githubUsername
+      );
       __setMockFeeds([feed]);
       await feed.save();
     });
@@ -93,6 +105,7 @@ describe('Post data class tests', () => {
       expect(feed.id).toEqual(data.id);
       expect(feed.link).toEqual(data.link);
       expect(feed.user).toEqual(data.user);
+      expect(feed.githubUsername).toEqual(data.githubUsername);
     });
 
     test('Feed.byId() for an invalid id should return null', async () => {
@@ -108,6 +121,7 @@ describe('Post data class tests', () => {
       expect(feed.id).toEqual(data.id);
       expect(feed.link).toEqual(data.link);
       expect(feed.user).toEqual(data.user);
+      expect(feed.githubUsername).toEqual(data.githubUsername);
     });
 
     test('Feed.byUrl() for an invalid url should return null', async () => {
@@ -147,7 +161,15 @@ describe('Post data class tests', () => {
     });
 
     test('Updated feed should be different from data', async () => {
-      const feed = new Feed(data.author, data.url, data.user, data.link, null, null);
+      const feed = new Feed(
+        data.author,
+        data.url,
+        data.user,
+        data.link,
+        null,
+        null,
+        data.githubUsername
+      );
       feed.author = 'Author Post';
       feed.url = 'https://modified.user.feed.com/feed.rss';
       __setMockFeeds([feed]);

--- a/src/api/posts/src/data/feed.js
+++ b/src/api/posts/src/data/feed.js
@@ -21,7 +21,7 @@ const {
 const urlToId = (url) => hash(normalizeUrl(url));
 
 class Feed {
-  constructor(author, url, user, link, etag, lastModified) {
+  constructor(author, url, user, link, etag, lastModified, githubUsername) {
     if (!url) {
       throw new Error('missing url for feed');
     }
@@ -38,6 +38,7 @@ class Feed {
     // We may or may not have these cache values when we create a feed.
     this.etag = etag === '' ? null : etag;
     this.lastModified = lastModified === '' ? null : lastModified;
+    this.githubUsername = githubUsername || null;
   }
 
   /**
@@ -134,7 +135,8 @@ class Feed {
       feedData.user,
       feedData.link,
       feedData.etag,
-      feedData.lastModified
+      feedData.lastModified,
+      feedData.githubUsername
     );
     await feed.save();
     return feed.id;
@@ -151,7 +153,15 @@ class Feed {
     if (!(data && data.id)) {
       return null;
     }
-    return new Feed(data.author, data.url, data.user, data.link, data.etag, data.lastModified);
+    return new Feed(
+      data.author,
+      data.url,
+      data.user,
+      data.link,
+      data.etag,
+      data.lastModified,
+      data.githubUsername
+    );
   }
 
   /**

--- a/src/api/posts/src/storage.js
+++ b/src/api/posts/src/storage.js
@@ -123,7 +123,7 @@ module.exports = {
     try {
       await redis
         .multi()
-        .hdel(key, 'id', 'author', 'url', 'user', 'link', 'etag', 'lastModified')
+        .hdel(key, 'id', 'author', 'url', 'user', 'link', 'etag', 'lastModified', 'githubUsername')
         .srem(redisKey, id)
         .exec();
     } catch (error) {

--- a/src/web/app/src/components/Posts/Post.tsx
+++ b/src/web/app/src/components/Posts/Post.tsx
@@ -452,6 +452,7 @@ const PostComponent = ({ postUrl, currentPost, totalPosts }: Props) => {
                 authorName={post.feed.author}
                 postDate={formatPublishedDate(post.updated)}
                 blogUrl={post.feed.link}
+                githubUsername={post.feed.githubUsername}
               />
               <GitHubInfo />
               <YouTubeInfo />
@@ -478,7 +479,11 @@ const PostComponent = ({ postUrl, currentPost, totalPosts }: Props) => {
                   </Typography>
                 </div>
                 <div className={classes.authorAvatarContainer}>
-                  <PostAvatar name={post.feed.author} url={post.feed.link} />
+                  <PostAvatar
+                    name={post.feed.author}
+                    url={post.feed.link}
+                    githubUsername={post.feed.githubUsername}
+                  />
                 </div>
                 <div className={classes.authorNameContainer}>
                   <h1 className={classes.author}>

--- a/src/web/app/src/components/Posts/PostAvatar.tsx
+++ b/src/web/app/src/components/Posts/PostAvatar.tsx
@@ -3,8 +3,8 @@ import { makeStyles } from '@material-ui/core/styles';
 
 type AvatarProps = {
   name: string;
-  img?: string;
   url?: string;
+  githubUsername: string;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -38,11 +38,22 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-const PostAvatar = ({ name, img, url }: AvatarProps) => {
+const PostAvatar = ({ name, url, githubUsername }: AvatarProps) => {
   const classes = useStyles();
 
-  if (img) {
-    return <Avatar className={classes.avatar} src={img} />;
+  if (githubUsername) {
+    const userAvatar = `https://github.com/${githubUsername}.png?size=64`;
+    return (
+      <>
+        {url?.length ? (
+          <a href={url} className={classes.link} title={name} target="_blank" rel="noreferrer">
+            <Avatar className={classes.avatar} src={userAvatar} />
+          </a>
+        ) : (
+          <Avatar className={classes.avatar} src={userAvatar} />
+        )}
+      </>
+    );
   }
 
   if (name.length > 0) {

--- a/src/web/app/src/components/Posts/PostInfo.tsx
+++ b/src/web/app/src/components/Posts/PostInfo.tsx
@@ -73,13 +73,14 @@ type Props = {
   blogUrl: string;
   authorName: string;
   postDate: string;
+  githubUsername: string;
 };
-const PostDesktopInfo = ({ authorName, postDate, blogUrl, postUrl }: Props) => {
+const PostDesktopInfo = ({ authorName, postDate, blogUrl, postUrl, githubUsername }: Props) => {
   const classes = useStyles();
   return (
     <ListSubheader component="div" className={classes.root}>
       <div className={classes.authorAvatarContainer}>
-        <PostAvatar name={authorName} url={blogUrl} />
+        <PostAvatar name={authorName} url={blogUrl} githubUsername={githubUsername} />
       </div>
       <div className={classes.authorNameContainer}>
         <p className={classes.author}>

--- a/src/web/app/src/components/SignUp/Forms/GitHubAccount.tsx
+++ b/src/web/app/src/components/SignUp/Forms/GitHubAccount.tsx
@@ -172,7 +172,7 @@ const GitHubAccount = connect<{}, SignUpForm>((props) => {
               <PostAvatar
                 name={values.github.username || values.displayName}
                 url={values.github.avatarUrl}
-                img={values.github?.avatarUrl}
+                githubUsername={values.github?.username}
               />
               <h2 className={classes.username}>{values.github.username}</h2>
             </div>

--- a/src/web/app/src/components/SignUp/Forms/Review.tsx
+++ b/src/web/app/src/components/SignUp/Forms/Review.tsx
@@ -106,7 +106,7 @@ const Review = connect<{ accountError: string | undefined }, SignUpForm>((props)
         <h1 className={classes.titlePage}>Review your Information</h1>
         <div className={classes.contentContainer}>
           <div className={classes.avatar}>
-            <PostAvatar name={displayName} img={github.avatarUrl} />
+            <PostAvatar name={displayName} githubUsername={github.username} />
             <h2>{displayName}</h2>
           </div>
           <div className={classes.senecaBlogInfo}>

--- a/src/web/app/src/interfaces/index.ts
+++ b/src/web/app/src/interfaces/index.ts
@@ -3,6 +3,7 @@ export type Feed = {
   author: string;
   url: string;
   link: string;
+  githubUsername: string;
 };
 
 export type Post = {


### PR DESCRIPTION
## Issue This PR Addresses

Fixes #3565

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR add changes to send the `github` username of a telescope user (if stored) to the frontend and use it to display the user's `github` avatar in posts.  

![image](https://user-images.githubusercontent.com/23108901/194801666-1f46fd6a-ce4b-4af8-9e75-c313972ff792.png)

![image](https://user-images.githubusercontent.com/23108901/194801719-4e4c7cad-819e-48f3-a1f0-5719a50a2d21.png)


## Steps to test the PR

- Run supabase locally and use the `db:init` script to add feeds to the database.
- Using the supabase dashboard, create rows in the `telescope_profiles` table with valid `github` usernames and link them to users in the `feeds` table by using the same id in `telescope_profiles->id` and `feeds->user_id`. 
- Run the rest of telescope.
- Assert that posts by users with a stored `github` username display the user's `github` avatar, and the user's initials when there's no `github` username stored. 

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
