### PR TITLE
Streamline ownership confirmation during sign-up

### DIFF
--- a/src/web/app/src/components/SignUp/Forms/BlogFeeds.tsx
+++ b/src/web/app/src/components/SignUp/Forms/BlogFeeds.tsx
@@ -1,7 +1,7 @@
 import RSSFeeds from './RSSFeeds';
 import formModels from '../Schema/FormModel';
 
-const { blogs, allBlogs, blogUrl, blogOwnership } = formModels;
+const { blogs, allBlogs, blogUrl } = formModels;
 
 const BlogFeeds = () => {
   return (
@@ -18,10 +18,6 @@ const BlogFeeds = () => {
       feeds={{
         selected: blogs.name as any,
         discovered: allBlogs.name as any,
-      }}
-      agreement={{
-        name: blogOwnership.name,
-        label: blogOwnership.label,
       }}
       input={{
         name: blogUrl.name,

--- a/src/web/app/src/components/SignUp/Forms/ChannelFeeds.tsx
+++ b/src/web/app/src/components/SignUp/Forms/ChannelFeeds.tsx
@@ -1,7 +1,7 @@
 import RSSFeeds from './RSSFeeds';
 import formModels from '../Schema/FormModel';
 
-const { channels, allChannels, channelUrl, channelOwnership } = formModels;
+const { channels, allChannels, channelUrl } = formModels;
 
 const ChannelFeeds = () => {
   return (
@@ -13,10 +13,6 @@ const ChannelFeeds = () => {
       feeds={{
         selected: channels.name as any,
         discovered: allChannels.name as any,
-      }}
-      agreement={{
-        name: channelOwnership.name,
-        label: channelOwnership.label,
       }}
       input={{
         name: channelUrl.name,

--- a/src/web/app/src/components/SignUp/Forms/GitHubAccount.tsx
+++ b/src/web/app/src/components/SignUp/Forms/GitHubAccount.tsx
@@ -5,10 +5,10 @@ import { connect } from 'formik';
 
 import { SignUpForm } from '../../../interfaces';
 import formModels from '../Schema/FormModel';
-import { TextInput, CheckBoxInput } from '../FormFields';
+import { TextInput } from '../FormFields';
 import PostAvatar from '../../Posts/PostAvatar';
 
-const { githubUsername, github, githubOwnership } = formModels;
+const { githubUsername, github } = formModels;
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -178,11 +178,6 @@ const GitHubAccount = connect<{}, SignUpForm>((props) => {
             </div>
           )}
         </div>
-        <CheckBoxInput
-          label={githubOwnership.label}
-          name={githubOwnership.name}
-          checked={values.githubOwnership}
-        />
       </div>
     </div>
   );

--- a/src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx
+++ b/src/web/app/src/components/SignUp/Forms/RSSFeeds.tsx
@@ -10,7 +10,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import { feedDiscoveryServiceUrl } from '../../../config';
 import useAuth from '../../../hooks/use-auth';
 import { SignUpForm, DiscoveredFeed, DiscoveredFeeds } from '../../../interfaces';
-import { TextInput, CheckBoxInput } from '../FormFields';
+import { TextInput } from '../FormFields';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -157,10 +157,6 @@ type RSSFeedsFormProps = {
     name: string;
     label: string;
   };
-  agreement: {
-    name: string;
-    label: string;
-  };
   noFeedsSelected?: string;
 };
 
@@ -173,7 +169,6 @@ const RSSFeeds = connect<RSSFeedsFormProps, SignUpForm>(
     buttonText,
     helperText,
     noFeedsSelected,
-    agreement,
     input,
     formik,
   }) => {
@@ -308,11 +303,6 @@ const RSSFeeds = connect<RSSFeedsFormProps, SignUpForm>(
               </div>
             </div>
           </div>
-          <CheckBoxInput
-            label={agreement.label}
-            name={agreement.name}
-            checked={values[agreement.name as keyof SignUpForm] as boolean}
-          />
         </div>
       </div>
     );

--- a/src/web/app/src/components/SignUp/Forms/Review.tsx
+++ b/src/web/app/src/components/SignUp/Forms/Review.tsx
@@ -157,6 +157,10 @@ const Review = connect<{ accountError: string | undefined }, SignUpForm>((props)
             </div>
           </div>
         </div>
+        <div>
+          By submitting these information, you confirm you are the owner and/or maintainer of the
+          accounts entered.
+        </div>
         <FormHelperText error>{props.accountError}</FormHelperText>
       </div>
     </div>

--- a/src/web/app/src/components/SignUp/Schema/FormModel.tsx
+++ b/src/web/app/src/components/SignUp/Schema/FormModel.tsx
@@ -28,11 +28,6 @@ export default {
     label: 'Github username',
     requiredErrorMsg: 'Github account is required',
   },
-  githubOwnership: {
-    name: 'githubOwnership',
-    label: 'I declare I’m the owner and the maintainer of this GitHub account',
-    invalidErrorMsg: 'You must be the owner of this account',
-  },
   blogUrl: {
     name: 'blogUrl',
     label: 'Blog URL(s), seperated by spaces',
@@ -58,15 +53,5 @@ export default {
   },
   allChannels: {
     name: 'allChannels',
-  },
-  blogOwnership: {
-    name: 'blogOwnership',
-    label: 'I declare I’m the owner and the maintainer of this blog account',
-    invalidErrorMsg: 'You must be the owner of this account',
-  },
-  channelOwnership: {
-    name: 'channelOwnership',
-    label: 'I declare I’m the owner and the maintainer of the channel(s) above',
-    invalidErrorMsg: 'You must be the owner of the channel(s)',
   },
 };

--- a/src/web/app/src/components/SignUp/Schema/FormSchema.tsx
+++ b/src/web/app/src/components/SignUp/Schema/FormSchema.tsx
@@ -1,4 +1,4 @@
-import { string, array, object, boolean } from 'yup';
+import { string, array, object } from 'yup';
 
 import formModels from './FormModel';
 
@@ -13,15 +13,12 @@ const {
   displayName,
   githubUsername,
   github,
-  githubOwnership,
   blogs,
   allBlogs,
   channels,
   allChannels,
   blogUrl,
   channelUrl,
-  blogOwnership,
-  channelOwnership,
 } = formModels;
 
 // Each signup step has one validation schema
@@ -44,11 +41,6 @@ export default [
         avatarUrl: string().url().required(),
       })
       .required(github.invalidErrorMsg),
-    [githubOwnership.name]: boolean().test(
-      'agreed',
-      githubOwnership.invalidErrorMsg,
-      (val) => !!val
-    ),
   }),
 
   // Third step we collect the user blog and the RSSfeeds from it.
@@ -56,7 +48,6 @@ export default [
     [blogUrl.name]: string(),
     [blogs.name]: array().of(DiscoveredFeed).min(1, blogs.requiredErrorMsg),
     [allBlogs.name]: array().of(DiscoveredFeed),
-    [blogOwnership.name]: boolean().test('agreed', blogOwnership.invalidErrorMsg, (val) => !!val),
   }),
 
   // Fourth step we collect the user YouTube/Twitch channels and the RSSfeeds from it.
@@ -64,10 +55,6 @@ export default [
     [channelUrl.name]: string(),
     [channels.name]: array().of(DiscoveredFeed),
     [allChannels.name]: array().of(DiscoveredFeed),
-    [channelOwnership.name]: boolean().when(allChannels.name, {
-      is: (val: {}[]) => !!val.length,
-      then: (shema) => shema.test('agreed', channelOwnership.invalidErrorMsg, (val) => !!val),
-    }),
   }),
 
   // Reviewing step has no validation logic. We just display all data that we collected.

--- a/src/web/app/src/interfaces/index.ts
+++ b/src/web/app/src/interfaces/index.ts
@@ -39,15 +39,12 @@ export type SignUpForm = {
     avatarUrl: string;
   };
   githubUsername: string;
-  githubOwnership: boolean;
   blogUrl: string;
   channelUrl: string;
   blogs: DiscoveredFeed[];
   allBlogs: DiscoveredFeed[];
   channels: DiscoveredFeed[];
   allChannels: DiscoveredFeed[];
-  blogOwnership: boolean;
-  channelOwnership: boolean;
 };
 
 export type ThemeName = 'light-default' | 'light-high-contrast' | 'dark-default' | 'dark-dim';

--- a/src/web/app/src/pages/signup.tsx
+++ b/src/web/app/src/pages/signup.tsx
@@ -41,15 +41,12 @@ const {
   displayName,
   githubUsername,
   github,
-  githubOwnership,
   blogUrl,
   blogs,
   channels,
   allBlogs,
   allChannels,
   email,
-  blogOwnership,
-  channelOwnership,
 } = formModels;
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -324,7 +321,6 @@ const SignUpPage = () => {
                   [displayName.name]: user?.name,
                   [email.name]: user?.email,
                   [githubUsername.name]: '',
-                  [githubOwnership.name]: false,
                   [github.name]: {
                     username: '',
                     avatarUrl: '',
@@ -334,8 +330,6 @@ const SignUpPage = () => {
                   [allBlogs.name]: [] as SignUpForm['allBlogs'],
                   [channels.name]: [] as SignUpForm['channels'],
                   [allChannels.name]: [] as SignUpForm['allChannels'],
-                  [blogOwnership.name]: false,
-                  [channelOwnership.name]: false,
                 } as SignUpForm
               }
             >


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses

Fixes #3608

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [x] **UI**: Change which improves UI

## Description

The original sign-up process requires users to tick multiple checkboxes to confirm ownership of each account entered. This PR streamlines the process to remove the checkboxes and instead show a line of confirmation text on the review page.
Users can now go to next page without being required to tick the checkboxes.

![image](https://user-images.githubusercontent.com/83015577/205123193-d3868471-7a88-4db1-ad46-c6a60802a4f7.png)
![image](https://user-images.githubusercontent.com/83015577/205123330-603f6cc1-a5db-4d55-9d1e-9f661b947a2f.png)
![image](https://user-images.githubusercontent.com/83015577/205123304-14889ad7-0eff-4512-b4c8-748e64db6d2e.png)

List of code changes:
- Delete `agreement` field from `RSSFeedsFormProps` and `RSSFeeds`, in `src\web\app\src\components\SignUp\Forms\RSSFeeds.tsx` 
- Delete `agreement` field from `src\web\app\src\components\SignUp\Forms\BlogFeeds.tsx` and `src\web\app\src\components\SignUp\Forms\ChannelFeeds.tsx`
- Delete `githubOwnership`, `blogOwnership`, and `channelOwnership` fields from `SignUpForm` in `src\web\app\src\interfaces\index.ts` 
- Delete `githubOwnership`, `blogOwnership`, and `channelOwnership` from `src\web\app\src\pages\signup.tsx`
- Delete `CheckBoxInput` from `src\web\app\src\components\SignUp\Forms\GitHubAccount.tsx` and `src\web\app\src\components\SignUp\Forms\RSSFeeds.tsx`
- Delete code relating to `githubOwnership`, `blogOwnership`, and `channelOwnership` checking from `src\web\app\src\components\SignUp\Schema\FormSchema.tsx`
- Delete `githubOwnership`, `blogOwnership`, and `channelOwnership` from `src\web\app\src\components\SignUp\Schema\FormModel.tsx`
- Add confirmation text in `src\web\app\src\components\SignUp\Forms\Review.tsx`


## Steps to test the PR

Test this by going through the sign-up process to view the channel page.
During testing, you can use test account `user1` with password `user1pass`.
You can enter any GitHub account name, blog URL, and (optional) Twitch/Youtube channel URL to get through the pages.
For testing, you can use these data:
GitHub Account: cychu42
Blog: https://dev.to/cychu42/
Twitch Channel: https://www.twitch.tv/nl_kripp

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
