### PR TITLE
Bump node engine version from 16 to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "typescript": "4.4.4"
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "pnpm": ">=6"
   },
   "packageManager": "pnpm@6.32.13",


### PR DESCRIPTION
## Issue This PR Addresses

1. Automatically close the issue when this PR is merged
    USAGE: Fixes #3837

## Type of Change

<!-- bug fix, feature, documentation, UI, etc. -->

- [ ] **Bugfix**: Change which fixes an issue

## Description

Changed node engine to 18 and above instead of 16
