### PR TITLE
Update `pnpm clean` script to include root directory and missing packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "develop": "pnpm dev",
     "lint": "pnpm turbo run lint && pnpm eslint",
     "lint-time": "pnpm turbo run lint-time && pnpm eslint-time",
-    "clean": "pnpm turbo run clean && pnpm -r exec rm -rf node_modules",
+    "clean": "run-s clean:turbo clean:root",
+    "clean:root": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules",
+    "clean:turbo": "pnpm exec turbo run clean",
     "prettier": "prettier --write \"./**/*.{md,jsx,json,html,css,js,yml,ts,tsx}\"",
     "prettier-check": "prettier --check \"./**/*.{md,jsx,json,html,css,js,yml,ts,tsx}\"",
     "db:migrate": "prisma migrate dev --schema=src/db/prisma/schema.prisma && prisma generate --schema=src/db/prisma/schema.prisma",
@@ -77,13 +79,14 @@
     "pretty-quick": "3.1.3",
     "prisma": "3.15.2",
     "redis-commands": "1.7.0",
+    "rimraf": "3.0.2",
     "supertest": "6.1.6",
     "ts-jest": "27.1.5",
     "turbo": "1.2.11",
     "typescript": "4.4.4"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=14",
     "pnpm": ">=6"
   },
   "packageManager": "pnpm@6.32.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ importers:
       pretty-quick: 3.1.3
       prisma: 3.15.2
       redis-commands: 1.7.0
+      rimraf: 3.0.2
       supertest: 6.1.6
       ts-jest: 27.1.5
       turbo: 1.2.11
@@ -66,6 +67,7 @@ importers:
       pretty-quick: 3.1.3_prettier@2.5.1
       prisma: 3.15.2
       redis-commands: 1.7.0
+      rimraf: 3.0.2
       supertest: 6.1.6
       ts-jest: 27.1.5_hg4wb444wq7xfutvq6ct4im4j4
       turbo: 1.2.11
@@ -81,6 +83,7 @@ importers:
       nodemon: 2.0.16
       octokit: 2.0.3
       query-registry: 2.2.0
+      rimraf: 3.0.2
       supertest: 6.1.6
     dependencies:
       '@senecacdot/satellite': 1.28.0
@@ -92,6 +95,7 @@ importers:
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.16
+      rimraf: 3.0.2
 
   src/api/feed-discovery:
     specifiers:
@@ -102,6 +106,7 @@ importers:
       got: 11.8.5
       nock: 13.2.4
       nodemon: 2.0.16
+      rimraf: 3.0.2
       supertest: 6.1.6
     dependencies:
       '@senecacdot/satellite': 1.28.0
@@ -112,6 +117,7 @@ importers:
       eslint: 7.32.0
       nock: 13.2.4
       nodemon: 2.0.16
+      rimraf: 3.0.2
       supertest: 6.1.6
 
   src/api/image:
@@ -123,6 +129,7 @@ importers:
       eslint: 7.32.0
       got: 11.8.5
       nodemon: 2.0.16
+      rimraf: 3.0.2
       sharp: 0.30.5
       supertest: 6.1.6
     dependencies:
@@ -136,6 +143,7 @@ importers:
       del-cli: 4.0.1
       eslint: 7.32.0
       nodemon: 2.0.16
+      rimraf: 3.0.2
 
   src/api/parser:
     specifiers:
@@ -158,6 +166,7 @@ importers:
       nock: 13.2.4
       nodemon: 2.0.16
       normalize-url: 6.1.0
+      rimraf: 3.0.2
       rss-parser: 3.12.0
       sanitize-html: 2.5.3
     dependencies:
@@ -183,6 +192,7 @@ importers:
       jest-fetch-mock: 3.0.3
       nock: 13.2.4
       nodemon: 2.0.16
+      rimraf: 3.0.2
 
   src/api/planet:
     specifiers:
@@ -194,6 +204,7 @@ importers:
       express: 4.17.3
       express-handlebars: 6.0.6
       nodemon: 2.0.16
+      rimraf: 3.0.2
     dependencies:
       '@senecacdot/satellite': 1.28.0
       '@supabase/supabase-js': 1.29.4
@@ -204,6 +215,7 @@ importers:
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.16
+      rimraf: 3.0.2
 
   src/api/posts:
     specifiers:
@@ -217,6 +229,7 @@ importers:
       jsdom: 18.1.1
       normalize-url: 6.1.0
       redis-commands: 1.7.0
+      rimraf: 3.0.2
       supertest: 6.1.6
     dependencies:
       '@senecacdot/satellite': 1.28.0
@@ -230,6 +243,7 @@ importers:
       '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       eslint: 7.32.0
       redis-commands: 1.7.0
+      rimraf: 3.0.2
       supertest: 6.1.6
 
   src/api/search:
@@ -239,6 +253,7 @@ importers:
       eslint: 7.32.0
       express-validator: 6.14.1
       nodemon: 2.0.16
+      rimraf: 3.0.2
       supertest: 6.1.6
     dependencies:
       '@senecacdot/satellite': 1.28.0
@@ -247,6 +262,7 @@ importers:
       '@senecacdot/eslint-config-telescope': 1.1.0_eslint@7.32.0
       eslint: 7.32.0
       nodemon: 2.0.16
+      rimraf: 3.0.2
       supertest: 6.1.6
 
   src/api/sso:
@@ -265,6 +281,7 @@ importers:
       normalize-url: 6.1.0
       passport: 0.5.2
       passport-saml: 3.2.2
+      rimraf: 3.0.2
       supertest: 6.1.6
     dependencies:
       '@senecacdot/satellite': 1.28.0
@@ -282,6 +299,7 @@ importers:
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.16
+      rimraf: 3.0.2
       supertest: 6.1.6
 
   src/api/status:
@@ -298,6 +316,7 @@ importers:
       npm-run-all: 4.1.5
       octokit: 2.0.3
       perfect-scrollbar: 1.5.5
+      rimraf: 3.0.2
       sass: 1.49.9
       vite: 2.9.13
       xterm: 4.18.0
@@ -324,15 +343,18 @@ importers:
       env-cmd: 10.1.0
       eslint: 7.32.0
       nodemon: 2.0.16
+      rimraf: 3.0.2
 
   src/db:
     specifiers:
       '@prisma/client': 3.15.2
       prisma: 3.15.2
+      rimraf: 3.0.2
     dependencies:
       '@prisma/client': 3.15.2_prisma@3.15.2
     devDependencies:
       prisma: 3.15.2
+      rimraf: 3.0.2
 
   src/github-url-parser:
     specifiers:
@@ -342,6 +364,7 @@ importers:
       jsdom: 18.1.1
       npm-run-all: 4.1.5
       parcel: 2.6.2
+      rimraf: 3.0.2
       typescript: 4.4.4
     devDependencies:
       '@parcel/core': 2.6.2
@@ -350,6 +373,7 @@ importers:
       jsdom: 18.1.1
       npm-run-all: 4.1.5
       parcel: 2.6.2
+      rimraf: 3.0.2
       typescript: 4.4.4
 
   src/satellite:
@@ -376,6 +400,7 @@ importers:
       pino-pretty: 7.5.3
       prettier: 2.5.1
       pretty-quick: 3.1.3
+      rimraf: 3.0.2
     dependencies:
       '@elastic/elasticsearch': 8.4.0
       '@elastic/elasticsearch-mock': 2.0.0
@@ -400,6 +425,7 @@ importers:
       nock: 13.2.4
       prettier: 2.5.1
       pretty-quick: 3.1.3_prettier@2.5.1
+      rimraf: 3.0.2
 
   src/web/app:
     specifiers:
@@ -448,6 +474,7 @@ importers:
       react-p5-wrapper: 3.1.0
       react-transition-group: 4.4.5
       react-use: 17.3.2
+      rimraf: 3.0.2
       smoothscroll-polyfill: 0.4.4
       swr: 1.2.2
       terser-webpack-plugin: 5.3.6
@@ -504,6 +531,7 @@ importers:
       '@typescript-eslint/parser': 4.33.0_wnilx7boviscikmvsfkd6ljepe
       babel-loader: 8.2.5_77pyk2cen3yciahrrdqdol36oa
       eslint: 7.32.0
+      rimraf: 3.0.2
       terser-webpack-plugin: 5.3.6_webpack@5.9.0
       typescript: 4.4.4
       webpack: 5.9.0
@@ -531,6 +559,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2
       react-p5-wrapper: 3.1.0
+      rimraf: 3.0.2
       typescript: 4.4.4
       unist-util-visit: 2.0.3
     dependencies:
@@ -556,6 +585,7 @@ importers:
       '@types/react': 17.0.45
       eslint: 7.32.0
       eslint-plugin-import: 2.25.4_eslint@7.32.0
+      rimraf: 3.0.2
       typescript: 4.4.4
       unist-util-visit: 2.0.3
 
@@ -568,6 +598,7 @@ importers:
       merge-stream: 2.0.0
       pm2: 5.2.0
       rereadable-stream: 1.4.13
+      rimraf: 3.0.2
       shelljs: 0.8.5
     dependencies:
       '@octokit/webhooks': 9.15.0
@@ -578,6 +609,8 @@ importers:
       pm2: 5.2.0
       rereadable-stream: 1.4.13
       shelljs: 0.8.5
+    devDependencies:
+      rimraf: 3.0.2
 
   tools/eslint:
     specifiers:
@@ -595,6 +628,7 @@ importers:
       eslint-plugin-react: 7.29.4
       eslint-plugin-react-hooks: 4.3.0
       prettier: 2.5.1
+      rimraf: 3.0.2
       typescript: 4.4.4
     devDependencies:
       eslint: 7.32.0
@@ -611,6 +645,7 @@ importers:
       eslint-plugin-react: 7.29.4_eslint@7.32.0
       eslint-plugin-react-hooks: 4.3.0_eslint@7.32.0
       prettier: 2.5.1
+      rimraf: 3.0.2
       typescript: 4.4.4
 
   tools/migrate:
@@ -621,6 +656,7 @@ importers:
       jsdom: 18.1.1
       node-fetch: 2.6.7
       normalize-url: 6.1.0
+      rimraf: 3.0.2
     dependencies:
       '@senecacdot/satellite': 1.28.0
       '@supabase/supabase-js': 1.29.4
@@ -628,6 +664,8 @@ importers:
       jsdom: 18.1.1
       node-fetch: 2.6.7
       normalize-url: 6.1.0
+    devDependencies:
+      rimraf: 3.0.2
 
 packages:
 
@@ -3264,13 +3302,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       core-js-pure: 3.25.5
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
 
   /@babel/runtime/7.19.4:
     resolution: {integrity: sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
 
   /@babel/template/7.18.10:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
@@ -6133,7 +6171,7 @@ packages:
       browserslist: 4.21.4
       detect-libc: 1.0.3
       nullthrows: 1.1.1
-      regenerator-runtime: 0.13.9
+      regenerator-runtime: 0.13.10
       semver: 5.7.1
     dev: true
 
@@ -15267,7 +15305,7 @@ packages:
       minimatch: 3.1.2
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.7.3
+      shell-quote: 1.7.4
       string.prototype.padend: 3.1.3
 
   /npm-run-path/4.0.1:
@@ -17006,7 +17044,7 @@ packages:
       prompts: 2.4.2
       react-error-overlay: 6.0.11
       recursive-readdir: 2.2.2
-      shell-quote: 1.7.3
+      shell-quote: 1.7.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 4.4.4
@@ -17404,8 +17442,8 @@ packages:
   /regenerate/1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
 
-  /regenerator-runtime/0.13.9:
-    resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
+  /regenerator-runtime/0.13.10:
+    resolution: {integrity: sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==}
 
   /regenerator-transform/0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
@@ -18092,8 +18130,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /shell-quote/1.7.3:
-    resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
+  /shell-quote/1.7.4:
+    resolution: {integrity: sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==}
 
   /shelljs/0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}

--- a/src/api/dependency-discovery/package.json
+++ b/src/api/dependency-discovery/package.json
@@ -11,7 +11,8 @@
     "eslint": "eslint --config .eslintrc.js \"**/*.js\"",
     "eslint-time": "TIMING=1 eslint --config .eslintrc.js \"**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"**/*.js\" --fix",
-    "test": "jest -c jest.config.js"
+    "test": "jest -c jest.config.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,7 @@
     "@senecacdot/eslint-config-telescope": "1.1.0",
     "env-cmd": "10.1.0",
     "eslint": "7.32.0",
-    "nodemon": "2.0.16"
+    "nodemon": "2.0.16",
+    "rimraf": "3.0.2"
   }
 }

--- a/src/api/feed-discovery/package.json
+++ b/src/api/feed-discovery/package.json
@@ -11,7 +11,8 @@
     "eslint-fix": "eslint --config .eslintrc.js \"./**/*.js\" --fix",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
-    "test": "jest -c jest.config.js"
+    "test": "jest -c jest.config.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -32,6 +33,7 @@
     "eslint": "7.32.0",
     "nock": "13.2.4",
     "nodemon": "2.0.16",
+    "rimraf": "3.0.2",
     "supertest": "6.1.6"
   }
 }

--- a/src/api/image/package.json
+++ b/src/api/image/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
-    "clean": "find ./photos -type f -not -name 'default.jpg' -delete",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
     "eslint": "eslint --config .eslintrc.js --ignore-path .gitignore \"./**/*.js\"",
@@ -34,6 +34,7 @@
    "@senecacdot/eslint-config-telescope": "1.1.0",
     "del-cli": "4.0.1",
     "eslint": "7.32.0",
-    "nodemon": "2.0.16"
+    "nodemon": "2.0.16",
+    "rimraf": "3.0.2"
   }
 }

--- a/src/api/parser/package.json
+++ b/src/api/parser/package.json
@@ -11,7 +11,8 @@
     "eslint-fix": "eslint --config .eslintrc.js \"./**/*.js\" --fix",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
-    "test": "jest -c jest.config.js"
+    "test": "jest -c jest.config.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -45,6 +46,7 @@
     "eslint": "7.32.0",
     "jest-fetch-mock": "3.0.3",
     "nock": "13.2.4",
-    "nodemon": "2.0.16"
+    "nodemon": "2.0.16",
+    "rimraf": "3.0.2"
   }
 }

--- a/src/api/planet/package.json
+++ b/src/api/planet/package.json
@@ -10,7 +10,8 @@
     "eslint-time": "TIMING=1 eslint --config .eslintrc.js \"./**/*.js\" ",
     "eslint-fix": "eslint --config .eslintrc.js \"./**/*.js\" --fix",
     "lint": "pnpm eslint",
-    "lint-time": "pnpm eslint-time"
+    "lint-time": "pnpm eslint-time",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -31,6 +32,7 @@
     "@senecacdot/eslint-config-telescope": "1.1.0",
     "env-cmd": "10.1.0",
     "eslint": "7.32.0",
-    "nodemon": "2.0.16"
+    "nodemon": "2.0.16",
+    "rimraf": "3.0.2"
   }
 }

--- a/src/api/posts/package.json
+++ b/src/api/posts/package.json
@@ -10,7 +10,8 @@
     "eslint-fix": "eslint --config .eslintrc.js \"./**/*.js\" --fix",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
-    "test": "jest -c jest.config.js"
+    "test": "jest -c jest.config.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -34,6 +35,7 @@
     "@senecacdot/eslint-config-telescope": "1.1.0",
     "eslint": "7.32.0",
     "redis-commands": "1.7.0",
+    "rimraf": "3.0.2",
     "supertest": "6.1.6"
   }
 }

--- a/src/api/search/package.json
+++ b/src/api/search/package.json
@@ -11,7 +11,8 @@
     "eslint-fix": "eslint --config .eslintrc.js \"./**/**/*.js\" --fix",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
-    "test": "jest -c jest.config.js"
+    "test": "jest -c jest.config.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -30,6 +31,7 @@
     "@senecacdot/eslint-config-telescope": "1.1.0",
     "eslint": "7.32.0",
     "nodemon": "2.0.16",
+    "rimraf": "3.0.2",
     "supertest": "6.1.6"
   }
 }

--- a/src/api/sso/package.json
+++ b/src/api/sso/package.json
@@ -11,7 +11,8 @@
     "eslint-fix": "eslint --config .eslintrc.js \"./**/*.js\" --fix",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
-    "test": "jest -c jest.config.js"
+    "test": "jest -c jest.config.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -39,6 +40,7 @@
     "env-cmd": "10.1.0",
     "eslint": "7.32.0",
     "nodemon": "2.0.16",
+    "rimraf": "3.0.2",
     "supertest": "6.1.6"
   }
 }

--- a/src/api/status/package.json
+++ b/src/api/status/package.json
@@ -7,7 +7,7 @@
     "dev": "run-p watch:*",
     "build": "run-s compile:*",
     "start": "node src/server.js",
-    "clean": "rm -rf .turbo public/dist",
+    "clean": "pnpm rimraf .turbo public/dist node_modules || pnpm rimraf node_modules",
     "watch:server": "env-cmd -f env.local nodemon src/server.js",
     "compile:js": "vite build",
     "watch:js": "vite build --watch",
@@ -48,6 +48,7 @@
     "eslint": "7.32.0",
     "nodemon": "2.0.16",
     "npm-run-all": "4.1.5",
+    "rimraf": "3.0.2",
     "sass": "1.49.9",
     "vite": "2.9.13"
   }

--- a/src/db/package.json
+++ b/src/db/package.json
@@ -5,16 +5,18 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "devDependencies": {
-    "prisma": "3.15.2"
-  },
   "scripts": {
     "migrate": "prisma migrate dev --",
     "create-migration": "prisma migrate dev --create-only",
     "format": "prisma format",
-    "seed": "prisma db seed"
+    "seed": "prisma db seed",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "dependencies": {
     "@prisma/client": "3.15.2"
+  },
+  "devDependencies": {
+    "prisma": "3.15.2",
+    "rimraf": "3.0.2"
   }
 }

--- a/src/github-url-parser/package.json
+++ b/src/github-url-parser/package.json
@@ -18,7 +18,8 @@
     "lint-time": "pnpm eslint-time",
     "watch": "parcel watch",
     "build": "parcel build",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -32,6 +33,7 @@
     "jsdom": "18.1.1",
     "npm-run-all": "4.1.5",
     "parcel": "2.6.2",
+    "rimraf": "3.0.2",
     "typescript": "4.4.4"
   }
 }

--- a/src/satellite/package.json
+++ b/src/satellite/package.json
@@ -11,7 +11,8 @@
     "eslint-time": "TIMING=1 eslint --config .eslintrc.js \"./src/**/*.js\"",
     "eslint-fix": "eslint --config .eslintrc.js \"./src/**/*.js\" --fix",
     "lint": "pnpm eslint",
-    "lint-time": "pnpm eslint-time"
+    "lint-time": "pnpm eslint-time",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
@@ -47,6 +48,7 @@
     "jest": "27.5.1",
     "nock": "13.2.4",
     "prettier": "2.5.1",
-    "pretty-quick": "3.1.3"
+    "pretty-quick": "3.1.3",
+    "rimraf": "3.0.2"
   }
 }

--- a/src/web/app/package.json
+++ b/src/web/app/package.json
@@ -11,7 +11,7 @@
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
     "test": "jest -c jest.config.js",
-    "clean": "rm -rf .next .turbo out"
+    "clean": "pnpm rimraf .next .turbo out node_modules || pnpm rimraf node_modules"
   },
   "version": "3.0.0",
   "dependencies": {
@@ -66,6 +66,7 @@
     "@typescript-eslint/parser": "4.33.0",
     "babel-loader": "8.2.5",
     "eslint": "7.32.0",
+    "rimraf": "3.0.2",
     "terser-webpack-plugin": "5.3.6",
     "typescript": "4.4.4",
     "webpack": "5.9.0"

--- a/src/web/docusaurus/package.json
+++ b/src/web/docusaurus/package.json
@@ -15,7 +15,7 @@
     "eslint-fix": "eslint --config .eslintrc.js --ignore-path .gitignore \"./**/*.js\" --fix",
     "lint": "pnpm eslint",
     "lint-time": "pnpm eslint-time",
-    "clean": "rm -rf .docusaurus .turbo build",
+    "clean": "pnpm rimraf .docusaurus .turbo build node_modules || pnpm rimraf node_modules",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },
@@ -43,6 +43,7 @@
     "@types/react": "17.0.45",
     "eslint": "7.32.0",
     "eslint-plugin-import": "2.25.4",
+    "rimraf": "3.0.2",
     "typescript": "4.4.4",
     "unist-util-visit": "2.0.3"
   },

--- a/tools/autodeployment/package.json
+++ b/tools/autodeployment/package.json
@@ -14,8 +14,12 @@
     "rereadable-stream": "1.4.13",
     "shelljs": "0.8.5"
   },
+  "devDependencies": {
+    "rimraf": "3.0.2"
+  },
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "repository": "https://github.com/Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "repository": "Seneca-CDOT/telescope",
   "license": "BSD-2-Clause",
+  "scripts": {
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
+  },
   "peerDependencies": {
     "eslint": "7.32.0"
   },
@@ -23,6 +26,7 @@
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.3.0",
     "prettier": "2.5.1",
+    "rimraf": "3.0.2",
     "typescript": "4.4.4"
   }
 }

--- a/tools/migrate/package.json
+++ b/tools/migrate/package.json
@@ -9,13 +9,17 @@
     "node-fetch": "2.6.7",
     "normalize-url": "6.1.0"
   },
+  "devDependencies": {
+    "rimraf": "3.0.2"
+  },
   "description": "Migrates users from the planet feed wiki list to a JSON file or supabase-db",
   "license": "ISC",
   "main": "migrate.js",
   "name": "migrate",
   "scripts": {
     "to_json": "node to_json.js",
-    "to_supabase": "node to_supabase.js"
+    "to_supabase": "node to_supabase.js",
+    "clean": "pnpm rimraf .turbo node_modules || pnpm rimraf node_modules"
   },
   "version": "1.1.0"
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->

Currently, if we run `pnpm clean` in the root directory, it does not delete the `node_modules` directory in root as expected. 

The two commands for the `clean` script do very much the same thing, which is to delete directories and files

```
// package.json
"scripts": {
    ...
    "clean": "pnpm turbo run clean && pnpm -r exec rm -rf node_modules",
    ...
}
```

1. `pnpm -r exec rm -rf node_modules` deletes only `node_modules` directories in our pnpm workspaces. There are a total of 18 workspace projects (including root)

2. `pnpm turbo run clean` runs all the `clean` scripts in the following directory:
- `src/web/app` (telescope-frontend)
- `src/web/docusaurus` (telescope-docs)
- `src/api/status` (status-service)
- `src/api/image` (image-service)

That's right. There are only four packages with the `clean` script. The reason only these four packages had `clean` scripts was that we needed to delete `out`, `build`, etc directories on top of the `node_modules` directory.

This PR allows us to use Turborepo to run `pnpm clean` within our project scope exactly the same way we use Turborepo to run `pnpm lint` and `pnpm test`. It further decouples our packages so we can use `pnpm clean` in the individual packages and not rely on `pnpm clean` in the root directory. However, in most cases, we want to use it in the root directory, but now, we can do both.

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

To test this PR locally:
1. Add my repository as a remote: `git remote add cindyledev https://github.com/cindyledev/telescope.git`
2. Fetch my branches: `git fetch cindyledev`
3. Checkout my branch: `git checkout fix-clean-script`
4. Install dependencies using pnpm in root: `pnpm install`
5. When you run `pnpm clean` in the root directory, you should see the following output

```
 Tasks:    17 successful, 17 total
Cached:    0 cached, 17 total
  Time:    8.702s
```

The reason it's 17,and not 18 is because the root directory is not included in the count

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
