### PR TITLE
Allow feed URL to be given during sign up

### DIFF
--- a/src/api/feed-discovery/src/middleware.js
+++ b/src/api/feed-discovery/src/middleware.js
@@ -1,6 +1,6 @@
 const { logger, createError } = require('@senecacdot/satellite');
 
-const { isTwitchUrl, toTwitchFeedUrl, getBlogBody, getFeedUrls } = require('./util');
+const { isTwitchUrl, toTwitchFeedUrl, isFeedUrl, getBlogBody, getFeedUrls } = require('./util');
 
 // A middleware to ensure we get an array
 module.exports.checkForArray = () => {
@@ -41,6 +41,15 @@ module.exports.discoverFeedUrls = () => {
               feedUrl: toTwitchFeedUrl(url),
               type: 'twitch',
             };
+          }
+
+          if (await isFeedUrl(url)) {
+            return [
+              {
+                feedUrl: url,
+                type: 'blog',
+              },
+            ];
           }
 
           // Otherwise, try to parse out the feed URL from the body of the page

--- a/src/api/feed-discovery/src/util.js
+++ b/src/api/feed-discovery/src/util.js
@@ -20,6 +20,27 @@ const toTwitchFeedUrl = (twitchChannelUrl) => {
   throw new Error('not a Twitch URL');
 };
 
+const isFeedUrl = async (url) => {
+  try {
+    const { statusCode, headers } = await got(url);
+    const contentType = headers['content-type'];
+    const validContentTypes = [
+      'application/xml',
+      'application/rss+xml',
+      'application/atom+xml',
+      'application/x.atom+xml',
+      'application/x-atom+xml',
+      'application/json',
+      'application/json+oembed',
+      'application/xml+oembed',
+    ];
+
+    return statusCode === 200 && validContentTypes.some((ct) => contentType.includes(ct));
+  } catch (err) {
+    return false;
+  }
+};
+
 const getBlogBody = async (blogUrl) => {
   try {
     logger.debug({ blogUrl }, 'Getting blog body');
@@ -101,3 +122,4 @@ module.exports.getBlogBody = getBlogBody;
 module.exports.getFeedUrls = getFeedUrls;
 module.exports.isTwitchUrl = isTwitchUrl;
 module.exports.toTwitchFeedUrl = toTwitchFeedUrl;
+module.exports.isFeedUrl = isFeedUrl;

--- a/src/api/feed-discovery/test/router.test.js
+++ b/src/api/feed-discovery/test/router.test.js
@@ -31,7 +31,7 @@ describe('POST /', () => {
       };
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl).get('/').reply(200, mockBlogUrlResponseBody, {
+      nock(blogUrl).get('/').twice().reply(200, mockBlogUrlResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -56,7 +56,7 @@ describe('POST /', () => {
       `;
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl1).get('/').reply(200, mockBlogUrl1ResponseBody, {
+      nock(blogUrl1).get('/').twice().reply(200, mockBlogUrl1ResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -72,7 +72,7 @@ describe('POST /', () => {
       `;
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl2).get('/').reply(200, mockBlogUrl2ResponseBody, {
+      nock(blogUrl2).get('/').twice().reply(200, mockBlogUrl2ResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -131,7 +131,7 @@ describe('POST /', () => {
       </html>`;
 
       // Mocking the response body html (send back nothing) when call GET request to blog url
-      nock(blogUrl).get('/').reply(200, mockBlogBody, {
+      nock(blogUrl).get('/').twice().reply(200, mockBlogBody, {
         'Content-Type': 'text/html',
       });
 
@@ -199,7 +199,7 @@ describe('POST /', () => {
       };
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl).get('/').reply(200, mockBlogUrlResponseBody, {
+      nock(blogUrl).get('/').twice().reply(200, mockBlogUrlResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -227,7 +227,7 @@ describe('POST /', () => {
       };
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl).get('/').reply(200, mockBlogUrlResponseBody, {
+      nock(blogUrl).get('/').twice().reply(200, mockBlogUrlResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -255,7 +255,7 @@ describe('POST /', () => {
       };
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl).get('/').reply(200, mockBlogUrlResponseBody, {
+      nock(blogUrl).get('/').twice().reply(200, mockBlogUrlResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -294,7 +294,7 @@ describe('POST /', () => {
       };
 
       // Mocking the response body html when call GET request to blog url
-      nock(blogUrl).get('/').reply(200, mockBlogUrlResponseBody, {
+      nock(blogUrl).get('/').twice().reply(200, mockBlogUrlResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -329,7 +329,7 @@ describe('POST /', () => {
       };
 
       // Mocking the response body html when call GET request to blog url
-      nock(youTubeDomain).get(channelUri).reply(200, mockYouTubeChannelUrlResponseBody, {
+      nock(youTubeDomain).get(channelUri).twice().reply(200, mockYouTubeChannelUrlResponseBody, {
         'Content-Type': 'text/html',
       });
 
@@ -344,6 +344,37 @@ describe('POST /', () => {
     it('should return 401 if no authorization token is included in headers', async () => {
       const res = await request(app).post('/').send(['https://test321.blogspot.com/']);
       expect(res.status).toBe(401);
+    });
+
+    it.concurrent.each([
+      'application/xml',
+      'application/rss+xml',
+      'application/atom+xml',
+      'application/x.atom+xml',
+      'application/x-atom+xml',
+      'application/json',
+      'application/json+oembed',
+      'application/xml+oembed',
+    ])('should return 200 and the url when url response content type is %s', async (type) => {
+      const feedUrl = 'https://test321.blogspot.com/feed/user/';
+
+      const result = {
+        feedUrls: [
+          {
+            feedUrl,
+            type: 'blog',
+          },
+        ],
+      };
+
+      nock(feedUrl).get('/').reply(200, undefined, { 'Content-Type': type });
+      const res = await request(app)
+        .post('/')
+        .set('Authorization', `bearer ${createServiceToken()}`)
+        .send([feedUrl]);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(result);
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Resolves #3689 
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

Currently, only a blog URL can be given during signup. Based on this URL, the feed discovery service returns a list of feed URLs.
This has been updated so a feed URL can also be given. The feed discovery service will check if the given URL is a feed URL, and simply return it back.
This URL is checked by performing a get request and comparing the content type header against a list of valid feed URL content types. The list of valid content types is similar to the one used by the `getFeedURLs` method.

- **Currrent:**
  
  <img width="500" alt="image" src="https://user-images.githubusercontent.com/67077705/202533820-372a5010-418c-43db-a754-0c4abe60ca9a.png">

- **Updated:**
  <img width="500" alt="image" src="https://user-images.githubusercontent.com/67077705/202533162-bcd3dfc9-23d3-49ee-977b-a2b081f923fa.png">


## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

- Run telescope locally, including the login sso
- Log in using one of the fake user accounts listed [here](https://telescope.cdot.systems/docs/tools-and-technologies/login)
- When prompted, click on sign up
- Follow the prompts until you get asked for a blog URL
- Enter a blog URL and click on 'Validate Blog'. This should list feed URLs
- Enter a blog feed URL and click on 'Validate Blog'. This should list the same feed URL
- Enter an invalid URL. This should show an error

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
