### PR TITLE
fix: remove package manager from vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,5 @@
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true,
-  "eslint.packageManager": "pnpm",
   "eslint.workingDirectories": [{ "mode": "auto" }]
 }


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR removes the line in our `settings.json` where `pnpm` was set as the project's package manager.
This line was causing the `vscode` extension for `eslint` to fail for some users:

![image](https://user-images.githubusercontent.com/23108901/202866595-fe76c6ff-9400-4144-a472-47e09ee25a9c.png)

My guess is that it's related to using [nvm](https://github.com/nvm-sh/nvm) instead of a traditional `nodejs` installation. The `vscode` repo has [an issue about this](https://github.com/microsoft/vscode/issues/148903), and it seems that a [solution that seems to work](https://github.com/microsoft/vscode/issues/148903#issuecomment-1153099390) is what's added in this PR.

## Steps to test the PR

- Check if this issue affects you by checking the output window (not the terminal) in `vscode`. If you see the error message, this affects you
- Check out the branch used in this PR
- Assert that linter errors are detected in `vscode`.

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
