### PR TITLE
fix: add route for let's encrypt challenge

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -169,6 +169,11 @@ http {
       proxy_set_header Host $host;
       proxy_pass http://portainer:9000/;
     }
+
+    # Let's Encrypt route
+    location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+    }
   }
 
   # Requests to the oauth2-proxy which redirect to supabase studio app once authenticated
@@ -184,6 +189,11 @@ http {
       proxy_set_header X-Scheme $scheme;
       proxy_pass http://oauth2-proxy:8080/;
     }
+
+    # Let's Encrypt route
+    location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+    }
   }
 
   # Requests to the api.* domain should be proxied to Traefik
@@ -197,6 +207,11 @@ http {
       proxy_set_header  X-Forwarded-for $remote_addr;
       # We run Traefik via Docker on port 8888
       proxy_pass        http://traefik:8888;
+    }
+
+    # Let's Encrypt route
+    location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
     }
   }
 


### PR DESCRIPTION
## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [x] **Bugfix**: Change which fixes an issue
- [ ] **New Feature**: Change which adds functionality
- [ ] **Documentation Update**: Change which improves documentation
- [ ] **UI**: Change which improves UI

## Description

This PR adds the required route for the [let's encrypt challenge](https://letsencrypt.org/docs/challenge-types/) so all the certificates for the domains used by `telescope` can be renewed.

## Steps to test the PR

N/A

## Checklist

<!-- Before submitting a PR, address each item -->

- [ ] **Quality**: This PR builds and passes our npm test and works locally
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not (if applicable)
- [ ] **Documentation**: This PR includes updated/added documentation to user exposed functionality or configuration variables are added/changed or an explanation of why it does not(if applicable)
