### PR TITLE
tests: fix e2e

### DIFF
--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -32,11 +32,11 @@ jobs:
 
       - uses: docker/setup-buildx-action@v1
 
-      - name: Install playwright
-        uses: microsoft/playwright-github-action@v1
-
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Playwright
+        run: pnpm playwright-deps
       # Pull, build, and run containers, then start e2e tests
-      - run: pnpm install
       - name: Pull/Build Docker Containers Necessary for Running E2E Tests
         run: docker compose --env-file ./config/env.development up -d ${{ env.DOCKER_CONTAINERS }}
       - name: Wait for Postgres and Login containers to become fully ready

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "pnpm turbo run test",
     "jest": "jest -c jest.config.js --",
     "jest:e2e": "jest -c jest.config.e2e.js --forceExit --",
+    "playwright-deps": "pnpm playwright install --with-deps",
     "coverage": "jest -c jest.config.js --collectCoverage --",
     "jest-watch": "jest -c jest.config.js --watch --",
     "jest-update": "jest -c jest.config.js --updateSnapshot --",


### PR DESCRIPTION
## Description

Our e2e tests are failing because the dependencies needed for playwright are not installed, This PR tries to address the issue following what's recommended by microsoft [here](https://github.com/microsoft/playwright-github-action#-you-dont-need-this-github-action).
Unfortunatelly, github actions is ignoring my changes in this PR, so I'm going to merge this and see if the fix works.
