### PR TITLE
Fixing 'About Us' wrong hyperlink

### DIFF
--- a/src/web/app/src/components/BannerButtons.tsx
+++ b/src/web/app/src/components/BannerButtons.tsx
@@ -7,7 +7,6 @@ import clsx from 'clsx';
 import useAuth from '../hooks/use-auth';
 import TelescopeAvatar from './TelescopeAvatar';
 import PopUp from './PopUp';
-import { webUrl } from '../config';
 
 const useStyles = makeStyles((theme: Theme) => ({
   buttonsContainer: {
@@ -102,7 +101,7 @@ const BannerButtons = () => {
           disagreeButtonText="CANCEL"
         />
       )}
-      <Link href={`${webUrl}/docs/overview/`} passHref>
+      <Link href="/docs/overview" passHref>
         <Button className={classes.buttons} variant="outlined">
           About us
         </Button>


### PR DESCRIPTION
## Issue This PR Addresses

Fixes [#3758](https://github.com/Seneca-CDOT/telescope/issues/3758)

### Type of Change

 UI: Fix issue regarding wrong hyperlink for "About Us"
 
### Description

The value provided for the hyperlink of the "About Us" on the navigation bar was pointing to an already publicized version of itself instead of the component it has within the repository, this is shown from the image below

![Image description](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/1uus6f658iiyhoma6988.png)

Once the value has been changed, you can see the the hyperlink now points at the actual component of repository, as seen from the image below

![image](https://user-images.githubusercontent.com/32577022/202520625-53ffbdf1-d12b-452b-9e4c-ed65dd56e6fb.png)

### Steps to test the PR
1) Start the developer's tool of your local repository
2) Look fo the "React Component" section, and click the "Select Element" Icon
3) Click on the "About Us" section, and view the `href` to see if the value is "/docs/overview/"


### Checklist

- [ ] Quality: This PR builds and passes our npm test and works locally
- [ ] Tests: This PR includes thorough tests or an explanation of why it does not
- [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] Documentation: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)