### PR TITLE
Fixes #3755 :Base blogRss class's max-width to a parent element

### DIFF
--- a/src/web/app/src/components/SignUp/Forms/Review.tsx
+++ b/src/web/app/src/components/SignUp/Forms/Review.tsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme: Theme) =>
       textAlign: 'start',
     },
     blogRss: {
-      maxWidth: '300px',
+      maxWidth: '306px',
       textAlign: 'start',
       padding: '1%',
       minHeight: '60px',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #3755. 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

![image](https://user-images.githubusercontent.com/83015577/201461412-648b581c-9019-45cb-83b0-0ca8cbf16d3b.png)
The issue is about a magic number being used for the max-width of `blogRSS` class `<div>`, as a follow-up to PR##3743. `300px ` was used as part of the PR to solve text overflow without basing the number on surroudning code. This PR is to make sure the number used for max-width is based on a parent element.

Upon further investigation, the size of nearby `<div>` don’t have a fixed width, except the `signUpContainer` class `<div>` (the blue background), which has `510px` as default width. Most use percentages instead.
Therefore, to base the `px` based max-width of `blogRSS` class `<div>` on surrounding elements, I have decided to use `306px`, as a representation for 60% of the `510px` width of the parent element.

The `senecaBlogInfo` class `<div>`  (containing full name, email, blog URL, and channel URL) to the top of `blogRSS` class `<div>`  does automatically change its size to match `blogRSS` class `<div>` , so there’s no issue lining them up.

## Steps to test the PR

Test this by going through the sign-up process to view the review page.
To see more comparable result with the issue filled, the following data can be used during testing: 
- GitHub user: AmasiaNalbandian
- Blog: https://dev.to/amasianalbandian
- Twitch Channels: http://www.twitch.tv/Opensrc http://www.twitch.tv/manekenpix

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
