### PR TITLE
Parse twitch feed URL for sign-up confirmation

### DIFF
--- a/src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx
+++ b/src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx
@@ -238,6 +238,17 @@ const RSSFeeds = connect<RSSFeedsFormProps, SignUpForm>(
       setFieldValue(selected, selectedFeeds, true);
     };
 
+    // Parse FeedUrl by Type to produce desired output for confirmation
+    const parseFeedUrlByType = ({ feedUrl, type }: DiscoveredFeed) => {
+      // For twitch URL on channel feed page, parse the feed url to find the twitch URL
+      if (type === 'twitch') {
+        const result = feedUrl.match(/https?:\/\/www.twitch.tv\/\w+/);
+        return result ? result[0] : feedUrl;
+      }
+      // By default, return the original feed url
+      return feedUrl;
+    };
+
     useEffect(() => {
       if (errors[input.name as keyof SignUpForm]) {
         validateBlog();
@@ -288,7 +299,7 @@ const RSSFeeds = connect<RSSFeedsFormProps, SignUpForm>(
                           }
                           label={
                             <h1 className={classes.formControlLabel}>
-                              {feed.type}: {feed.feedUrl}
+                              {feed.type}: {parseFeedUrlByType(feed)}
                             </h1>
                           }
                         />


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #3610 

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description
The issue raised a point about twitch channel confirmation during sign-up being confusing to users, because the UI doesn't show actual the twitch link(s) for users to confirm. This PR changes what's shown for twitch channel confirmation on that page.
![image](https://user-images.githubusercontent.com/83015577/205091359-e670aca1-aca5-42b9-abd3-ee9b8b78d6ea.png)

Change:
Add a function `parseFeedUrlByType` to parse the fetched twitch URL(s) to be the correct one(s), in `src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx` .

More code can be added to the function to parse other types of fetched links in the future, if needed.

If I'm missing something, please let me know.

## Steps to test the PR

Test this by going through the sign-up process to view the channel page.
During testing, you can use test account `user1` with password `user1pass`.
You can enter any Github account name and blog URL to get through the pages before this page.
For testing, you can use these data:
GitHub Account: cychu42
Blog: https://dev.to/cychu42/
Twitch Channel: https://www.twitch.tv/nl_kripp

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
