### PR TITLE
change font and font size of list item

### DIFF
--- a/src/web/app/src/components/SearchHelp.tsx
+++ b/src/web/app/src/components/SearchHelp.tsx
@@ -15,8 +15,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingBottom: '1.5rem',
   },
   list: {
-    fontFamily: 'Times New Roman',
-    fontSize: '1.7rem',
+    fontFamily: 'Spartan',
+    fontSize: '1.5rem',
     lineHeight: '3rem',
     color: theme.palette.text.primary,
     listStyleType: 'none',


### PR DESCRIPTION
## Issue This PR Addresses
Fixes #3750 

## Type of Change

- [x] **UI**: Change which improves UI

## Description

On the search page, description of how to use search uses different font. Font family was changed to the same font as other elements use.

Before:
![image](https://user-images.githubusercontent.com/73063742/200899148-ec0e4b58-b98b-4a7d-ab9f-01caeb7434ee.png)

After:
![image](https://user-images.githubusercontent.com/73063742/200899118-b9a87abd-3bc0-4744-836f-cba02b1abe29.png)

## Steps to test the PR

    1) `npm install`
    2) Go to '\telescope\telescope\src\web\app\src\components\SearchHelp.tsx'
    3) Scroll down to 'list' item
    4) Font is change to be __Spartan__  and font size changed to 1.5rem.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
