### PR TITLE
Fixes #3611: Make RSS on Sign-up review page into snippets with hover display

### DIFF
--- a/src/web/app/src/components/SignUp/Forms/Review.tsx
+++ b/src/web/app/src/components/SignUp/Forms/Review.tsx
@@ -78,6 +78,7 @@ const useStyles = makeStyles((theme: Theme) =>
       textAlign: 'start',
     },
     blogRss: {
+      maxWidth: '300px',
       textAlign: 'start',
       padding: '1%',
       minHeight: '60px',
@@ -90,6 +91,14 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: '0.9em',
       alignSelf: 'end',
       color: '#474747',
+    },
+    rssContainer: {
+      display: 'flex',
+    },
+    rssContent: {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
     },
   })
 );
@@ -128,14 +137,20 @@ const Review = connect<{ accountError: string | undefined }, SignUpForm>((props)
               <h3 className={classes.titleRss}>Blog RSS:</h3>
               <div>
                 {blogs.map(({ feedUrl }) => (
-                  <h4 key={feedUrl}>{feedUrl}</h4>
+                  <h4 key={feedUrl} className={classes.rssContainer}>
+                    <span className={classes.rssContent} title={feedUrl}>
+                      {feedUrl}
+                    </span>
+                  </h4>
                 ))}
               </div>
-              <h3 className={classes.titleRss}>Twich/Youtube Channel RSS:</h3>
+              <h3 className={classes.titleRss}>Twitch/Youtube Channel RSS:</h3>
               <div>
                 {channels.map(({ type, feedUrl }) => (
-                  <h4 key={feedUrl}>
-                    {type}: {feedUrl}
+                  <h4 key={feedUrl} className={classes.rssContainer}>
+                    <span className={classes.rssContent} title={feedUrl}>
+                      {type}: {feedUrl}
+                    </span>
                   </h4>
                 ))}
               </div>


### PR DESCRIPTION
## Issue This PR Addresses
 Fixes #3611 

## Type of Change
- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
![eg](https://user-images.githubusercontent.com/83015577/198720724-d4fbdba3-06c1-4483-8245-5364a2321b71.jpg)

The RSS links on sign-up review page can be rather long and cause text overflow, so this PR turned them into snippets that will display the full text on hover. Overflow text is shorten with ellipses.

**Changes on `src/web/app/src/components/SignUp/Forms/Review.tsx`:**
- add `title={feedUrl}` to the RSS links in Blog RSS and Twitch/Youtube Channel RSS, to show text on hover
- added `RssContainer` and `RssContent` class for CSS
- assign `RssContainer` class to each RSS item, and wrap the actual RSS URL in  `RssContent` class `<span>`, to handle overflow
- fix typo from `Twich` to `Twitch` 
- add max width to `blogRSS` class's CSS to limit text length for overflow handling

## Steps to test the PR
Test this by going through the sign-up process to view the review page.
To see more comparable result with the issue filled, the following data can be used during testing: 
- GitHub user: AmasiaNalbandian
- Blog: https://dev.to/amasianalbandian
- Twitch Channels: http://www.twitch.tv/Opensrc http://www.twitch.tv/manekenpix


## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
