### PR TITLE
Filter out irrelevant feed URLs

### DIFF
--- a/src/api/feed-discovery/src/util.js
+++ b/src/api/feed-discovery/src/util.js
@@ -76,6 +76,17 @@ const getFeedUrlType = (feedUrl) => {
   }
 };
 
+// return true if the feedURL is a relevant URL that we want to keep
+const relevantFeedUrl = (feedUrl) => {
+  const invalidPathMatchers = [
+    /\/comments\/feed\/$/, // wordpress.com comments feed
+    /^https:\/\/public-api.wordpress.com\/oembed/,
+    /^https:\/\/www.blogger.com\/feeds\/[0-9]*\/posts\/default$/,
+    /\/feeds\/posts\/default\?alt=rss$/, // blogspot.com alternate rss feed
+  ];
+  return invalidPathMatchers.every((matcher) => !matcher.test(feedUrl));
+};
+
 // Helper function to return the feed url of a given blog url
 const getFeedUrls = (document) => {
   try {
@@ -103,10 +114,12 @@ const getFeedUrls = (document) => {
     if (links.length > 0) {
       for (let i = 0; i < links.length; i += 1) {
         const feedUrl = links[i].attribs.href;
-        feedUrls.push({
-          feedUrl,
-          type: getFeedUrlType(feedUrl),
-        });
+        if (relevantFeedUrl(feedUrl)) {
+          feedUrls.push({
+            feedUrl,
+            type: getFeedUrlType(feedUrl),
+          });
+        }
       }
     }
 
@@ -123,3 +136,4 @@ module.exports.getFeedUrls = getFeedUrls;
 module.exports.isTwitchUrl = isTwitchUrl;
 module.exports.toTwitchFeedUrl = toTwitchFeedUrl;
 module.exports.isFeedUrl = isFeedUrl;
+module.exports.relevantFeedUrl = relevantFeedUrl;

--- a/src/api/feed-discovery/test/router.test.js
+++ b/src/api/feed-discovery/test/router.test.js
@@ -267,17 +267,25 @@ describe('POST /', () => {
       expect(res.body).toEqual(result);
     });
 
-    it('should return 200 and all feed urls if there are multiple link elements that could contain a feed url', async () => {
+    it('should return 200 and all relevant feed urls if there are multiple link elements that could contain a feed url', async () => {
       const blogUrl = 'https://test321.blogspot.com/';
       const mockBlogUrlResponseBody = `
           <!doctype html>
           <html lang="en">
             <head>
-              <link rel="alternate" type="application/x.atom+xml" href="https://test321.blogspot.com/x.atom/feeds/posts/default/-/open-source"/>
-              <link rel="alternate" type="application/x-atom+xml" href="https://test321.blogspot.com/x-atom/feeds/posts/default/-/open-source"/>
-              <link rel="alternate" type="application/json" href="https://test321.blogspot.com/json"/>
-              <link rel="alternate" type="application/json+oembed" href="https://test321.blogspot.com/oembed/?format=json"/>
-              <link rel="alternate" type="application/xml+oembed" href="https://test321.blogspot.com/oembed/?format=xml"/>
+              <link rel="alternate" type="application/x.atom+xml" href="https://test321.blogspot.com/x.atom/feeds/posts/default/-/open-source" />
+              <link rel="alternate" type="application/x-atom+xml" href="https://test321.blogspot.com/x-atom/feeds/posts/default/-/open-source" />
+              <link rel="alternate" type="application/json" href="https://test321.blogspot.com/json" />
+              <link rel="alternate" type="application/json+oembed" href="https://test321.blogspot.com/oembed/?format=json" />
+              <link rel="alternate" type="application/xml+oembed" href="https://test321.blogspot.com/oembed/?format=xml" />
+              <link rel="alternate" type="application/rss+xml" href="https://test321.blogspot.com/feeds/posts/default" />
+              <link rel="alternate" type="application/rss+xml" href="https://test321.blogspot.com/feeds/posts/default?alt=rss" />
+              <link rel="alternate" type="application/atom+xml" href="https://www.blogger.com/feeds/123/posts/default" />
+              <link rel="alternate" type="application/rss+xml" href="https://test321.wordpress.com/feed/" />
+              <link rel="alternate" type="application/rss+xml" href="https://test321.wordpress.com/comments/feed/" />
+              <link rel="alternate" type="application/json+oembed" href="https://public-api.wordpress.com/oembed/?format=json&url=https%3A%2F%2Ftest321.wordpress.com%2F&for=wpcom-auto-discovery" />
+              <link rel="alternate" type="application/rss+xml" href="https://medium.com/feed/@test321" />
+              <link rel="alternate" type="application/rss+xml" href="https://dev.to/feed/test321" />
             </head>
             <body></body>
           </html>
@@ -290,6 +298,10 @@ describe('POST /', () => {
           'https://test321.blogspot.com/json',
           'https://test321.blogspot.com/oembed/?format=json',
           'https://test321.blogspot.com/oembed/?format=xml',
+          'https://test321.blogspot.com/feeds/posts/default',
+          'https://test321.wordpress.com/feed/',
+          'https://medium.com/feed/@test321',
+          'https://dev.to/feed/test321',
         ].map((feedUrl) => ({ feedUrl, type: 'blog' })),
       };
 

--- a/src/api/feed-discovery/test/util.test.js
+++ b/src/api/feed-discovery/test/util.test.js
@@ -6,6 +6,7 @@ const {
   isFeedUrl,
   getBlogBody,
   getFeedUrlType,
+  relevantFeedUrl,
   getFeedUrls,
 } = require('../src/util');
 
@@ -127,6 +128,27 @@ describe('util.js', () => {
     expect(getFeedUrlType('not-valid')).toBe('blog');
   });
 
+  test('relevantFeedUrl returns true for relevant feed URLs', () => {
+    [
+      'https://test321.com/feed/user',
+      'https://test321.workpress.com/feed/',
+      'https://test321.blogspot.com/feeds/posts/default',
+    ].forEach((feedUrl) => {
+      expect(relevantFeedUrl(feedUrl)).toBe(true);
+    });
+  });
+
+  test('relevantFeedUrl returns false for irrelevant feed URLs', () => {
+    [
+      'https://test321.workpress.com/comments/feed/',
+      'https://public-api.wordpress.com/oembed/?format=json&url=https%3A%2F%2Ftest321.wordpress.com%2F&for=wpcom-auto-discovery',
+      'https://www.blogger.com/feeds/123/posts/default',
+      'https://test321.blogspot.com/feeds/posts/default?alt=rss',
+    ].forEach((feedUrl) => {
+      expect(relevantFeedUrl(feedUrl)).toBe(false);
+    });
+  });
+
   test('getFeedUrls returns expected atom+xml feed URL for a given document', () => {
     const html = (type) => `
       <html lang="en">
@@ -157,5 +179,32 @@ describe('util.js', () => {
 
   test('getFeedUrls returns null if document cannot be parsed', () => {
     expect(getFeedUrls(null)).toBe(null);
+  });
+
+  test('getFeedUrls filters irrelevant feed URLs', () => {
+    const html = `
+    <html lang="en">
+      <head>
+        <link rel="alternate" type="application/atom+xml" href="https://test321.blogspot.com/feeds/posts/default" />
+        <link rel="alternate" type="application/rss+xml" href="https://test321.blogspot.com/feeds/posts/default?alt=rss" />
+        <link rel="alternate" type="application/atom+xml" href="https://www.blogger.com/feeds/123/posts/default" />
+        <link rel="alternate" type="application/rss+xml" href="https://test321.wordpress.com/feed/" />
+        <link rel="alternate" type="application/rss+xml" href="https://test321.wordpress.com/comments/feed/" />
+        <link rel="alternate" type="application/json+oembed" href="https://public-api.wordpress.com/oembed/?format=json&url=https%3A%2F%2Ftest321.wordpress.com%2F&for=wpcom-auto-discovery" />
+        <link rel="alternate" type="application/rss+xml" href="https://medium.com/feed/@test321" />
+        <link rel="alternate" type="application/rss+xml" href="https://dev.to/feed/test321" />
+      </head>
+      <body></body>
+    </html>
+  `;
+
+    const expectedFeedUrls = [
+      'https://test321.blogspot.com/feeds/posts/default',
+      'https://test321.wordpress.com/feed/',
+      'https://medium.com/feed/@test321',
+      'https://dev.to/feed/test321',
+    ].map((feedUrl) => ({ feedUrl, type: 'blog' }));
+
+    expect(getFeedUrls(html)).toEqual(expectedFeedUrls);
   });
 });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Resolves #3688 

<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [x] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

The feed discovery services can return feed URLs that are not relevant. One such example is the wordpress.com's comments feed: `https://blog.wordpress.com/comments/feed`.
We want to filter out the irrelevant URLs for four hosts - `dev.to`, `medium.com`, `wordpress.com`, `blogspot.com`.
This PR adds filters to remove the following:
- wordpress comments feed
- wordpress json oembed feed - Wordpress already returns an `rss+xml` feed url. So, we skip the `json+oembed` feed url
- blogspot.com `service.post` url - There are two other feed urls for `atom+xml` and `rss+xml` which are returned

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

- Ensure you have login component running locally
- Go through the sign up process until you reach the blog URL form
- Test different blog URLs from different hosts and check if the feed URLs mentioned above are filtered out

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
