### PR TITLE
set trust for first proxy when env is prod

### DIFF
--- a/src/satellite/src/app.js
+++ b/src/satellite/src/app.js
@@ -10,7 +10,7 @@ const { errorHandler } = require('./middleware');
 function createApp(router, options = {}) {
   const app = express();
 
-  if (process.env.NODE_ENV === 'production') app.set('trust proxy', 1);
+  if (process.env.NODE_ENV === 'production') app.set('trust proxy', 2);
 
   app.use(pinoHttp({ logger }));
 

--- a/src/satellite/src/app.js
+++ b/src/satellite/src/app.js
@@ -10,6 +10,8 @@ const { errorHandler } = require('./middleware');
 function createApp(router, options = {}) {
   const app = express();
 
+  if (process.env.NODE_ENV === 'production') app.set('trust proxy', 1);
+
   app.use(pinoHttp({ logger }));
 
   // Allow disabling or passing options to helmet


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
- if this is your first time, please ensure you have read through our contributor guide: https://github.com/Seneca-CDOT/telescope/blob/master/docs/CONTRIBUTING.md
-->

## Issue This PR Addresses
Fixes #3792 


## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description
I am trying to find a way to make the new cookie settings work, perhaps this might be a step in the right direction.
<!-- Please add a detailed description of what this PR does and why it is needed -->

## Steps to test the PR

<!-- Please add steps to build the changes in your PR locally so that peers can test your PR
    Example:
    - `npm install`
    - Go to '...'
    - Click on '....'
    - Scroll down to '....'
    - See error

    Please remember, the more clear you are, the faster your PR will be reviewed and merged.
 -->

## Checklist

<!-- Before submitting a PR, address each item -->

- [x] **Quality**: This PR builds and passes our npm test and works locally (but it only changes anything in prod so idk if this means anything)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
