### PR TITLE
Adjusted Sign Up Flow to allow for more than one blog URL to be selected

### DIFF
--- a/src/web/app/src/components/SignUp/Schema/FormSchema.tsx
+++ b/src/web/app/src/components/SignUp/Schema/FormSchema.tsx
@@ -53,7 +53,7 @@ export default [
 
   // Third step we collect the user blog and the RSSfeeds from it.
   object().shape({
-    [blogUrl.name]: string().url().required(blogUrl.requiredErrorMsg),
+    [blogUrl.name]: string(),
     [blogs.name]: array().of(DiscoveredFeed).min(1, blogs.requiredErrorMsg),
     [allBlogs.name]: array().of(DiscoveredFeed),
     [blogOwnership.name]: boolean().test('agreed', blogOwnership.invalidErrorMsg, (val) => !!val),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #3607 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

<!-- Please add a detailed description of what this PR does and why it is needed -->
This PR adjusts the Sign-Up Form validation schema in `FormSchema.tsx` to allow for more than one blog/RSS feed to be selected.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/69481177/202378138-ba15cf7a-0c2f-44c8-8695-568a00faaa1c.png">

Currently, you can only add one URL to be validated which contradicts the sign-up instructions. However, as I stated in this [comment](https://github.com/Seneca-CDOT/telescope/issues/3607#issuecomment-1315690787), the Channel Selection part of the sign-up form does not have the same issue even though they use the same `<RSSFeeds>` component.

The cause of this issue is due to the Blog URL and Channel URL having different validation schemas in `FormSchema.tsx`.
```typescript
// Third step we collect the user blog and the RSSfeeds from it.
  object().shape({
    [blogUrl.name]: string().url().required(blogUrl.requiredErrorMsg),//<--Invalid URL error with more than one URL
    [blogs.name]: array().of(DiscoveredFeed).min(1, blogs.requiredErrorMsg),
    [allBlogs.name]: array().of(DiscoveredFeed),
    [blogOwnership.name]: boolean().test('agreed', blogOwnership.invalidErrorMsg, (val) => !!val),
  }),

  // Fourth step we collect the user YouTube/Twitch channels and the RSSfeeds from it.
  object().shape({
    [channelUrl.name]: string(), //<--NOT validated as a URL, allows for more than one URL to be validated
    [channels.name]: array().of(DiscoveredFeed),
    [allChannels.name]: array().of(DiscoveredFeed),
    [channelOwnership.name]: boolean().when(allChannels.name, {
      is: (val: {}[]) => !!val.length,
      then: (shema) => shema.test('agreed', channelOwnership.invalidErrorMsg, (val) => !!val),
    }),
  }),
```

Validating `blogUrl.name` with `.url()` ensures that you can't enter more than one URL because any space in the input field would automatically cause an error. There is no error when validating `channelUrl.name` because it's only validated with `string()`. 

With this PR, I changed the `blogURL.name` validation to match `ChannelUrl.name` which allows you to select more than one blog/RSS feed. A URL that can't be fetched will still show up as an error for the user. 

The only downside to this fix is that the URL is not validated as the user types anymore. However, I believe this can be another issue as there should be a way to implement validation as the user types while allowing multiple URL selection.




## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->
I tested this running the frontend and backend locally on my machine.
- Sign-up as a new user
- Add one or multiple URLs (separated by a space) in the input field when selecting blog/RSS feeds to use
- Check one or multiple URLs to use.
- Complete sign-up

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
