### PR TITLE
Changing Cookie to be sameSite none

### DIFF
--- a/src/api/sso/src/index.js
+++ b/src/api/sso/src/index.js
@@ -18,6 +18,7 @@ const service = new Satellite({
         secret: process.env.JWT_SECRET || `telescope-has-many-secrets-${Date.now()}!`,
         resave: false,
         saveUninitialized: false,
+        cookie: { secure: true, sameSite: 'none' },
       })
     );
     app.use(passport.initialize());

--- a/src/api/sso/src/index.js
+++ b/src/api/sso/src/index.js
@@ -18,7 +18,7 @@ const service = new Satellite({
         secret: process.env.JWT_SECRET || `telescope-has-many-secrets-${Date.now()}!`,
         resave: false,
         saveUninitialized: false,
-        cookie: { secure: true, sameSite: 'none' },
+        cookie: process.env.NODE_ENV === 'production' && { secure: true, sameSite: 'none' },
       })
     );
     app.use(passport.initialize());


### PR DESCRIPTION
## Issue This PR Addresses


Fixes #3567


## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

There is a 400 we sometimes get because the cookie that is sent to us with the post binding from Azure AD is sometimes blocked since it is from a different origin/site. Enabling sameSite 'none' should hopefully fix this. By default sameSite is set to 'Lax' which sometimes block incoming cookies from other sites such as the request AD makes to our callback.

This is all outlined nicely in the following document David found https://web.dev/samesite-cookie-recipes/#unsafe-requests-across-sites. 

>This pattern is used for sites that may redirect the user out to a remote service to perform some operation before returning, for example redirecting to a third-party identity provider. Before the user leaves the site, a cookie is set containing a single use token with the expectation that this token can be checked on the returning request to mitigate [Cross Site Request Forgery (CSRF)](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html) attacks. If that returning request comes via POST then it will be necessary to mark the cookies as `SameSite=None; Secure`.

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    I was not able to reproduce the error locally. 
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
