### PR TITLE
Fix login document docker-compose command typo

### DIFF
--- a/src/web/docusaurus/docs/tools-and-technologies/login.md
+++ b/src/web/docusaurus/docs/tools-and-technologies/login.md
@@ -51,11 +51,11 @@ You can [read more about how it works here](https://medium.com/disney-streaming/
 
 To get this to run locally, you need to update your `.env`. Copy `env.example` if you don't have one, and the default values should work.
 
-4. Start the backend apps using `docker-compose up –build`. This will build the SAML2 server that is being used as a local service for testing purposes, and Telescope (express). From there, you should be able to click on the login button at `http://localhost:3000/` that will redirect you to the proper login page.
+4. Start the backend apps using `docker-compose up -–build`. This will build the SAML2 server that is being used as a local service for testing purposes, and Telescope (express). From there, you should be able to click on the login button at `http://localhost:3000/` that will redirect you to the proper login page.
 
 :::note
 
-If running Elasticsearch or Redis natively, please avoid using `docker-compose up -build` and instead use `docker-compose up login` to start the SAML2 server for testing. This will avoid any issues with duplicate services of Redis and Elasticsearch started by `docker-compose up -build`.
+If running Elasticsearch or Redis natively, please avoid using `docker-compose up --build` and instead use `docker-compose up login` to start the SAML2 server for testing. This will avoid any issues with duplicate services of Redis and Elasticsearch started by `docker-compose up --build`.
 
 :::
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
This PR does not have a related issue
<!--
1. Automatically close the issue when this PR is merged
    USAGE: Fixes #<issue number>
2. If your PR addresses an issue but does not close it
    USAGE: #<issue number> <reason>(i.e. This issue was worked on by @user and myself and his PR should close the issue.)
-->

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [x] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
Fixed  `docker-compose` command typos in the login documentation in the following places:
It should be `--build` instead of `-build`

![image](https://user-images.githubusercontent.com/67077705/212428627-fa658098-3618-4ff2-9682-7fe9991239de.png)

<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR
- Run telescope locally
- Navigate to the documentation by clicking on the `ABOUT US` button on the home page
- Under `Tools and Technologies`, navigate to `Login`
- Scroll down to the `Running an SSO Identity Provider` section
- Check if the typos have been fixed

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [x] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
