### PR TITLE
Auto select feed if only one exists

### DIFF
--- a/src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx
+++ b/src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx
@@ -203,6 +203,10 @@ const RSSFeeds = connect<RSSFeedsFormProps, SignUpForm>(
         }
         const { feedUrls }: DiscoveredFeeds = await response.json();
 
+        if (feedUrls.length === 1) {
+          setFieldValue(selected, [feedUrls[0]], true);
+        }
+
         setUrlError('');
         setFieldValue(discovered, feedUrls);
       } catch (err) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #3687 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
During the signup process, after the user enters their blog URL and clicks Validate Blog, it shows a list of possible feed URLs. 
If only one feed URL is returned, it should get selected automatically
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->
- Follow the setup instructions to setup login (if testing locally)
- Navigate to telescope homepage, and click on sign up
- Follow the prompts until you reach the Blog URL form
- Enter a Blog URL for which only one Feed URL exists and click 'Validate Blog'
- Check that Feed URL is automatically selected
- Repeat the above with a Blog URL for which there are multiple feed URLs and click 'Validate Blog'
- Check that no feed URL is automatically checked
## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
